### PR TITLE
dts: Add Galaxy Tab A 8.0 (SM-T357W)

### DIFF
--- a/dts/msm8916-samsung-r06.dts
+++ b/dts/msm8916-samsung-r06.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8916.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <206 0>;
+	qcom,board-id = <0xCE08FF01 6>;
+
+	gt58ltebmc {
+		model = "Samsung Galaxy Tab A 8.0 (CAN)";
+		compatible = "samsung,gt58ltebmc", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "T357W*";
+	};
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -7,5 +7,6 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-motorola-harpia.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r01.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r03.dtb \
-	$(LOCAL_DIR)/msm8916-samsung-r04.dtb
+	$(LOCAL_DIR)/msm8916-samsung-r04.dtb \
+	$(LOCAL_DIR)/msm8916-samsung-r06.dtb
 endif


### PR DESCRIPTION
Added dts file for Galaxy Tab A 8.0, Canadian LTE version SM-T357W