### PR TITLE
aboot: add missing null-termination to return of concat_args

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -610,7 +610,7 @@ static char *concat_args(const char *a, const char *b)
 	char *r = malloc(lenA + lenB + 2);
 	memcpy(r, a, lenA);
 	r[lenA] = ' ';
-	memcpy(r + lenA + 1, b, lenB);
+	memcpy(r + lenA + 1, b, lenB + 1);
 	return r;
 }
 


### PR DESCRIPTION
make memcpy also copy null-terminator.