### PR TITLE
target: msm8916: Fix rules.mk

### DIFF
--- a/target/msm8916/rules.mk
+++ b/target/msm8916/rules.mk
@@ -32,7 +32,7 @@ DEFINES += \
 
 OBJS += \
 	$(LOCAL_DIR)/init.o \
-	$(LOCAL_DIR)/meminfo.o \
+	$(LOCAL_DIR)/meminfo.o
 
 ifneq ($(DISPLAY_USE_CONTINUOUS_SPLASH),1)
 OBJS += \


### PR DESCRIPTION
Last file need to be without \, because it is last.