### PR TITLE
dts: add Samsung SM-T533

### DIFF
--- a/dts/apq8016-samsung-r02.dts
+++ b/dts/apq8016-samsung-r02.dts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8916.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <247 0>;
+	qcom,board-id = <0xF708FF01 2>;
+
+	// Unfortunately, Samsung uses the same qcom,board-id for all its
+	// APQ8016 devices. Therefore, it will always pick this shared device
+	// tree and we need to do more manual work to differentiate the devices.
+	matissevewifi {
+		model = "Samsung Galaxy Tab 4 10.1 (2015) T533";
+		compatible = "samsung,matissevewifi", "qcom,apq8016", "lk2nd,device";
+		lk2nd,match-bootloader = "T533*";
+	};
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -2,6 +2,7 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 
 ifeq ($(PROJECT), msm8916-secondary)
 DTBS += \
+	$(LOCAL_DIR)/apq8016-samsung-r02.dtb \
 	$(LOCAL_DIR)/apq8016-samsung-r07.dtb \
 	$(LOCAL_DIR)/msm8916-longcheer-l8150.dtb \
 	$(LOCAL_DIR)/msm8916-motorola-harpia.dtb \


### PR DESCRIPTION
This adds Samsung SM-T533 (Samsung Galaxy Tab 4 10.1 (2015), to dts.
I can compile, flash on my device and it seems to work.

However, I have some doubts:
* I think the codename is matissewifive-eur-r00 but I am not sure (I don't have the original Android installed on my tablet)
* I used dts files related to this codename in the downstream kernel
* In the downstream files: some property are set differently to the file I plugged in:
  *  `qcom,msm-id = <206 0>` instead of `247`
  *  ` qcom,board-id = <0xF708FF01 0>` instead of `7` for the second cell
* I am not sure if these differences are important