### PR TITLE
Add support for new devices, and fix incorrect bootloader name in j5xlte-eur

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy J3 (2015) - SM-J3109
 - Samsung Galaxy J3 Pro (2016) - SM-J3110
 - Samsung Galaxy J3 Pro (2016) - SM-J3119
+- Samsung Galaxy J5 (2015) - SM-J5008
 - Samsung Galaxy J5 (2015) - SM-J500FN
 - Samsung Galaxy J5 (2016) - SM-J5108
 - Samsung Galaxy J5 (2016) - SM-J510FN

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy J3 Pro (2016) - SM-J3119
 - Samsung Galaxy J5 (2015) - SM-J5008
 - Samsung Galaxy J5 (2015) - SM-J500FN
+- Samsung Galaxy J5 (2015) - SM-J500H
 - Samsung Galaxy J5 (2016) - SM-J5108
 - Samsung Galaxy J5 (2016) - SM-J510FN
 - Samsung Galaxy J7 (2015) - SM-J7008

--- a/README.md
+++ b/README.md
@@ -24,18 +24,10 @@ and then loaded by lk2nd.
 - Samsung Galaxy A3 (2015) - SM-A300FU
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU
 - Samsung Galaxy J3 (2015) - SM-J3109
-- Samsung Galaxy J3 Pro (2016) - SM-J3110
-- Samsung Galaxy J3 Pro (2016) - SM-J3119
-- Samsung Galaxy J5 (2015) - SM-J5008
-- Samsung Galaxy J5 (2015) - SM-J500F
-- Samsung Galaxy J5 (2015) - SM-J500FN
-- Samsung Galaxy J5 (2015) - SM-J500H
-- Samsung Galaxy J5 (2016) - SM-J5108
-- Samsung Galaxy J5 (2016) - SM-J510F
-- Samsung Galaxy J5 (2016) - SM-J510FN
-- Samsung Galaxy J5 (2016) - SM-J510H
-- Samsung Galaxy J7 (2015) - SM-J7008
-- Samsung Galaxy J7 (2015) - SM-J700P
+- Samsung Galaxy J3 Pro (2016) - SM-J3110, SM-J3119
+- Samsung Galaxy J5 (2015) - SM-J5008, SM-J500F, SM-J500FN, SM-J500H
+- Samsung Galaxy J5 (2016) - SM-J5108, SM-J510F, SM-J510FN, SM-J510H
+- Samsung Galaxy J7 (2015) - SM-J7008, SM-J700P
 - Samsung Galaxy S4 Mini Value Edition - GT-I9195I
 - Samsung Galaxy Tab 4 10.1 (2015) - SM-T533
 - Samsung Galaxy Tab A 8.0 LTE (2015) - SM-T357W

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU
 - Samsung Galaxy J3 (2015) - SM-J3109
 - Samsung Galaxy J3 Pro (2016) - SM-J3110
+- Samsung Galaxy J3 Pro (2016) - SM-J3119
 - Samsung Galaxy J5 (2015) - SM-J500FN
 - Samsung Galaxy J5 (2016) - SM-J510FN
 - Samsung Galaxy J7 (2015) - SM-J7008

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy J5 (2015) - SM-J500FN
 - Samsung Galaxy J5 (2016) - SM-J510FN
 - Samsung Galaxy J7 (2015) - SM-J7008
+- Samsung Galaxy J7 (2015) - SM-J700P
 - Samsung Galaxy S4 Mini Value Edition - GT-I9195I
 - Samsung Galaxy Tab 4 10.1 (2015) - SM-T533
 - Samsung Galaxy Tab A 8.0 LTE (2015) - SM-T357W

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and then loaded by lk2nd.
 - Motorola Moto G4 Play (harpia)
 - Samsung Galaxy A3 (2015) - SM-A300FU
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU
+- Samsung Galaxy J3 (2015) - SM-J3109
 - Samsung Galaxy J5 (2015) - SM-J500FN
 - Samsung Galaxy J5 (2016) - SM-J510FN
 - Samsung Galaxy J7 (2015) - SM-J7008

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy A3 (2015) - SM-A300FU
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU
 - Samsung Galaxy J3 (2015) - SM-J3109
+- Samsung Galaxy J3 Pro (2016) - SM-J3110
 - Samsung Galaxy J5 (2015) - SM-J500FN
 - Samsung Galaxy J5 (2016) - SM-J510FN
 - Samsung Galaxy J7 (2015) - SM-J7008

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy J5 (2015) - SM-J500H
 - Samsung Galaxy J5 (2016) - SM-J5108
 - Samsung Galaxy J5 (2016) - SM-J510FN
+- Samsung Galaxy J5 (2016) - SM-J510H
 - Samsung Galaxy J7 (2015) - SM-J7008
 - Samsung Galaxy J7 (2015) - SM-J700P
 - Samsung Galaxy S4 Mini Value Edition - GT-I9195I

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ and then loaded by lk2nd.
 
 ## Supported SoCs
 - MSM8916
+- MSM8929
 - MSM8939
 
 ### Supported devices

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy J3 Pro (2016) - SM-J3110
 - Samsung Galaxy J3 Pro (2016) - SM-J3119
 - Samsung Galaxy J5 (2015) - SM-J500FN
+- Samsung Galaxy J5 (2016) - SM-J5108
 - Samsung Galaxy J5 (2016) - SM-J510FN
 - Samsung Galaxy J7 (2015) - SM-J7008
 - Samsung Galaxy J7 (2015) - SM-J700P

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU
 - Samsung Galaxy J5 (2015) - SM-J500FN
 - Samsung Galaxy J5 (2016) - SM-J510FN
+- Samsung Galaxy J7 (2015) - SM-J7008
 - Samsung Galaxy S4 Mini Value Edition - GT-I9195I
 - Samsung Galaxy Tab 4 10.1 (2015) - SM-T533
 - Samsung Galaxy Tab A 8.0 LTE (2015) - SM-T357W

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy J3 Pro (2016) - SM-J3110
 - Samsung Galaxy J3 Pro (2016) - SM-J3119
 - Samsung Galaxy J5 (2015) - SM-J5008
+- Samsung Galaxy J5 (2015) - SM-J500F
 - Samsung Galaxy J5 (2015) - SM-J500FN
 - Samsung Galaxy J5 (2015) - SM-J500H
 - Samsung Galaxy J5 (2016) - SM-J5108

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy J5 (2015) - SM-J500FN
 - Samsung Galaxy J5 (2015) - SM-J500H
 - Samsung Galaxy J5 (2016) - SM-J5108
+- Samsung Galaxy J5 (2016) - SM-J510F
 - Samsung Galaxy J5 (2016) - SM-J510FN
 - Samsung Galaxy J5 (2016) - SM-J510H
 - Samsung Galaxy J7 (2015) - SM-J7008

--- a/dts/msm8916-samsung-r01.dts
+++ b/dts/msm8916-samsung-r01.dts
@@ -24,4 +24,14 @@
 		compatible = "samsung,a5u-eur", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "A500FU*";
 	};
+
+	j5lte-chn {
+		model = "Samsung Galaxy J5 LTE (CHN CMCC)";
+		compatible = "samsung,j5lte-chn", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J5008*";
+		samsung,muic-reset {
+			i2c-gpios = <105 106>;
+			i2c-address = <0x25>;
+		};
+	};
 };

--- a/dts/msm8916-samsung-r03.dts
+++ b/dts/msm8916-samsung-r03.dts
@@ -40,4 +40,14 @@
 			i2c-address = <0x25>;
 		};
 	};
+
+	j5xlte-chn {
+		model = "Samsung Galaxy J5X LTE (CHN CMCC)";
+		compatible = "samsung,j5xlte-chn", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J5108*";
+		samsung,muic-reset {
+			i2c-gpios = <105 106>;
+			i2c-address = <0x25>;
+		};
+	};
 };

--- a/dts/msm8916-samsung-r03.dts
+++ b/dts/msm8916-samsung-r03.dts
@@ -19,4 +19,14 @@
 			i2c-address = <0x14>;
 		};
 	};
+
+	j3xprolte-chnopen {
+		model = "Samsung Galaxy J3XPRO LTE (CHN OPEN)";
+		compatible = "samsung,j3xprolte-chnopen", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J3110*";
+		samsung,muic-reset {
+			i2c-gpios = <0 1>;
+			i2c-address = <0x25>;
+		};
+	};
 };

--- a/dts/msm8916-samsung-r03.dts
+++ b/dts/msm8916-samsung-r03.dts
@@ -29,4 +29,15 @@
 			i2c-address = <0x25>;
 		};
 	};
+
+	j3xprolte-chnctc {
+		model = "Samsung Galaxy J3XPRO LTE (CHN CTC)";
+		compatible = "samsung,j3xprolte-chnctc", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J3119*";
+
+		samsung,muic-reset {
+			i2c-gpios = <0 1>;
+			i2c-address = <0x25>;
+		};
+	};
 };

--- a/dts/msm8916-samsung-r04.dts
+++ b/dts/msm8916-samsung-r04.dts
@@ -12,7 +12,7 @@
 	j5xlte-eur {
 		model = "Samsung Galaxy J5 2016 LTE (EUR)";
 		compatible = "samsung,j5xlte-eur", "qcom,msm8916", "lk2nd,device";
-		lk2nd,match-bootloader = "J510FN*";
+		lk2nd,match-bootloader = "J510F*";
 
 		samsung,muic-reset {
 			i2c-gpios = <105 106>;

--- a/dts/msm8916-samsung-r04.dts
+++ b/dts/msm8916-samsung-r04.dts
@@ -19,4 +19,15 @@
 			i2c-address = <0x25>;
 		};
 	};
+
+	j5x3g-mea {
+		model = "Samsung Galaxy J5 2016 3G (MEA)";
+		compatible = "samsung,j5x3g-mea", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J510H*";
+
+		samsung,muic-reset {
+			i2c-gpios = <105 106>;
+			i2c-address = <0x25>;
+		};
+	};
 };

--- a/dts/msm8916-samsung-r05.dts
+++ b/dts/msm8916-samsung-r05.dts
@@ -39,4 +39,14 @@
 			i2c-address = <0x25>;
 		};
 	};
+
+	j5lte-eur {
+		model = "Samsung Galaxy J5 LTE (EUR)";
+		compatible = "samsung,j5lte-eur", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J500F*";
+		samsung,muic-reset {
+			i2c-gpios = <105 106>;
+			i2c-address = <0x25>;
+		};
+	};
 };

--- a/dts/msm8916-samsung-r05.dts
+++ b/dts/msm8916-samsung-r05.dts
@@ -19,4 +19,14 @@
 			i2c-address = <0x25>;
 		};
 	};
+
+	j3lte-chnctc {
+		model = "Samsung Galaxy J3 LTE (CHN CTC)";
+		compatible = "samsung,j3lte-chnctc", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J3109*";
+		samsung,muic-reset {
+			i2c-gpios = <0 1>;
+			i2c-address = <0x25>;
+		};
+	};
 };

--- a/dts/msm8916-samsung-r05.dts
+++ b/dts/msm8916-samsung-r05.dts
@@ -29,4 +29,14 @@
 			i2c-address = <0x25>;
 		};
 	};
+
+	j53g-eur {
+		model = "Samsung Galaxy J5 3G (EUR)";
+		compatible = "samsung,j53g-eur", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J500H*";
+		samsung,muic-reset {
+			i2c-gpios = <105 106>;
+			i2c-address = <0x25>;
+		};
+	};
 };

--- a/dts/msm8929-samsung-r01.dts
+++ b/dts/msm8929-samsung-r01.dts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8916.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+        qcom,msm-id =   <268 0>,
+                        <269 0>,
+                        <270 0>,
+                        <271 0>;
+	qcom,board-id = <0x0C01FF01 1>;
+
+	j7-spr {
+		model = "Samsung Galaxy J7 (SPR)";
+		compatible = "samsung,j7-spr", "qcom,msm8929", "lk2nd,device";
+		lk2nd,match-bootloader = "J700P*";
+		samsung,muic-reset {
+			i2c-gpios = <31 32>;
+			i2c-address = <0x25>;
+		};
+	};
+};

--- a/dts/msm8929-samsung-r01.dts
+++ b/dts/msm8929-samsung-r01.dts
@@ -6,10 +6,7 @@
 
 / {
 	// This is used by the bootloader to find the correct DTB
-        qcom,msm-id =   <268 0>,
-                        <269 0>,
-                        <270 0>,
-                        <271 0>;
+	qcom,msm-id = <268 0>;
 	qcom,board-id = <0x0C01FF01 1>;
 
 	j7-spr {

--- a/dts/msm8929-samsung-r04.dts
+++ b/dts/msm8929-samsung-r04.dts
@@ -6,10 +6,7 @@
 
 / {
 	// This is used by the bootloader to find the correct DTB
-        qcom,msm-id =   <268 0>,
-                        <269 0>,
-                        <270 0>,
-                        <271 0>;
+	qcom,msm-id = <268 0>;
 	qcom,board-id = <0x0C01FF01 4>;
 
 	j7-chn {

--- a/dts/msm8929-samsung-r04.dts
+++ b/dts/msm8929-samsung-r04.dts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8916.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+        qcom,msm-id =   <268 0>,
+                        <269 0>,
+                        <270 0>,
+                        <271 0>;
+	qcom,board-id = <0x0C01FF01 4>;
+
+	j7-chn {
+		model = "Samsung Galaxy J7 (CHN CMCC)";
+		compatible = "samsung,j7-chn", "qcom,msm8929", "lk2nd,device";
+		lk2nd,match-bootloader = "J7008*";
+		samsung,muic-reset {
+			i2c-gpios = <31 32>;
+			i2c-address = <0x25>;
+		};
+	};
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -13,6 +13,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-samsung-r05.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r06.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r08.dtb \
+	$(LOCAL_DIR)/msm8929-samsung-r01.dtb \
 	$(LOCAL_DIR)/msm8929-samsung-r04.dtb \
 	$(LOCAL_DIR)/msm8939-mtp.dtb
 endif

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -13,5 +13,6 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-samsung-r05.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r06.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r08.dtb \
+	$(LOCAL_DIR)/msm8929-samsung-r04.dtb \
 	$(LOCAL_DIR)/msm8939-mtp.dtb
 endif


### PR DESCRIPTION
Device list:
J3109
J3110
J3119
J5008
J500F
J500H
J5108
J510H
J7008
J700P

The bootloader name in j5xlte-eur should be J510F*
And the J510FN should be called j5xnlte