### PR TITLE
dts: Add Samsung Galaxy J5 2015 (SM-J500H) (Rev. 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy A3 (2015) - SM-A300FU
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU
 - Samsung Galaxy J5 (2015) - SM-J500FN
+- Samsung Galaxy J5 (2015) - SM-J500H
 - Samsung Galaxy J5 (2016) - SM-J510FN
 - Samsung Galaxy S4 Mini Value Edition - GT-I9195I
 - Samsung Galaxy Tab 4 10.1 (2015) - SM-T533

--- a/dts/msm8916-samsung-r09.dts
+++ b/dts/msm8916-samsung-r09.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8916.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <206 0>;
+	qcom,board-id = <0xF808FF01 5>;
+
+	j53g-eur {
+		model = "Samsung Galaxy J5 2015 (SM-J500H)";
+		compatible = "samsung,j53gxx", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J500H*";
+		
+		samsung,muic-reset {
+			i2c-gpios = <105 106>;
+			i2c-address = <0x25>;
+		};
+	};
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -13,5 +13,6 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-samsung-r05.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r06.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r08.dtb \
+        $(LOCAL_DIR)/msm8916-samsung-r09.dtb \
 	$(LOCAL_DIR)/msm8939-mtp.dtb
 endif


### PR DESCRIPTION
Samsung Galaxy J5(2015) device port.

Samsung Galaxy SM-J500H has a different board ID and is not detectable by lk2nd. This adds J500H support to lk2nd.