### PR TITLE
Fix builds on GCC 10, add gprimeltecan dts

### DIFF
--- a/dts/msm8916-samsung-r02.dts
+++ b/dts/msm8916-samsung-r02.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8916.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <206 0>;
+	qcom,board-id = <0xCE08FF01 2>;
+
+	gprimeltecan {
+		model = "Samsung Galaxy Grand Prime (CAN)";
+		compatible = "samsung,gprimeltecan", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "G530W*";
+		
+		samsung,muic-reset {
+			i2c-gpios = <2 3>;
+			i2c-address = <0x25>;
+		};
+	};
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -9,6 +9,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-mtp.dtb \
 	$(LOCAL_DIR)/msm8916-qrd9-v1.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r01.dtb \
+	$(LOCAL_DIR)/msm8916-samsung-r02.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r03.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r04.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r05.dtb \

--- a/makefile
+++ b/makefile
@@ -52,7 +52,9 @@ ifeq ($(ENABLE_TRUSTZONE),1)
 endif
 
 INCLUDES := -I$(BUILDDIR) -Iinclude
-CFLAGS := -fcommon -O2 -g -fno-builtin -finline -Wno-multichar -Wno-unused-parameter -Wno-unused-function -include $(CONFIGHEADER)
+CFLAGS := -O2 -g -fno-builtin -finline -Wno-multichar -Wno-unused-parameter -Wno-unused-function -include $(CONFIGHEADER)
+# -fcommon is needed to build this using GCC 10
+CFLAGS += -fcommon
 #CFLAGS += -Werror
 ifeq ($(EMMC_BOOT),1)
   CFLAGS += -D_EMMC_BOOT=1

--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ ifeq ($(ENABLE_TRUSTZONE),1)
 endif
 
 INCLUDES := -I$(BUILDDIR) -Iinclude
-CFLAGS := -O2 -g -fno-builtin -finline -Wno-multichar -Wno-unused-parameter -Wno-unused-function -include $(CONFIGHEADER)
+CFLAGS := -fcommon -O2 -g -fno-builtin -finline -Wno-multichar -Wno-unused-parameter -Wno-unused-function -include $(CONFIGHEADER)
 #CFLAGS += -Werror
 ifeq ($(EMMC_BOOT),1)
   CFLAGS += -D_EMMC_BOOT=1


### PR DESCRIPTION
I couldn't get it to build for a while but someone mentioned that a recent update to gcc or something changed the default behaviour from "-fcommon" to "-fnocommon", and I might be mistaken, but I think that's what broke builds on this, because when I added -fcommon my builds are working again.

And the other commit here is adding the gprimeltecan file.
Hopefully it all looks good. 