### PR TITLE
Add support for Asus Zenfone 2 Laser 720p (Z00L)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ and then loaded by lk2nd.
 
 ### Supported devices
 - Alcatel OneTouch Idol 3 (5.5) - 6045*
+- Asus Zenfone 2 Laser (720p) - Z00L
 - Asus Zenfone 2 Laser (1080p) - Z00T
 - BQ Aquaris X5 (paella, picmt)
 - Lenovo PHAB Plus - PB1-770M, PB1-770N

--- a/dts/msm8916-asus-z00l.dts
+++ b/dts/msm8916-asus-z00l.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8916.dtsi"
+
+/ {
+        qcom,msm-id =   <206 0>,
+			<248 0>,
+			<249 0>,
+			<250 0>;
+	qcom,board-id = <21 0>;
+	model = "Asus Zenfone Laser 2 ZE550KL";
+	compatible = "asus,z00l", "qcom,msm8916", "lk2nd,device";
+};

--- a/dts/msm8916-asus-z00l.dts
+++ b/dts/msm8916-asus-z00l.dts
@@ -5,16 +5,8 @@
 /include/ "msm8916.dtsi"
 
 / {
-        qcom,msm-id =   <206 0>,
-			<248 0>,
-			<249 0>,
-			<250 0>;
+	qcom,msm-id =   <206 0>;
 	qcom,board-id = <21 0>;
-	compatible = "qcom,msm8916-mtp", "qcom,msm8916";
-	
-	asus-z00l {
-		model = "Asus Zenfone 2 Laser (720p)";
-		compatible = "asus,z00l", "qcom,msm8916", "lk2nd,device";
-		lk2nd,match-cmdline = "*LASER*";
-	};
+	model = "Asus Zenfone Laser 2 (720p)";
+	compatible = "asus,z00l", "qcom,msm8916", "lk2nd,device";
 };

--- a/dts/msm8916-asus-z00l.dts
+++ b/dts/msm8916-asus-z00l.dts
@@ -10,6 +10,6 @@
 			<249 0>,
 			<250 0>;
 	qcom,board-id = <21 0>;
-	model = "Asus Zenfone Laser 2 ZE550KL";
+	model = "Asus Zenfone Laser 2 (720p)";
 	compatible = "asus,z00l", "qcom,msm8916", "lk2nd,device";
 };

--- a/dts/msm8916-asus-z00l.dts
+++ b/dts/msm8916-asus-z00l.dts
@@ -10,6 +10,11 @@
 			<249 0>,
 			<250 0>;
 	qcom,board-id = <21 0>;
-	model = "Asus Zenfone Laser 2 (720p)";
-	compatible = "asus,z00l", "qcom,msm8916", "lk2nd,device";
+	compatible = "qcom,msm8916-mtp", "qcom,msm8916";
+	
+	asus-z00l {
+		model = "Asus Zenfone 2 Laser (720p)";
+		compatible = "asus,z00l", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-cmdline = "*LASER*";
+	};
 };

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -5,6 +5,7 @@ DTBS += \
 	$(LOCAL_DIR)/apq8016-samsung-r02.dtb \
 	$(LOCAL_DIR)/apq8016-samsung-r07.dtb \
 	$(LOCAL_DIR)/msm8216-samsung-r05.dtb \
+	$(LOCAL_DIR)/msm8916-asus-z00l.dtb \
 	$(LOCAL_DIR)/msm8916-lg.dtb \
 	$(LOCAL_DIR)/msm8916-motorola-harpia-p1b-4d.dtb \
 	$(LOCAL_DIR)/msm8916-motorola-harpia-p1b-4e.dtb \


### PR DESCRIPTION
This PR adds support to boot lk2nd in Asus Zenfone 2 Laser 720p (Z00L).