### PR TITLE
lk2nd: Introduce mainline panel selection 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Asus Zenfone 2 Laser (1080p) - Z00T
 - Asus Zenfone Max ZC550KL (2016) - Z010D
 - BQ Aquaris X5 (paella, picmt)
+- Lenovo A6000
 - Lenovo A6010
 - Lenovo PHAB Plus - PB1-770M, PB1-770N
 - LG K10 (m216) - K420 (see notes in `dts/msm8916-lg.dts` for now)

--- a/app/aboot/lk2nd-device.c
+++ b/app/aboot/lk2nd-device.c
@@ -167,6 +167,17 @@ static bool match_string(const char *s, const char *match, size_t len)
 	return strncmp(s, match, len + 1) == 0;
 }
 
+static bool match_panel(const void *fdt, int offset, const char *panel_name)
+{
+	offset = fdt_subnode_offset(fdt, offset, "panel");
+	if (offset < 0) {
+		dprintf(CRITICAL, "No panels defined, cannot match\n");
+		return false;
+	}
+
+	return fdt_subnode_offset(fdt, offset, panel_name) >= 0;
+}
+
 static bool lk2nd_device_match(const void *fdt, int offset)
 {
 	int len;
@@ -183,8 +194,14 @@ static bool lk2nd_device_match(const void *fdt, int offset)
 	if (val && len > 0) {
 		if (!lk2nd_dev.cmdline)
 			return false;
-
 		return match_string(lk2nd_dev.cmdline, val, len);
+	}
+
+	fdt_getprop(fdt, offset, "lk2nd,match-panel", &len);
+	if (len >= 0) {
+		if (!lk2nd_dev.panel.name)
+			return false;
+		return match_panel(fdt, offset, lk2nd_dev.panel.name);
 	}
 
 	return true; // No match property

--- a/app/aboot/lk2nd-device.h
+++ b/app/aboot/lk2nd-device.h
@@ -5,6 +5,13 @@
 
 #include <dev_tree.h>
 
+struct lk2nd_panel {
+	const char *name;
+	const char *old_compatible;
+	const char *compatible;
+	int compatible_size;
+};
+
 struct lk2nd_device {
 	void *fdt;
 	struct board_id board_id;
@@ -17,7 +24,8 @@ struct lk2nd_device {
 	const char *serialno;
 	const char *carrier;
 	const char *radio;
-	const char *panel;
+
+	struct lk2nd_panel panel;
 };
 
 extern struct lk2nd_device lk2nd_dev;
@@ -27,5 +35,7 @@ int lk2nd_fdt_parse_early_uart(void);
 
 void lk2nd_samsung_muic_reset(const void *fdt, int offset);
 void lk2nd_motorola_smem_write_unit_info(const void *fdt, int offset);
+
+void lk2nd_update_device_tree(void *fdt, const char *cmdline);
 
 #endif

--- a/dts/msm8916/msm8916-asus-z00l.dts
+++ b/dts/msm8916/msm8916-asus-z00l.dts
@@ -9,4 +9,15 @@
 	qcom,board-id = <21 0>;
 	model = "Asus Zenfone Laser 2 (720p)";
 	compatible = "asus,z00l", "qcom,msm8916", "lk2nd,device";
+
+	panel {
+		compatible = "asus,z00l-panel";
+
+		qcom,mdss_dsi_otm1284a_720p_video {
+			compatible = "asus,z00l-otm1284a";
+		};
+		qcom,mdss_dsi_cpt5p5_otm1284a_720p_video {
+			compatible = "asus,z00l-cpt5p5-otm1284a";
+		};
+	};
 };

--- a/dts/msm8916/msm8916-motorola-harpia.dtsi
+++ b/dts/msm8916/msm8916-motorola-harpia.dtsi
@@ -4,4 +4,15 @@
 / {
 	model = "Motorola Moto G4 Play (harpia)";
 	compatible = "motorola,harpia", "qcom,msm8916", "lk2nd,device";
+
+	panel {
+		compatible = "motorola,harpia-panel";
+
+		qcom,mdss_dsi_mot_boe_499_720p_video_v1 {
+			compatible = "motorola,harpia-panel-boe";
+		};
+		qcom,mdss_dsi_mot_tianma_499_720p_video_v2 {
+			compatible = "motorola,harpia-panel-tianma";
+		};
+	};
 };

--- a/dts/msm8916/msm8916-motorola-osprey.dts
+++ b/dts/msm8916/msm8916-motorola-osprey.dts
@@ -6,4 +6,18 @@
 
 	model = "Motorola Moto G 2015 (osprey)";
 	compatible = "motorola,osprey", "qcom,msm8916", "lk2nd,device";
+
+	panel {
+		compatible = "motorola,osprey-panel";
+
+		qcom,mdss_dsi_mot_inx_500_720p_video_v0 {
+			compatible = "motorola,osprey-panel-inx";
+		};
+		qcom,mdss_dsi_mot_tdi_500_720p_video_v0 {
+			compatible = "motorola,osprey-panel-tdi";
+		};
+		qcom,mdss_dsi_mot_boe_500_720p_video_v0 {
+			compatible = "motorola,osprey-panel-boe";
+		};
+	};
 };

--- a/dts/msm8916/msm8916-motorola-surnia.dts
+++ b/dts/msm8916/msm8916-motorola-surnia.dts
@@ -6,4 +6,15 @@
 
 	model = "Motorola Moto E 2015 LTE (surnia)";
 	compatible = "motorola,surnia", "qcom,msm8916", "lk2nd,device";
+
+	panel {
+		compatible = "motorola,surnia-panel";
+
+		qcom,mdss_dsi_mot_boe_450_qhd_video_v3 {
+			compatible = "motorola,surnia-panel-boe";
+		};
+		qcom,mdss_dsi_mot_inx_450_qhd_video_v1 {
+			compatible = "motorola,surnia-panel-inx";
+		};
+	};
 };

--- a/dts/msm8916/msm8916-qrd12-v1.dts
+++ b/dts/msm8916/msm8916-qrd12-v1.dts
@@ -10,6 +10,33 @@
 	wingtech-wt88047 {
 		compatible = "wingtech,wt88047", "qcom,msm8916", "lk2nd,device";
 		model = "Xiaomi Redmi 2 (Wingtech WT88047)";
-		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_r61308_720p_video:1:none *";
+		lk2nd,match-panel;
+
+		panel {
+			compatible = "wingtech,wt88047-panel";
+
+			qcom,mdss_dsi_r69431_720p_video {
+				compatible = "wingtech,sharp-r69431";
+			};
+			qcom,mdss_dsi_nt35521_720p_video {
+				compatible = "wingtech,auo-nt35521";
+			};
+			qcom,mdss_dsi_nt35521s_720p_video {
+				compatible = "wingtech,boe-nt35521s";
+			};
+			qcom,mdss_dsi_nt35521_ofilm_720p_video {
+				compatible = "wingtech,ofilm-nt35521";
+			};
+			/* qcom,mdss_dsi_otm1285a_720p_video is not supported */
+			qcom,mdss_dsi_r61308_720p_video {
+				compatible = "wingtech,auo-r61308";
+			};
+			qcom,mdss_dsi_otm1285a_otp_720p_video {
+				compatible = "wingtech,ebbg-otm1285a";
+			};
+			qcom,mdss_dsi_r61308_s88047a1_720p_video {
+				compatible = "wingtech,auo-r61308";
+			};
+		};
 	};
 };

--- a/dts/msm8916/msm8916-qrd8-v1.dts
+++ b/dts/msm8916/msm8916-qrd8-v1.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "skeleton.dtsi"
+
+/ {
+	compatible = "qcom,msm8916-v1-qrd/8-v1", "qcom,msm8916";
+
+	lenovo-a6000 {
+		model = "Lenovo A6000 (Wingtech WT86518)";
+		compatible = "wingtech,wt86518", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-panel;
+
+		panel {
+			compatible = "wingtech,wt86518-panel";
+
+			qcom,mdss_dsi_innolux_720p_video {
+				compatible = "wingtech,innolux-otm1283a";
+			};
+			qcom,mdss_dsi_hx8394d_720p_video {
+				compatible = "wingtech,tianma-hx8394d";
+			};
+			qcom,mdss_dsi_ili9881_720p_video {
+				compatible = "wingtech,yassy-ili9881";
+			};
+			qcom,mdss_dsi_ili9881_qimei_720p_video {
+				compatible = "wingtech,qimei-ili9881";
+			};
+		};
+	};
+};

--- a/dts/msm8916/msm8916-qrd9-v1.dts
+++ b/dts/msm8916/msm8916-qrd9-v1.dts
@@ -8,21 +8,69 @@
 	compatible = "qcom,msm8916-v1-qrd/9-v1", "qcom,msm8916";
 
 	wileyfox-crackling {
-		model = "Wileyfox Swift";
-		compatible = "wileyfox,crackling", "longcheer,l8150",
-			     "qcom,msm8916", "lk2nd,device";
+		model = "Wileyfox Swift (Longcheer L8150)";
+		compatible = "longcheer,l8150", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "crackling-*";
+
+		panel {
+			compatible = "longcheer,l8150-panel";
+
+			/* TODO: qcom,mdss_dsi_truly_otm1288a_720p_video */
+			qcom,mdss_dsi_dijing_ILI9881C_720p_video {
+				compatible = "longcheer,dijing-ili9881c";
+			};
+			qcom,mdss_dsi_booyi_OTM1287_720p_video {
+				compatible = "longcheer,booyi-otm1287";
+			};
+		};
 	};
 
 	bq-paella {
-		model = "BQ Aquaris X5";
-		compatible = "bq,paella", "qcom,msm8916", "lk2nd,device";
+		model = "BQ Aquaris X5 (Longcheer L8910)";
+		compatible = "longcheer,l8910", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "paella-*";
+
+		panel {
+			compatible = "longcheer,l8910-panel";
+
+			qcom,mdss_dsi_truly_otm1288a_720p_video {
+				compatible = "longcheer,truly-otm1288a";
+			};
+			qcom,mdss_dsi_truly_otm1288a_720p_cmd {
+				compatible = "longcheer,truly-otm1288a";
+			};
+			qcom,mdss_dsi_yushun_NT35520_720p_cmd {
+				compatible = "longcheer,yushun-nt35520";
+			};
+			qcom,mdss_dsi_truly_HX8394_720p_video {
+				compatible = "longcheer,truly-hx8394";
+			};
+			qcom,mdss_dsi_yushun_NT35521S_720p_video {
+				compatible = "longcheer,yushun-nt35521s";
+			};
+		};
 	};
 
 	lenovo-a6010 {
-		model = "Lenovo A6010";
-		compatible = "lenovo,a6010", "qcom,msm8916", "lk2nd,device";
-		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_ili9881_720p_video:1:none";
+		model = "Lenovo A6010 (Wingtech WT86528)";
+		compatible = "wingtech,wt86528", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-panel;
+
+		panel {
+			compatible = "wingtech,wt86528-panel";
+
+			qcom,mdss_dsi_innolux_720p_video {
+				compatible = "wingtech,innolux-otm1283a";
+			};
+			qcom,mdss_dsi_hx8394d_720p_video {
+				compatible = "wingtech,tianma-hx8394d";
+			};
+			qcom,mdss_dsi_ili9881_720p_video {
+				compatible = "wingtech,yassy-ili9881";
+			};
+			qcom,mdss_dsi_ili9881_qimei_720p_video {
+				compatible = "wingtech,qimei-ili9881";
+			};
+		};
 	};
 };

--- a/dts/msm8916/rules.mk
+++ b/dts/msm8916/rules.mk
@@ -12,6 +12,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-motorola-surnia.dtb \
 	$(LOCAL_DIR)/msm8916-mtp.dtb \
 	$(LOCAL_DIR)/msm8916-mtp-smb1360.dtb \
+	$(LOCAL_DIR)/msm8916-qrd8-v1.dtb \
 	$(LOCAL_DIR)/msm8916-qrd9-v1.dtb \
 	$(LOCAL_DIR)/msm8916-qrd12-v1.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r01.dtb \

--- a/platform/msm_shared/dev_tree.c
+++ b/platform/msm_shared/dev_tree.c
@@ -37,6 +37,7 @@
 #include <board.h>
 #include <list.h>
 #include <kernel/thread.h>
+#include <lk2nd-device.h>
 
 struct dt_entry_v1
 {
@@ -1441,6 +1442,7 @@ int update_device_tree(void *fdt, const char *cmdline,
 		}
 	}
 
+	lk2nd_update_device_tree(fdt, cmdline);
 	fdt_pack(fdt);
 
 	return ret;

--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -432,8 +432,8 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 		msg_buf);
 	display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
 
-	if (lk2nd_dev.panel) {
-		snprintf(msg, sizeof(msg), "PANEL - %s\n", lk2nd_dev.panel);
+	if (lk2nd_dev.panel.name) {
+		snprintf(msg, sizeof(msg), "PANEL - %s\n", lk2nd_dev.panel.name);
 		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
 	}
 


### PR DESCRIPTION
Some devices have multiple possible panels. In that case, we need
to load different panel drivers. On downstream this is implemented
directly in the kernel, but this is difficult to implement cleanly
in mainline.

Instead, it's easier to do this as part of lk2nd. The mainline device
tree only contains a generic compatible (e.g. "motorola,harpia-panel")
with all required properties for it (e.g. GPIOs, regulators, ...).
We assume that the panels are similar enough that they all need exactly
the same properties.

The lk2nd device tree then contains a list of possible panels with
their mainline compatibles (e.g. "motorola,harpia-panel-tianma").
We can identify the panel using the "mdss_mdp.panel" parameter passed
by the primary bootloader.

When mainline is booted, we search for the "generic" compatible,
and replace it with the real one. The kernel will then probe the
correct panel. Yay!