### PR TITLE
scripts: fix shebang

### DIFF
--- a/scripts/dtbTool
+++ b/scripts/dtbTool
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 #
 #  Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
 #

--- a/scripts/mkbootimg
+++ b/scripts/mkbootimg
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 #
 #  Copyright (c) 2013, The Linux Foundation. All rights reserved.
 #


### PR DESCRIPTION
Due to the strange shebang in the script, the patche-shebang failed
when it was built on the Guix/Nix package manager. I fixed it.