### PR TITLE
Add support for LG Leon LTE (c50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Lenovo A6010
 - Lenovo PHAB Plus - PB1-770M, PB1-770N
 - LG K10 (m216) - K420
+- LG Leon LTE (c50) - H340, H342, H343, H345, MS345, etc
 - Marshall London
 - Motorola Moto E (2015) - surnia
 - Motorola Moto G (2015) - osprey

--- a/dts/msm8916/msm8916-lg.dts
+++ b/dts/msm8916/msm8916-lg.dts
@@ -9,6 +9,12 @@
 	qcom,msm-id = <206 0>;
 	qcom,board-id = <100 0>;
 
+	c50 {
+		model = "LG Leon LTE";
+		compatible = "lg,c50", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-cmdline = "* model.name=LG-H34*";
+	};
+
 	m216 {
 		model = "LG K10 (K420n)";
 		compatible = "lg,m216", "qcom,msm8916", "lk2nd,device";

--- a/target/msm8916/init.c
+++ b/target/msm8916/init.c
@@ -150,7 +150,7 @@ int target_volume_up()
 	uint8_t status = 0;
 
         if (!first_time) {
-            gpio_tlmm_config(TLMM_VOL_UP_BTN_GPIO, 0, GPIO_INPUT, GPIO_PULL_UP, GPIO_2MA, GPIO_ENABLE);
+            gpio_tlmm_config(108, 0, GPIO_INPUT, GPIO_PULL_UP, GPIO_2MA, GPIO_ENABLE);
 
 	    /* Wait for the gpio config to take effect - debounce time */
 	    udelay(10000);
@@ -159,17 +159,32 @@ int target_volume_up()
         }
 
 	/* Get status of GPIO */
-	status = gpio_status(TLMM_VOL_UP_BTN_GPIO);
+	status = gpio_status(108);
 
 	/* Active low signal. */
 	return !status;
 }
 
 /* Return 1 if vol_down pressed */
-uint32_t target_volume_down()
+int target_volume_down()
 {
-	/* Volume down button tied in with PMIC RESIN. */
-	return pm8x41_resin_status();
+    static uint8_t first_time = 0;
+	uint8_t status = 0;
+
+        if (!first_time) {
+            gpio_tlmm_config(107, 0, GPIO_INPUT, GPIO_PULL_UP, GPIO_2MA, GPIO_ENABLE);
+
+	    /* Wait for the gpio config to take effect - debounce time */
+	    udelay(10000);
+
+            first_time = 1;
+        }
+
+	/* Get status of GPIO */
+	status = gpio_status(107);
+
+	/* Active low signal. */
+	return !status;
 }
 
 static void target_keystatus()


### PR DESCRIPTION
Device does not have fastboot and ability to boot into recovery with keys combination itself.
It uses both volume buttons as gpios, volume down is 107 and volume up is 108. Usually 107 is volume up, so lk2nd reacts on volume down key as volume up and doesn't react on volume up key at all. I can boot into recovery via lk2nd menu and use fastboot boot, but after flashing boot.img there will no ability to enter lk2nd fastboot.
For now i hardcoded gpios in target/msm8916/init.c, so PR is draft.