### PR TITLE
lk2nd: Implement more sophisticated DTB override mechanism

### DIFF
--- a/dts/msm8916/msm8916-samsung-r02.dts
+++ b/dts/msm8916/msm8916-samsung-r02.dts
@@ -18,6 +18,7 @@
 		compatible = "samsung,a5u-eur", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "A500FU*";
 
+		qcom,msm-id = <206 0>;
 		qcom,board-id = <0xCE08FF01 1>;
 	};
 

--- a/dts/msm8916/msm8929-samsung-r04.dts
+++ b/dts/msm8916/msm8929-samsung-r04.dts
@@ -26,6 +26,7 @@
 
 		// The stock Samsung bootloader seems to pick <0x0C01FF01 4> as the board id as opposed to <0xCE08FF01 3>
 		// This line should fix that
+		qcom,msm-id = <206 0>;
 		qcom,board-id = <0xCE08FF01 3>;
 
 		samsung,muic-reset {

--- a/include/lk2nd.h
+++ b/include/lk2nd.h
@@ -17,7 +17,7 @@ struct lk2nd_panel {
 
 struct lk2nd_device {
 	void *fdt;
-	struct board_id board_id;
+	struct dt_entry dt_entry;
 
 	const char *model;
 	const char *cmdline;

--- a/platform/msm_shared/dev_tree.c
+++ b/platform/msm_shared/dev_tree.c
@@ -124,9 +124,8 @@ static void dt_entry_list_delete(struct dt_entry_node *dt_node_member)
 	}
 }
 
-static int dev_tree_compatible(void *dtb, uint32_t dtb_size, struct dt_entry_node *dtb_list)
+static int dev_tree_compatible(void *dtb, uint32_t dtb_size, int root_offset, struct dt_entry_node *dtb_list)
 {
-	int root_offset;
 	const void *prop = NULL;
 	const char *plat_prop = NULL;
 	const char *board_prop = NULL;
@@ -149,7 +148,8 @@ static int dev_tree_compatible(void *dtb, uint32_t dtb_size, struct dt_entry_nod
 	uint32_t board_data_count;
 	uint32_t pmic_data_count;
 
-	root_offset = fdt_path_offset(dtb, "/");
+	if (!root_offset)
+		root_offset = fdt_path_offset(dtb, "/");
 	if (root_offset < 0)
 		return false;
 
@@ -207,6 +207,12 @@ static int dev_tree_compatible(void *dtb, uint32_t dtb_size, struct dt_entry_nod
 	 * z: SOC rev
 	 */
 	if (dtb_ver == DEV_TREE_VERSION_V1) {
+#if WITH_LK2ND
+		if (dtb_list->dt_entry_m && len_plat_id != DT_ENTRY_V1_SIZE) {
+			free(model);
+			return false;
+		}
+#endif
 		cur_dt_entry = (struct dt_entry *)
 				malloc(sizeof(struct dt_entry));
 
@@ -268,6 +274,13 @@ static int dev_tree_compatible(void *dtb, uint32_t dtb_size, struct dt_entry_nod
 		msm_data_count = (len_plat_id / PLAT_ID_SIZE);
 		/* If dtb version is v2.0, the pmic_data_count will be <= 0 */
 		pmic_data_count = (len_pmic_id / PMIC_ID_SIZE);
+
+#if WITH_LK2ND
+		if (dtb_list->dt_entry_m && (board_data_count > 1 || msm_data_count > 1 || pmic_data_count > 1)) {
+			free(model);
+			return false;
+		}
+#endif
 
 		/* If we are using dtb v3.0, then we have split board, msm & pmic data in the DTB
 		*  If we are using dtb v2.0, then we have split board & msmdata in the DTB
@@ -461,6 +474,7 @@ void *dev_tree_appended(void *kernel, uint32_t kernel_size, uint32_t dtb_offset,
 		return NULL;
 	}
 	list_initialize(&dt_entry_queue->node);
+	dt_entry_queue->dt_entry_m = NULL;
 
 	if (dtb_offset)
 		app_dtb_offset = dtb_offset;
@@ -490,7 +504,7 @@ void *dev_tree_appended(void *kernel, uint32_t kernel_size, uint32_t dtb_offset,
 			return NULL;
 		}
 
-		dev_tree_compatible(dtb, dtb_size, dt_entry_queue);
+		dev_tree_compatible(dtb, dtb_size, 0, dt_entry_queue);
 
 		/* goto the next device tree if any */
 		dtb += dtb_size;
@@ -604,21 +618,45 @@ static int platform_dt_absolute_match(struct dt_entry *cur_dt_entry, struct dt_e
 	if (board_hardware_id() > 0xff)
 		cur_dt_hw_platform = cur_dt_entry->variant_id;
 
+#if WITH_LK2ND
+	if (dt_list && dt_list->dt_entry_m) {
+		memcpy(dt_list->dt_entry_m, cur_dt_entry, sizeof(struct dt_entry));
+		return 1;
+	}
+
+	if (dt_list && lk2nd_dev.dt_entry.offset) {
+		/*
+		 * If the bootloader selected an unexpected DTB, we match
+		 * platform_id/variant_id/board_hw_subtype exactly, because we
+		 * don't know which DTB the stock bootloader would have selected.
+		 */
+		if (lk2nd_dev.dt_entry.platform_id != cur_dt_entry->platform_id ||
+		    lk2nd_dev.dt_entry.variant_id != cur_dt_entry->variant_id ||
+		    lk2nd_dev.dt_entry.board_hw_subtype != cur_dt_entry->board_hw_subtype)
+			return 0;
+	} else
+#endif
+
 	/* 1. must match the msm_id, platform_hw_id, platform_subtype and DDR size
 	*  soc, board major/minor, pmic major/minor must less than board info
 	*  2. find the matched DTB then return 1
 	*  3. otherwise return 0
 	*/
-	if((cur_dt_msm_id == (board_platform_id() & 0x0000ffff)) &&
+	if(!((cur_dt_msm_id == (board_platform_id() & 0x0000ffff)) &&
 		(cur_dt_hw_platform == board_hardware_id()) &&
 		(cur_dt_hw_subtype == board_hardware_subtype()) &&
 		(cur_dt_hlos_ddr == (target_get_hlos_subtype() & 0x700)) &&
+		((cur_dt_entry->variant_id & 0x00ffff00) <= (board_target_id() & 0x00ffff00))))
+		return 0;
+	if (
 		(cur_dt_entry->soc_rev <= board_soc_version()) &&
-		((cur_dt_entry->variant_id & 0x00ffff00) <= (board_target_id() & 0x00ffff00)) &&
 		((cur_dt_entry->pmic_rev[0] & 0x00ffff00) <= (board_pmic_target(0) & 0x00ffff00)) &&
 		((cur_dt_entry->pmic_rev[1] & 0x00ffff00) <= (board_pmic_target(1) & 0x00ffff00)) &&
 		((cur_dt_entry->pmic_rev[2] & 0x00ffff00) <= (board_pmic_target(2) & 0x00ffff00)) &&
 		((cur_dt_entry->pmic_rev[3] & 0x00ffff00) <= (board_pmic_target(3) & 0x00ffff00))) {
+
+		if (!dt_list)
+			return 1;
 
 		dt_node_tmp = dt_entry_list_init();
 		memcpy((char*)dt_node_tmp->dt_entry_m,(char*)cur_dt_entry, sizeof(struct dt_entry));
@@ -647,6 +685,11 @@ static int platform_dt_absolute_compat_match(struct dt_entry_node *dt_list, uint
 	uint32_t best_pmic_model[4] = {0, 0, 0, 0};
 	uint32_t delete_current_dt = 0;
 	uint32_t i;
+
+#if WITH_LK2ND
+	if (lk2nd_dev.dt_entry.offset && dtb_info != DTB_PMIC_MODEL)
+		return 1;
+#endif
 
 	/* start to select the exact entry
 	* default to exact match 0, if find current DTB entry info is the same as board info,
@@ -765,6 +808,11 @@ static int update_dtb_entry_node(struct dt_entry_node *dt_list, uint32_t dtb_inf
 	uint32_t current_info = 0;
 	uint32_t board_info = 0;
 	uint32_t best_info = 0;
+
+#if WITH_LK2ND
+	if (lk2nd_dev.dt_entry.offset && dtb_info == DTB_MAJOR_MINOR)
+		return 1;
+#endif
 
 	/* start to select the best entry*/
 	list_for_every_entry(&dt_list->node, dt_node_tmp1, dt_node, node) {
@@ -976,6 +1024,7 @@ int dev_tree_get_entry_info(struct dt_table *table, struct dt_entry *dt_entry_in
 	}
 
 	list_initialize(&dt_entry_queue->node);
+	dt_entry_queue->dt_entry_m = NULL;
 	dprintf(INFO, "DTB Total entry: %d, DTB version: %d\n", table->num_entries, table->version);
 	for(i = 0; found == 0 && i < table->num_entries; i++)
 	{
@@ -1483,23 +1532,21 @@ const char *dev_tree_get_boot_args(const void *fdt)
 	return bootargs;
 }
 
-int dev_tree_get_board_id(const void *fdt, int offset, struct board_id *board_id)
+int dev_tree_get_dt_entry(const void *fdt, int offset, struct dt_entry *dt_entry)
 {
-	int len;
-	const struct board_id *board_prop;
+	struct dt_entry_node node = {
+		.node = LIST_INITIAL_VALUE(node.node),
+		.dt_entry_m = dt_entry
+	};
 
-	if (!offset)
-		offset = fdt_path_offset(fdt, "/");
-	if (offset < 0) {
-		dprintf(INFO, "Could not find node in device tree: %d\n", offset);
-		return 1;
+	if (!dev_tree_compatible((void*)fdt, fdt_totalsize(fdt), offset, &node))
+		return false;
+
+	if (platform_dt_absolute_match(dt_entry, NULL)) {
+		dprintf(INFO, "LK would match our own DTB. Cool!\n");
+		dt_entry->offset = 0; /* No need to override */
+	} else {
+		dprintf(INFO, "Weird DTB selected by bootloader. Need to override. Sad.\n");
 	}
-
-	board_prop = (const struct board_id*) fdt_getprop(fdt, offset, "qcom,board-id", &len);
-	if (!board_prop || len != BOARD_ID_SIZE)
-		return 1;
-
-	board_id->variant_id = fdt32_to_cpu(board_prop->variant_id);
-	board_id->platform_subtype = fdt32_to_cpu(board_prop->platform_subtype);
-	return 0;
+	return true;
 }

--- a/platform/msm_shared/dev_tree.c
+++ b/platform/msm_shared/dev_tree.c
@@ -256,10 +256,10 @@ static int dev_tree_compatible(void *dtb, uint32_t dtb_size, int root_offset, st
 					board_platform_id(),
 					board_hardware_id(),
 					board_soc_version());
-				plat_prop += DT_ENTRY_V1_SIZE;
-				len_plat_id -= DT_ENTRY_V1_SIZE;
-				continue;
 			}
+
+			plat_prop += DT_ENTRY_V1_SIZE;
+			len_plat_id -= DT_ENTRY_V1_SIZE;
 		}
 		free(cur_dt_entry);
 

--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -455,13 +455,6 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 		snprintf(msg, sizeof(msg), "MODEL - %s\n", lk2nd_dev.model);
 		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
 	}
-
-	if (lk2nd_dev.board_id.variant_id) {
-		snprintf(msg, sizeof(msg), "BOARD_ID - <%#x %d>\n",
-			 lk2nd_dev.board_id.variant_id,
-			 lk2nd_dev.board_id.platform_subtype);
-		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
-	}
 #endif
 
 	memset(msg_buf, 0, sizeof(msg_buf));
@@ -497,6 +490,18 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 	target_serialno((unsigned char *) msg_buf);
 	snprintf(msg, sizeof(msg), "SERIAL NUMBER - %s\n", msg_buf);
 	display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
+
+#if WITH_LK2ND
+	if (lk2nd_dev.dt_entry.size) {
+		snprintf(msg, sizeof(msg), "DTB - <%u %#x %u %#x>\n",
+			 lk2nd_dev.dt_entry.platform_id,
+			 lk2nd_dev.dt_entry.variant_id,
+			 lk2nd_dev.dt_entry.soc_rev,
+			 lk2nd_dev.dt_entry.board_hw_subtype);
+		display_fbcon_menu_message(msg, lk2nd_dev.dt_entry.offset ? FBCON_YELLOW_MSG : FBCON_COMMON_MSG,
+					   common_factor);
+	}
+#endif
 
 	display_fastboot_menu_print_fw_info(msg, sizeof(msg));
 

--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -454,6 +454,9 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 	if (lk2nd_dev.model) {
 		snprintf(msg, sizeof(msg), "MODEL - %s\n", lk2nd_dev.model);
 		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
+	} else {
+		display_fbcon_menu_message("MODEL - Unknown (FIXME!)\n",
+					   FBCON_RED_MSG, common_factor);
 	}
 #endif
 

--- a/platform/msm_shared/include/dev_tree.h
+++ b/platform/msm_shared/include/dev_tree.h
@@ -146,5 +146,5 @@ void *dev_tree_appended(void *kernel, uint32_t kernel_size, uint32_t dtb_offset,
 
 int dev_tree_check_header(const void *fdt);
 const char *dev_tree_get_boot_args(const void *fdt);
-int dev_tree_get_board_id(const void *fdt, int offset, struct board_id *board_id);
+int dev_tree_get_dt_entry(const void *fdt, int offset, struct dt_entry *dt_entry);
 #endif


### PR DESCRIPTION
Implements and fixes #60 

**Testing:**
- [x] MSM8916
- [x] MSM8974
- [x] MSM8226

To test:
- Check lk_log (`fastboot oem lk_log && fastboot get_staged <some-file>.txt`)
- Check display menu (`fastboot oem screenshot && fastboot get_staged /dev/stdout | convert - lk2nd.png`)
- Test if `fastboot boot`ing lk2nd from lk2nd is possible
- Test if booting some downstream kernel is possible (e.g. TWRP)