### PR TITLE
Improve on-screen instructions

### DIFF
--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -343,7 +343,7 @@ void display_bootverify_option_menu_renew(struct select_msg_info *msg_info)
 	len = ARRAY_SIZE(verify_option_menu);
 	display_fbcon_menu_message("Options menu:\n\n",
 		FBCON_COMMON_MSG, big_factor);
-	display_fbcon_menu_message("Press volume key to select, and "\
+	display_fbcon_menu_message("Press volume keys to navigate, and "\
 		"press power key to select\n\n", FBCON_COMMON_MSG, common_factor);
 
 	for (i = 0; i < len; i++) {
@@ -441,7 +441,7 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 	display_fbcon_menu_message(fastboot_option_menu[option_index],
 		msg_type, big_factor);
 	fbcon_draw_line(msg_type);
-	display_fbcon_menu_message("\n\nPress volume key to select, and "\
+	display_fbcon_menu_message("\n\nPress volume keys to navigate, and "\
 		"press power key to select\n\n", FBCON_COMMON_MSG, common_factor);
 
 	display_fbcon_menu_message("FASTBOOT MODE\n", FBCON_RED_MSG, common_factor);


### PR DESCRIPTION
The current on-screen instructions "Press volume key to select, and press power key to select" don't really clarify how to navigate and select an option. I'd suggest the following text to replace it: "Press volume keys to navigate, and press power key to select"