### PR TITLE
dts: gt58lte-aus: fix incorrect id's from bootloader

### DIFF
--- a/dts/msm8916/msm8916-samsung-r00.dts
+++ b/dts/msm8916/msm8916-samsung-r00.dts
@@ -3,29 +3,16 @@
 /dts-v1/;
 
 #include <skeleton.dtsi>
+#include <lk2nd.h>
 
 / {
 	// This is used by the bootloader to find the correct DTB
 	qcom,msm-id = <206 0>;
-	qcom,board-id = <0xCE08FF01 4>;
-
-	j5xlte-eur {
-		model = "Samsung Galaxy J5 2016 LTE (EUR)";
-		compatible = "samsung,j5xlte-eur", "qcom,msm8916", "lk2nd,device";
-		lk2nd,match-bootloader = "J510F*";
-
-		samsung,muic-reset {
-			i2c-gpio-pins = <105 106>;
-			i2c-address = <0x25>;
-		};
-	};
+	qcom,board-id = <0xCE08FF01 0>;
 
 	gt58lte-aus {
 		model = "Samsung Galaxy Tab A 8.0 2015 (SM-T355Y)";
 		compatible = "samsung,gt58lte-aus", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "T355Y*";
-
-		qcom,msm-id = <206 0>;
-		qcom,board-id = <0xCE08FF01 0>;
 	};
 };

--- a/dts/msm8916/rules.mk
+++ b/dts/msm8916/rules.mk
@@ -18,6 +18,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-qrd7+12-v1.dtb \
 	$(LOCAL_DIR)/msm8916-qrd8-v1.dtb \
 	$(LOCAL_DIR)/msm8916-qrd9-v1.dtb \
+	$(LOCAL_DIR)/msm8916-samsung-r00.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r01.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r02.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r03.dtb \


### PR DESCRIPTION
Fixes bugs that prevented stock android kernel from loading