### PR TITLE
dts: htc-m8qlul: Add support for HTC One M8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Asus Zenfone Max ZC550KL (2016) - Z010D
 - BQ Aquaris X5 - paella, picmt
 - DragonBoard 410c - apq8016-sbc
+- HTC One M8s - m8qlul (quirky - see comment in `dts/msm8916/msm8939-htc-m8qlul.dts`)
 - Huawei Ascend G7 - G7-L01
 - Huawei Honor 5X - kiwi
 - Lenovo A6000

--- a/dts/msm8916/msm8939-htc-m8qlul.dts
+++ b/dts/msm8916/msm8939-htc-m8qlul.dts
@@ -1,0 +1,19 @@
+/dts-v1/;
+
+/*
+ * To build for htc-m8qlul, comment out all dtbs and add
+ * $(LOCAL_DIR)/msm8939-htc-m8qlul.dtb to rules.mk in this directory.
+ * m8qlul does not work with all dtbs enabled; the bootloader gets upset and
+ * goes into the phone's fastboot.
+ */
+
+#include <skeleton.dtsi>
+
+/ {
+	model = "HTC One M8s";
+	compatible = "htc,m8qlul", "qcom,msm8939", "lk2nd,device";
+	qcom,msm-id = <382 0x10000>;
+	htc,project-id = <382 0x10000>;
+	htc,hw-id = <0 0>, <1 0>, <2 0>, <128 0>;
+	qcom,board-id = <1 0>;
+};


### PR DESCRIPTION
This adds support for htc-m8qlul (or htc-m8ql_ul), also known as HTC One M8s.

This doesn't actually work! But it does. You need to disable all other dts and then it works. If you don't, the device will go to its own fastboot instead of lk2nd after you boot. Minecrell suggested we merge it like this and do something more proper when/if I get mainline Linux booting on this thing.