### PR TITLE
htc-m8qlul: fix volume and power keys, add licence identifier 

### DIFF
--- a/dts/msm8916/msm8939-htc-m8qlul.dts
+++ b/dts/msm8916/msm8939-htc-m8qlul.dts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /dts-v1/;
 
 /*

--- a/dts/msm8916/msm8939-htc-m8qlul.dts
+++ b/dts/msm8916/msm8939-htc-m8qlul.dts
@@ -10,6 +10,7 @@
  */
 
 #include <skeleton.dtsi>
+#include <lk2nd.h>
 
 / {
 	model = "HTC One M8s";
@@ -18,4 +19,8 @@
 	htc,project-id = <382 0x10000>;
 	htc,hw-id = <0 0>, <1 0>, <2 0>, <128 0>;
 	qcom,board-id = <1 0>;
+
+	lk2nd,keys =
+		<KEY_VOLUMEDOWN	108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+		<KEY_VOLUMEUP	107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 };


### PR DESCRIPTION
I notice the layout is the same as https://github.com/msm8916-mainline/lk2nd/blob/master/dts/msm8916/msm8916-lg.dts#L28, but I'm not sure this is worth generalising.