### PR TITLE
dts: sm-g5108q: Add support for the Samsung Galaxy Core Max

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Motorola Moto G4 Play - harpia
 - Samsung Galaxy A3 (2015) - SM-A300FU
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU
+- Samsung Galaxy Core Max - SM-G5108Q (quirky - see comment in `dts/msm8916/msm8916-samsung-r08.dts`)
 - Samsung Galaxy Core Prime LTE - SM-G360F
 - Samsung Galaxy Grand Prime - SM-G530W
 - Samsung Galaxy J3 (2016) - SM-J3109

--- a/dts/msm8916/msm8916-samsung-r08.dts
+++ b/dts/msm8916/msm8916-samsung-r08.dts
@@ -2,6 +2,11 @@
 
 /dts-v1/;
 
+/*
+ * Before building for G5108Q, please comment out all dtbs except "$(LOCAL_DIR)/msm8916-samsung-r08.dtb" at './rules.mk'.
+ * g5108q doesn't work with multi-dtbs; only goes into the "Download mode".
+*/
+
 #include <skeleton.dtsi>
 #include <lk2nd.h>
 
@@ -22,5 +27,16 @@
 		lk2nd,match-bootloader = "T555*";
 
 		lk2nd,keys = <KEY_HOME 109 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+
+	g5108q {
+		model = "Samsung Galaxy Core Max (SM-G5108Q)";
+		compatible = "samsung,g5108q", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "G5108Q*";
+
+		samsung,muic-reset {
+			i2c-gpio-pins = <2 3>;
+			i2c-address = <0x14>;
+		};
 	};
 };


### PR DESCRIPTION
Work well on this msm8916 device.
![IMG_20210706_090833](https://user-images.githubusercontent.com/73088482/124529835-e61d8e00-de3d-11eb-938a-68bb64ce0d19.jpg)
