### PR TITLE
dts: huawei-y635-l01: Add support for Huawei Y635-L01

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - HTC One M8s - m8qlul (quirky - see comment in `dts/msm8916/msm8939-htc-m8qlul.dts`)
 - Huawei Ascend G7 - G7-L01
 - Huawei Honor 5X - kiwi
+- Huawei Y635 - Y635-L01 (quirky - see comment in `dts/msm8916/msm8916-huawei-y635-l01.dts`)
 - Lenovo A6000
 - Lenovo A6010
 - Lenovo PHAB Plus - PB1-770M, PB1-770N

--- a/dts/msm8916/msm8916-huawei-y635-l01.dts
+++ b/dts/msm8916/msm8916-huawei-y635-l01.dts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/*
+ * To get a working build for huawei-y635-l01, comment out
+ * $(LOCAL_DIR)/msm8916-mtp.dtb in rules.mk in this directory.
+ * y635-l01 does not work with msm8916-mtp.dtb enabled; the bootloader
+ * gets upset and goes into the phone's fastboot.
+ */
+
+#include <skeleton.dtsi>
+
+/ {
+        qcom,msm-id = <206 0>;
+        qcom,board-id = <8003 4>;
+
+        model = "Huawei Y635-L01";
+        compatible = "huawei,y635-l01", "qcom,msm8916", "lk2nd,device";
+};

--- a/dts/msm8916/rules.mk
+++ b/dts/msm8916/rules.mk
@@ -8,6 +8,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-asus-z00l.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-g7-l01.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-hwt1a21l.dtb \
+	$(LOCAL_DIR)/msm8916-huawei-y635-l01.dtb \
 	$(LOCAL_DIR)/msm8916-lg.dtb \
 	$(LOCAL_DIR)/msm8916-motorola-harpia-p1b-4d.dtb \
 	$(LOCAL_DIR)/msm8916-motorola-harpia-p1b-4e.dtb \


### PR DESCRIPTION
The phone will not boot lk2nd with **some** dtbs enabled, just like the [htc-m8qlul](https://github.com/msm8916-mainline/lk2nd/pull/78), so in order to fix this all other dtbs (or just msm8916-mtp.dts as of now) need to be disabled in [rules.mk](https://github.com/ungeskriptet/lk2nd/blob/master/dts/msm8916/rules.mk).

![lk2nd](https://user-images.githubusercontent.com/40729975/130212020-4e131530-2f36-43a1-9dd7-ace7b02437f9.png)