### PR TITLE
dts: Add LG Google Nexus 5 D820 and D821 (hammerhead)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 
 #### msm8974-secondary
 - LG G3 - D855
+- LG Google Nexus 5 - hammerhead D820, D821
 - Samsung Galaxy S5 - SM-G900F
 
 #### msm8226-secondary

--- a/dts/msm8974/msm8974-lge-hammerhead.dts
+++ b/dts/msm8974/msm8974-lge-hammerhead.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <0x7e 0x96 0x20002 0x2b>;
+
+	hammerhead-d820 {
+		model = "LG Google Nexus 5 D820";
+		compatible = "lge,hammerhead", "qcom,msm8974", "lk2nd,device";
+		lk2nd,match-cmdline = "* androidboot.hardware.sku=D820 *";
+
+		lk2nd,keys =
+			<KEY_VOLUMEUP   PM_GPIO(2) PM_GPIO_PULL_UP_1_5>,
+			<KEY_VOLUMEDOWN PM_GPIO(3) PM_GPIO_PULL_UP_1_5>;
+	};
+
+	hammerhead-d821 {
+		// Currently unable to use a dedicated device tree because it won't
+		// load D821 after D820 loaded.
+		qcom,msm-id = <0x7e 0x96 0x20002 0x0b>;
+
+		model = "LG Google Nexus 5 D821";
+		compatible = "lge,hammerhead", "qcom,msm8974", "lk2nd,device";
+		lk2nd,match-cmdline = "* androidboot.hardware.sku=D821 *";
+
+		lk2nd,keys =
+			<KEY_VOLUMEUP   PM_GPIO(2) PM_GPIO_PULL_UP_1_5>,
+			<KEY_VOLUMEDOWN PM_GPIO(3) PM_GPIO_PULL_UP_1_5>;
+	};
+};

--- a/dts/msm8974/rules.mk
+++ b/dts/msm8974/rules.mk
@@ -2,4 +2,5 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 
 DTBS += \
 	$(LOCAL_DIR)/msm8974-lge-d855.dtb \
+	$(LOCAL_DIR)/msm8974-lge-hammerhead.dtb \
 	$(LOCAL_DIR)/msm8974-samsung-klte.dtb

--- a/platform/msm_shared/dev_tree.c
+++ b/platform/msm_shared/dev_tree.c
@@ -198,6 +198,9 @@ static int dev_tree_compatible(void *dtb, void *real_dtb, uint32_t dtb_size,
 	} else if (len_plat_id % min_plat_id_len) {
 		dprintf(INFO, "qcom,msm-id in device tree is (%d) not a multiple of (%d)\n",
 			len_plat_id, min_plat_id_len);
+		if (dtb_ver == DEV_TREE_VERSION_V1 && len_plat_id == DT_ENTRY_LGE8974_SIZE)
+			min_plat_id_len = DT_ENTRY_LGE8974_SIZE;
+		else
 		return false;
 	}
 
@@ -209,7 +212,7 @@ static int dev_tree_compatible(void *dtb, void *real_dtb, uint32_t dtb_size,
 	 */
 	if (dtb_ver == DEV_TREE_VERSION_V1) {
 #if WITH_LK2ND
-		if (dtb_list->dt_entry_m && len_plat_id != DT_ENTRY_V1_SIZE) {
+		if (dtb_list->dt_entry_m && len_plat_id != min_plat_id_len) {
 			free(model);
 			return false;
 		}
@@ -236,6 +239,9 @@ static int dev_tree_compatible(void *dtb, void *real_dtb, uint32_t dtb_size,
 			cur_dt_entry->offset = (uint32_t)real_dtb;
 			cur_dt_entry->size = dtb_size;
 
+			if (min_plat_id_len == DT_ENTRY_LGE8974_SIZE)
+				cur_dt_entry->board_hw_subtype = fdt32_to_cpu(((const struct dt_entry_v1 *)plat_prop)->offset);
+
 			dprintf(SPEW, "Found an appended flattened device tree (%s - %u %u 0x%x)\n",
 				model ? model : "unknown",
 				cur_dt_entry->platform_id, cur_dt_entry->variant_id, cur_dt_entry->soc_rev);
@@ -259,8 +265,8 @@ static int dev_tree_compatible(void *dtb, void *real_dtb, uint32_t dtb_size,
 					board_soc_version());
 			}
 
-			plat_prop += DT_ENTRY_V1_SIZE;
-			len_plat_id -= DT_ENTRY_V1_SIZE;
+			plat_prop += min_plat_id_len;
+			len_plat_id -= min_plat_id_len;
 		}
 		free(cur_dt_entry);
 

--- a/platform/msm_shared/include/dev_tree.h
+++ b/platform/msm_shared/include/dev_tree.h
@@ -58,6 +58,7 @@
 #define PLAT_ID_SIZE            0x8
 #define BOARD_ID_SIZE           0x8
 #define PMIC_ID_SIZE           0x8
+#define DT_ENTRY_LGE8974_SIZE   16
 
 
 struct dt_entry_v2


### PR DESCRIPTION
A possible solution to [pmaports#1227
](https://gitlab.com/postmarketOS/pmaports/-/issues/1227)
![hh](https://user-images.githubusercontent.com/86928419/132450714-ecabfdef-0811-4d2e-beaa-d97db61d72ef.png)
pmOS and TWRP are able to boot on ``androidboot.hardware.ddr=elpida`` devices with this dts. But not on ``androidboot.hardware.ddr=hynix`` devices.

Closes #96 