### PR TITLE
Cherry-pick « Add "fastboot oem pstore" command » by Junak

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -791,7 +791,7 @@ unsigned char* generate_mac_address()
 
 	return mac;
 }
-
+extern void lk2nd_clear_pstore();
 typedef void entry_func_ptr(unsigned, unsigned, unsigned*);
 void boot_linux(void *kernel, unsigned *tags,
 		const char *cmdline, unsigned machtype,
@@ -810,6 +810,8 @@ void boot_linux(void *kernel, unsigned *tags,
 	ramdisk = PA(ramdisk);
 
 	final_cmdline = update_cmdline((const char*)cmdline);
+
+	lk2nd_clear_pstore();
 
 #if DEVICE_TREE
 	dprintf(INFO, "Updating device tree: start\n");

--- a/app/aboot/fastboot-lk2nd.c
+++ b/app/aboot/fastboot-lk2nd.c
@@ -8,6 +8,11 @@ static void cmd_oem_dtb(const char *arg, void *data, unsigned sz)
 	fastboot_stage(lk2nd_dev.fdt, fdt_totalsize(lk2nd_dev.fdt));
 }
 
+static void cmd_oem_pstore(const char *arg, void *data, unsigned sz)
+{
+	fastboot_stage(lk2nd_dev.pstore, lk2nd_dev.pstore_size);
+}
+
 static void cmd_oem_cmdline(const char *arg, void *data, unsigned sz)
 {
 	fastboot_stage(lk2nd_dev.cmdline, strlen(lk2nd_dev.cmdline));
@@ -31,6 +36,9 @@ static void cmd_oem_smb1360_reload(const char *arg, void *data, unsigned sz)
 void fastboot_lk2nd_register_commands(void) {
 	if (lk2nd_dev.fdt)
 		fastboot_register("oem dtb", cmd_oem_dtb);
+
+	if (lk2nd_dev.pstore)
+		fastboot_register("oem pstore", cmd_oem_pstore);
 
 	if (lk2nd_dev.cmdline)
 		fastboot_register("oem cmdline", cmd_oem_cmdline);

--- a/include/lk2nd.h
+++ b/include/lk2nd.h
@@ -40,6 +40,9 @@ struct lk2nd_device {
 	const char *carrier;
 	const char *radio;
 
+	void *pstore;
+	unsigned int pstore_size;
+
 	const char *battery;
 	const struct smb1360 *smb1360;
 	const struct smb1360_battery *smb1360_battery;

--- a/lk2nd/lk2nd-device.c
+++ b/lk2nd/lk2nd-device.c
@@ -282,7 +282,7 @@ void lk2nd_pstore_map(uint32_t phys, uint32_t size)
 	lk2nd_dev.pstore = (void *) phys;
 	lk2nd_dev.pstore_size = size;
 
-	for ( ; phys < phys + size; phys += 0x100000 ) {
+	for ( ; phys < ((uint32_t) lk2nd_dev.pstore) + size; phys += 0x100000 ) {
 		arm_mmu_map_section(phys, phys, 0
 					| MMU_MEMORY_TYPE_NORMAL_WRITE_THROUGH
 					| MMU_MEMORY_AP_READ_WRITE


### PR DESCRIPTION
Requires addition in device' dts eg.
lk2nd,pstore = <0x9ff00000 0x00100000>;

Couldn't check it really works yet, so it's a draft for now...