### PR TITLE
dts: huawei-kiwi: add modem to config

### DIFF
--- a/dts/msm8916/msm8939-huawei-kiwi.dts
+++ b/dts/msm8916/msm8939-huawei-kiwi.dts
@@ -17,5 +17,6 @@
 	model = "Huawei Honor 5X";
 	compatible = "huawei,kiwi", "qcom,msm8939", "lk2nd,device";
 
+	// fix modem not connecting to cellular network
 	huawei,modem_id = <0xFFB40105 0x0>;
 };

--- a/dts/msm8916/msm8939-huawei-kiwi.dts
+++ b/dts/msm8916/msm8939-huawei-kiwi.dts
@@ -16,4 +16,6 @@
 
 	model = "Huawei Honor 5X";
 	compatible = "huawei,kiwi", "qcom,msm8939", "lk2nd,device";
+
+	huawei,modem_id = <0xFFB40105 0x0>;
 };


### PR DESCRIPTION
This fixes #75 like @Newbytee suggested in https://github.com/msm8916-mainline/lk2nd/issues/75#issuecomment-920028380.

I don't know how this works but it resolves the issue where the device didn't connect to mobile network after booting :upside_down_face: :tada: 