### PR TITLE
dts: Fix broken lk2nd-msm8974-appended.dtb.img

### DIFF
--- a/dts/msm8974/msm8974-lge-d855.dts
+++ b/dts/msm8974/msm8974-lge-d855.dts
@@ -9,11 +9,13 @@
 	// This is used by the bootloader to find the correct DTB
 	qcom,msm-id = <194 118 0x10001>;
 
-	model = "LG G3 (D855)";
-	compatible = "lge,d855", "qcom,msm8974", "lk2nd,device";
-	lk2nd,match-cmdline = "*LG-D855*";
+    d855 {
+		model = "LG G3 (D855)";
+		compatible = "lge,d855", "qcom,msm8974", "lk2nd,device";
+		lk2nd,match-cmdline = "*LG-D855*";
 
-	lk2nd,keys =
-		<KEY_VOLUMEUP   PM_GPIO(2) PM_GPIO_PULL_UP_1_5>,
-		<KEY_VOLUMEDOWN PM_GPIO(3) PM_GPIO_PULL_UP_1_5>;
+		lk2nd,keys =
+			<KEY_VOLUMEUP   PM_GPIO(2) PM_GPIO_PULL_UP_1_5>,
+			<KEY_VOLUMEDOWN PM_GPIO(3) PM_GPIO_PULL_UP_1_5>;
+    };
 };


### PR DESCRIPTION
``lk2nd-appended-dtb.img`` doesn't boot with ``msm8974-lge-d855.dtb`` enabled.
``fastboot boot lk2nd-appended-dtb.img`` gets stuck and it crashes after ``fastboot flash boot lk2nd-appended-dtb.img`` and booting from hammerhead.
``compatible = "lge,d855", "qcom,msm8974", "lk2nd,device";`` is known to be what breaks ``lk2nd-msm8974-appended-dtb.img``.
So I tried to make this file in a common format.