### PR TITLE
dts: Add Samsung Galaxy E7 (SM-E7000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU, SM-A500YZ, SM-A500H
 - Samsung Galaxy Core Max - SM-G5108Q (quirky - see comment in `dts/msm8916/msm8916-samsung-r08.dts`)
 - Samsung Galaxy Core Prime LTE - SM-G360F
+- Samsung Galaxy E7 - SM-E7000
 - Samsung Galaxy Grand Prime - SM-G530W
 - Samsung Galaxy J3 (2016) - SM-J3109
 - Samsung Galaxy J3 Pro - SM-J3110, SM-J3119

--- a/dts/msm8916/msm8916-samsung-r06.dts
+++ b/dts/msm8916/msm8916-samsung-r06.dts
@@ -9,6 +9,12 @@
 	qcom,msm-id = <206 0>;
 	qcom,board-id = <0xCE08FF01 6>;
 
+	e7000 {
+		model = "Samsung Galaxy E7 (SM-E7000)";
+		compatible = "samsung,e7000", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "E7000*";
+	};
+
 	gt58ltebmc {
 		model = "Samsung Galaxy Tab A 8.0 (CAN)";
 		compatible = "samsung,gt58ltebmc", "qcom,msm8916", "lk2nd,device";


### PR DESCRIPTION
![e7000_lk2nd img](https://user-images.githubusercontent.com/86928419/134422952-8d319593-366b-4f4d-9276-c86053a400ef.png)
[e7000_lk2nd.img.dts.txt](https://github.com/msm8916-mainline/lk2nd/files/7213854/e7000_lk2nd.img.dts.txt)
[e7000_lk2nd.img.txt](https://github.com/msm8916-mainline/lk2nd/files/7213855/e7000_lk2nd.img.txt)

- [x] Downstream boots
- [ ] TWRP for this model is not available