### PR TITLE
msm8226: rename vendor of apq8026-lge-lenok

### DIFF
--- a/dts/msm8226/apq8026-lg-lenok.dts
+++ b/dts/msm8226/apq8026-lg-lenok.dts
@@ -6,7 +6,7 @@
 
 / {
 	// This is used by the bootloader to find the correct DTB
-	compatible = "lge,lenok", "qcom,apq8026", "lk2nd,device";
+	compatible = "lg,lenok", "qcom,apq8026", "lk2nd,device";
 	qcom,msm-id = <199 0x20000>;
 	qcom,board-id = <132 0x0a>;
 

--- a/dts/msm8226/rules.mk
+++ b/dts/msm8226/rules.mk
@@ -1,4 +1,4 @@
 LOCAL_DIR := $(GET_LOCAL_DIR)
 
 DTBS += \
-	$(LOCAL_DIR)/apq8026-lge-lenok.dtb
+	$(LOCAL_DIR)/apq8026-lg-lenok.dtb


### PR DESCRIPTION
Rename lge to lg as requested by Linux maintainers.