### PR TITLE
Detect size_t in a way that is compatible with musl-libc

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -37,9 +37,6 @@ typedef unsigned short u_short;
 typedef unsigned int u_int;
 typedef unsigned long u_long;
 
-#ifndef _SIZE_T_DEFINED_
-typedef unsigned long size_t;
-#endif
 typedef long          ssize_t;
 typedef long long     off_t;
 


### PR DESCRIPTION
There is a build error when compiling lk2nd in Alpine Linux environment:

```
 In file included from include/platform/debug.h:26,
                  from include/debug.h:31,
                  from target/msm8916/init.c:29:
 include/sys/types.h:41:23: error: conflicting types for 'size_t'
    41 | typedef unsigned long size_t;
       |                       ^~~~~~
 In file included from /usr/include/stddef.h:17,
                  from include/sys/types.h:27,
                  from include/platform/debug.h:26,
                  from include/debug.h:31,
                  from target/msm8916/init.c:29:
 /usr/include/bits/alltypes.h:43:24: note: previous declaration of 'size_t' was here
    43 | typedef unsigned _Addr size_t;
       |
```

This is related to musl-libc specific type sizes for 32-bit architectures.

Good thing is that we don't need to redefine size_t at all. We can use
musl-specific define: `__DEFINED_size_t` to detect that `size_t` is
already defined.

Proof (use pmbootstrap):
```sh
$ pmbootstrap -y zap
$ pmbootstrap build_init -b armv7
$ pmbootstrap chroot -b armv7 -- grep -C 5 size_t /usr/include/bits/alltypes.h
```
```c
...
#if defined(__NEED_size_t) && !defined(__DEFINED_size_t)
typedef unsigned _Addr size_t;
#define __DEFINED_size_t
#endif
...
```