### PR TITLE
aboot: fastboot-extra: Add "fastboot oem dump-rpm-data-ram"

### DIFF
--- a/app/aboot/fastboot-extra.c
+++ b/app/aboot/fastboot-extra.c
@@ -251,6 +251,28 @@ static void cmd_oem_dump_saw2(const char *arg, void *data, unsigned sz)
 }
 #endif
 
+#ifdef RPM_DATA_RAM
+static void cmd_oem_dump_rpm_data_ram(const char *arg, void *data, unsigned sz)
+{
+	char response[MAX_RSP_SIZE];
+
+	snprintf(response, sizeof(response), "rpm-rail-stats offset: %#x",
+		 readl(RPM_DATA_RAM + 0x0c));
+	fastboot_info(response);
+	snprintf(response, sizeof(response), "rpm-sleep-stats offset: %#x",
+		 readl(RPM_DATA_RAM + 0x14));
+	fastboot_info(response);
+	snprintf(response, sizeof(response), "rpm-log offset: %#x",
+		 readl(RPM_DATA_RAM + 0x18));
+	fastboot_info(response);
+	snprintf(response, sizeof(response), "rpm free heap space: %d bytes",
+		 readl(RPM_DATA_RAM + 0x1c));
+	fastboot_info(response);
+
+	fastboot_okay("");
+}
+#endif
+
 void fastboot_extra_register_commands(void) {
 	fastboot_register("oem dump", cmd_oem_dump_partition);
 
@@ -268,8 +290,10 @@ void fastboot_extra_register_commands(void) {
 #ifdef BOOT_ROM_BASE
 	fastboot_register("oem dump-boot-rom", cmd_oem_dump_boot_rom);
 #endif
-
 #ifdef APCS_BANKED_SAW2_BASE
 	fastboot_register("oem dump-saw2", cmd_oem_dump_saw2);
+#endif
+#ifdef RPM_DATA_RAM
+	fastboot_register("oem dump-rpm-data-ram", cmd_oem_dump_rpm_data_ram);
 #endif
 }

--- a/platform/msm8916/include/platform/iomap.h
+++ b/platform/msm8916/include/platform/iomap.h
@@ -283,4 +283,6 @@
 
 #define BOOT_ROM_BASE               0x00100000
 #define BOOT_ROM_END                0x00124000  /* Crashes when reading more */
+
+#define RPM_DATA_RAM                0x00290000
 #endif


### PR DESCRIPTION
Dump the offsets to cool data in the RPM data RAM that are used by
the rpm-(sleep)-stats driver that was proposed for mainline Linux.
This allows seeing which MSM8916 devices have the proper offsets
declared there vs having to use an hardcoded address in the device
tree. Looks like newer firmware versions have the offset.

Also see: https://lore.kernel.org/linux-arm-msm/YWaC43o8ZR6zrthh@gerhold.net/