### PR TITLE
dts: Add Samsung Galaxy J3 2016 (SM-J320YZ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Samsung Galaxy Core Prime LTE - SM-G360F
 - Samsung Galaxy E7 - SM-E7000
 - Samsung Galaxy Grand Prime - SM-G530W
-- Samsung Galaxy J3 (2016) - SM-J3109
+- Samsung Galaxy J3 (2016) - SM-J3109, SM-J320YZ
 - Samsung Galaxy J3 Pro - SM-J3110, SM-J3119
 - Samsung Galaxy J5 (2015) - SM-J5008, SM-J500F, SM-J500FN, SM-J500H
 - Samsung Galaxy J5 (2016) - SM-J5108, SM-J510F, SM-J510FN

--- a/dts/msm8916/msm8916-samsung-r01.dts
+++ b/dts/msm8916/msm8916-samsung-r01.dts
@@ -34,6 +34,16 @@
 		lk2nd,match-bootloader = "A500FU*";
 	};
 
+	j3lte-zt {
+		model = "Samsung Galaxy J3 2016 (SM-J320YZ)";
+		compatible = "samsung,j3lte-zt", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J320YZ*";
+		samsung,muic-reset {
+			i2c-gpio-pins = <0 1>;
+			i2c-address = <0x25>;
+		};
+	};
+
 	j5lte-chn {
 		model = "Samsung Galaxy J5 2015 (SM-J5008)";
 		compatible = "samsung,j5lte-chn", "qcom,msm8916", "lk2nd,device";


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/86928419/137810900-43e54cac-a34b-4aff-98b9-032df4452970.png)

[lk_log.txt](https://github.com/msm8916-mainline/lk2nd/files/7368632/lk_log.txt)

* Mainline boots
* Stock Android doesn't boot
* Panel crashes in TWRP. However it's still accessible via `adb`


