### PR TITLE
makefile: Drop -fno-builtin

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -5,6 +5,7 @@
 #include <printf.h>
 
 void putc(char c);
+int putchar(int c);
 int puts(const char *str);
 int getc(char *c); // XXX not really getc
 

--- a/lib/libc/printf.c
+++ b/lib/libc/printf.c
@@ -32,6 +32,12 @@ void putc(char c)
 	return _dputc(c);
 }
 
+int putchar(int c)
+{
+	_dputc(c);
+	return c;
+}
+
 int puts(const char *str)
 {
 	return _dputs(str);

--- a/makefile
+++ b/makefile
@@ -71,7 +71,7 @@ ifeq ($(ENABLE_TRUSTZONE),1)
 endif
 
 INCLUDES := -I$(BUILDDIR) -Iinclude
-CFLAGS := -O2 -g -fno-builtin -finline -Wno-multichar -Wno-unused-parameter -Wno-unused-function -include $(CONFIGHEADER)
+CFLAGS := -O2 -g -finline -Wno-multichar -Wno-unused-parameter -Wno-unused-function -include $(CONFIGHEADER)
 # -fcommon is needed to build this using GCC 10
 CFLAGS += -fcommon
 #CFLAGS += -Werror


### PR DESCRIPTION
This allows gcc to inline standard calls like strlen("constant string").

https://github.com/msm8916-mainline/lk2nd/pull/111#discussion_r738467131

Before:
![image](https://user-images.githubusercontent.com/3035868/139286875-4b1ace65-49f5-422f-a765-4c9c0a3fb0d9.png)

After:
![image](https://user-images.githubusercontent.com/3035868/139286982-8998f852-7ff5-46ff-9d86-4f92dbdc9c04.png)


Cc: @minlexx 
