### PR TITLE
Introduce Multi-DTB container support

### DIFF
--- a/dts/msm8916/apq8016-samsung-r07.dts
+++ b/dts/msm8916/apq8016-samsung-r07.dts
@@ -14,7 +14,7 @@
 	// tree and we need to do more manual work to differentiate the devices.
 	gt510wifi {
 		model = "Samsung Galaxy Tab A 9.7 WiFi (2015) (SM-T550)";
-		compatible = "samsung,gt510wifi", "qcom,apq8016", "lk2nd,device";
+		compatible = "samsung,gt510", "qcom,apq8016", "lk2nd,device";
 		lk2nd,match-bootloader = "T550*";
 	};
 };

--- a/dts/msm8916/msm8216-samsung-r05.dts
+++ b/dts/msm8916/msm8216-samsung-r05.dts
@@ -11,7 +11,7 @@
 
 	j53g-eur {
 		model = "Samsung Galaxy J5 2015 (SM-J500H)";
-		compatible = "samsung,j53g-eur", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,j5", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "J500H*";
 
 		samsung,muic-reset {

--- a/dts/msm8916/msm8216-samsung-r08.dts
+++ b/dts/msm8916/msm8216-samsung-r08.dts
@@ -11,7 +11,7 @@
 
 	a53g {
 		model = "Samsung Galaxy A5 (SM-A500H)";
-		compatible = "samsung,a53g", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,a5u-eur", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "A500H*";
 		lk2nd,smd-rpm-hack-opening;
 	};

--- a/dts/msm8916/msm8916-huawei-g7-l01.dts
+++ b/dts/msm8916/msm8916-huawei-g7-l01.dts
@@ -9,5 +9,5 @@
 	qcom,board-id = <8039 4>;
 
 	model = "Huawei Ascend G7-L01";
-	compatible = "huawei,g7-l01", "qcom,msm8916", "lk2nd,device";
+	compatible = "huawei,g7", "qcom,msm8916", "lk2nd,device";
 };

--- a/dts/msm8916/msm8916-samsung-r00.dts
+++ b/dts/msm8916/msm8916-samsung-r00.dts
@@ -12,7 +12,7 @@
 
 	gt58lte-aus {
 		model = "Samsung Galaxy Tab A 8.0 2015 (SM-T355Y)";
-		compatible = "samsung,gt58lte-aus", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,gt58", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "T355Y*";
 	};
 

--- a/dts/msm8916/msm8916-samsung-r01.dts
+++ b/dts/msm8916/msm8916-samsung-r01.dts
@@ -46,7 +46,7 @@
 
 	j5lte-chn {
 		model = "Samsung Galaxy J5 2015 (SM-J5008)";
-		compatible = "samsung,j5lte-chn", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,j5", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "J5008*";
 		samsung,muic-reset {
 			i2c-gpio-pins = <105 106>;

--- a/dts/msm8916/msm8916-samsung-r01.dts
+++ b/dts/msm8916/msm8916-samsung-r01.dts
@@ -34,6 +34,12 @@
 		lk2nd,match-bootloader = "A500FU*";
 	};
 
+	gt58lte {
+		model = "Samsung Galaxy Tab A 8.0 2015 (SM-T355)";
+		compatible = "samsung,gt58", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "T355X*";
+	};
+
 	j3lte-zt {
 		model = "Samsung Galaxy J3 2016 (SM-J320YZ)";
 		compatible = "samsung,j3lte-zt", "qcom,msm8916", "lk2nd,device";

--- a/dts/msm8916/msm8916-samsung-r02.dts
+++ b/dts/msm8916/msm8916-samsung-r02.dts
@@ -24,7 +24,7 @@
 
 	gprimeltecan {
 		model = "Samsung Galaxy Grand Prime (CAN)";
-		compatible = "samsung,gprimeltecan", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,gprime", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "G530W*";
 
 		samsung,muic-reset {

--- a/dts/msm8916/msm8916-samsung-r03.dts
+++ b/dts/msm8916/msm8916-samsung-r03.dts
@@ -11,7 +11,7 @@
 
 	serranovelte {
 		model = "Samsung Galaxy S4 Mini Value Edition";
-		compatible = "samsung,serranovelte", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,serranove", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "I9195I*";
 
 		samsung,muic-reset {
@@ -43,7 +43,7 @@
 
 	j5xlte-chn {
 		model = "Samsung Galaxy J5 2016 (SM-J5108)";
-		compatible = "samsung,j5xlte-chn", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,j5x", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "J5108*";
 		samsung,muic-reset {
 			i2c-gpio-pins = <105 106>;

--- a/dts/msm8916/msm8916-samsung-r04.dts
+++ b/dts/msm8916/msm8916-samsung-r04.dts
@@ -28,4 +28,13 @@
 		qcom,msm-id = <206 0>;
 		qcom,board-id = <0xCE08FF01 0>;
 	};
+
+	gt58lte {
+		model = "Samsung Galaxy Tab A 8.0 2015 (SM-T355)";
+		compatible = "samsung,gt58", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "T355X*";
+
+		qcom,msm-id = <206 0>;
+		qcom,board-id = <0xCE08FF01 1>;
+	};
 };

--- a/dts/msm8916/msm8916-samsung-r04.dts
+++ b/dts/msm8916/msm8916-samsung-r04.dts
@@ -11,7 +11,7 @@
 
 	j5xlte-eur {
 		model = "Samsung Galaxy J5 2016 LTE (EUR)";
-		compatible = "samsung,j5xlte-eur", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,j5x", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "J510F*";
 
 		samsung,muic-reset {
@@ -22,7 +22,7 @@
 
 	gt58lte-aus {
 		model = "Samsung Galaxy Tab A 8.0 2015 (SM-T355Y)";
-		compatible = "samsung,gt58lte-aus", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,gt58", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "T355Y*";
 
 		qcom,msm-id = <206 0>;

--- a/dts/msm8916/msm8916-samsung-r05.dts
+++ b/dts/msm8916/msm8916-samsung-r05.dts
@@ -11,7 +11,7 @@
 
 	j5nlte-eur {
 		model = "Samsung Galaxy J5 2015 (SM-J500FN)";
-		compatible = "samsung,j5nlte-eur", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,j5", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "J500FN*";
 		
 		samsung,muic-reset {
@@ -32,7 +32,7 @@
 
 	j5lte-eur {
 		model = "Samsung Galaxy J5 2015 (SM-J500F)";
-		compatible = "samsung,j5lte-eur", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,j5", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "J500F*";
 		samsung,muic-reset {
 			i2c-gpio-pins = <105 106>;

--- a/dts/msm8916/msm8916-samsung-r06.dts
+++ b/dts/msm8916/msm8916-samsung-r06.dts
@@ -17,7 +17,7 @@
 
 	gt58ltebmc {
 		model = "Samsung Galaxy Tab A 8.0 (CAN)";
-		compatible = "samsung,gt58ltebmc", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,gt58", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "T357W*";
 	};
 };

--- a/dts/msm8916/msm8916-samsung-r08.dts
+++ b/dts/msm8916/msm8916-samsung-r08.dts
@@ -12,7 +12,7 @@
 
 	a5lte {
 		model = "Samsung Galaxy A5 (SM-A500F)";
-		compatible = "samsung,a5lte", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,a5u-eur", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "A500F*";
 	};
 
@@ -26,7 +26,7 @@
 
 	gt510lte {
 		model = "Samsung Galaxy Tab A 9.7 LTE (2015) (SM-T555)";
-		compatible = "samsung,gt510lte", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,gt510", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "T555*";
 
 		lk2nd,keys = <KEY_HOME 109 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;

--- a/include/lk2nd.h
+++ b/include/lk2nd.h
@@ -33,6 +33,7 @@ struct lk2nd_device {
 
 	const char *model;
 	const char *cmdline;
+	const char *compatible;
 
 	const char *device;
 	const char *bootloader;

--- a/lib/grove/grove.c
+++ b/lib/grove/grove.c
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "grove.h"
+
+#include <libfdt.h>
+#include <decompress.h>
+
+/*
+ * grove is a multi-dtb container that uses fdt format to incapsulate the blobs.
+ * It's loosely inspired by u-boot FIT uImage but only targets the Device-Tree
+ * selection.
+ *
+ * It's assumed that the bootloader has libfdt available and also already
+ * knows the compatible string of the device.
+ *
+ * gzip implementation is required to support compressed dtb blobs.
+ */
+
+/**
+ * grove_check() - Check if the given fdt is compatible.
+ * @grove: pointer to the multi-dtb container
+ *
+ * Return: 1 if compatible, 0 or negative errno otherwise.
+ */
+int grove_check(const void *grove)
+{
+	int ret;
+	const uint32_t *val;
+
+	// Sanity check the container.
+	ret = fdt_check_header(grove);
+	if (ret)
+		return ret;
+
+	// Check if the given FDT is actually the container
+	// and it's version is compatible.
+	val = fdt_getprop(grove, 0, "grove,version", &ret);
+	if (!val && ret == -FDT_ERR_NOTFOUND)
+		return 0;
+	else if (!val)
+		return ret;
+	else if (fdt32_to_cpu(*val) != GROVE_VERSION)
+		return -GROVE_EBADVER;
+
+	return 1;
+}
+
+/**
+ * grove_extract() - Copy a compatible device-tree blob from the container
+ * @grove: pointer to the multi-dtb container
+ * @buf: pointer to memory where the selected device is to be moved
+ * @bufsize: size of the memory space at buf
+ * @compatible: compatible string to match the device tree in the contaienr
+ *
+ * This method finds the dtb that is compatible with the device and copies it
+ * into given buffer, possibly unpacking it.
+ *
+ * Return: Extracted size on success, negative errno or zero if fdt is not a
+ * compatible container.
+ */
+int grove_extract(const void *grove,
+		  void *buf,
+		  int bufsize,
+		  const char *compatible)
+{
+	int ret, len, chosen_node;
+	const void *dtb;
+	const char *compression;
+
+	ret = grove_check(grove);
+	if (ret != 1)
+		return ret;
+
+	// 0 offset so we don't match the root node.
+	chosen_node = fdt_node_offset_by_compatible(grove, 0, compatible);
+	if (ret < 0)
+		return ret;
+
+	dtb = fdt_getprop(grove, chosen_node, "dtb", &ret);
+	if (ret < 0)
+		return ret;
+
+	if (fdt_check_header(dtb) == 0) {
+		if (ret > bufsize)
+			return -GROVE_ENOSIZE;
+
+		memcpy(buf, dtb, ret);
+		return ret;
+	}
+	else if (is_gzip_package(dtb, ret)) {
+		ret = decompress(dtb, ret, buf, bufsize, NULL, &len);
+		if (ret)
+			return -GROVE_ECOMPFAIL;
+		return len;
+	}
+
+	return -GROVE_EBADCOMP;
+}
+
+/**
+ * grove_get_label() - Get a label string from the container
+ * @grove: pointer to the multi-dtb container
+ *
+ * Return: Pointer to the label in the container or NULL.
+ */
+char * grove_get_label(const void *grove)
+{
+	int ret;
+
+	ret = grove_check(grove);
+	if (ret != 1)
+		return NULL;
+
+	return (char *)fdt_getprop(grove, 0, "grove,label", NULL);
+}

--- a/lib/grove/grove.h
+++ b/lib/grove/grove.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef GROVE_H
+#define GROVE_H
+
+#define GROVE_VERSION 1
+
+/* Methods can pass libfdt error codes, grove-specific errors start at 1000 */
+#define GROVE_EBADVER	1001
+	/* GROVE_EBADVER: The container version is incompatible. */
+#define GROVE_ENOSIZE	1002
+	/* GROVE_ENOSIZE: Target has not enough size for the dtb. */
+#define GROVE_EBADCOMP	1003
+	/* GROVE_EBADCOMP: Compression method is incompatible. */
+#define GROVE_ECOMPFAIL	1004
+	/* GROVE_ECOMPFAIL: Decompression failed. */
+
+int grove_check(const void *grove);
+
+int grove_extract(const void *grove,
+		  void *buf,
+		  int bufsize,
+		  const char *compatible);
+
+char * grove_get_label(const void *grove);
+
+#endif /* GROVE_H */

--- a/lib/grove/rules.mk
+++ b/lib/grove/rules.mk
@@ -1,0 +1,9 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+MODULES += lib/libfdt
+
+INCLUDES += -I$(LOCAL_DIR)
+
+OBJS += \
+	$(LOCAL_DIR)/grove.o
+

--- a/lk2nd/lk2nd-device.c
+++ b/lk2nd/lk2nd-device.c
@@ -298,6 +298,8 @@ static void lk2nd_parse_device_node(const void *fdt)
 	else
 		dprintf(CRITICAL, "Device node is missing 'model' property\n");
 
+	lk2nd_dev.compatible = fdt_copyprop_str(fdt, offset, "compatible");
+
 	/* Check if the bootloader selected a weird DTB and we need to override */
 	if (!dev_tree_get_dt_entry(fdt, offset, &lk2nd_dev.dt_entry) && offset)
 		/* Try again on root node */

--- a/project/lk2nd-common.mk
+++ b/project/lk2nd-common.mk
@@ -1,5 +1,5 @@
 # FIXME: Move to lk2nd-1st-common.mk
-MODULES += lk2nd
+MODULES += lk2nd lib/grove
 
 # Reserve 512 KiB in boot partition for lk2nd (should be plenty)
 DEFINES += LK2ND_SIZE=512*1024

--- a/scripts/forester.py
+++ b/scripts/forester.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-only
+"""
+This script packages multiple fdt blobs into a container for multi-dtb images.
+
+The same FDT is used for the container storage as it's assumed that the
+bootloader implementation already has libfdt available. The format is loosly
+inspired by u-boot FIT uImage format but it's only intended for DTB packaging.
+The example of the generated format is as follows:
+
+/dts-v1/;
+
+/ {
+    grove,version = 1;
+    grove,label = "Multi-DTB container";
+
+    apq8016-sbc {
+        compatible = "qcom,apq8016-sbc", "qcom,apq8016";
+        compression = "none";
+        dtb = /incbin/("arch/arm64/dts/qcom/apq8016-sbc.dtb");
+    };
+
+    msm8916-samsung-gt58 {
+        compatible = "samsung,gt58", "qcom,msm8916";
+        compression = "gzip";
+        dtb = /incbin/("arch/arm64/dts/qcom/msm8916-samsung-gt58.dtb.gz");
+    };
+};
+
+"""
+import argparse
+import pathlib
+import gzip
+
+import libfdt
+
+class FdtBlob(libfdt.FdtRo):
+
+    """Class for a device-tree for inclusion to the container."""
+
+    def __init__(self, data, name=None):
+        libfdt.FdtRo.__init__(self, data)
+
+        if name is None:
+            name = self.get_compatible_list()[0].replace(",", "-")
+        self.name = name
+
+    def get_compatible(self):
+        """Get top level compatible for the device-tree.
+        :returns: compatible: property
+
+        """
+        root = self.path_offset('/')
+        return self.getprop(root, "compatible")
+
+    def get_compatible_list(self):
+        """Get a list of values in a top level compatible.
+        :returns: compatibles, list
+
+        """
+        ret = []
+        for val in self.get_compatible()[:-1].split(b"\0"):
+            ret.append(val.decode('utf-8'))
+
+        return ret
+
+    def is_compatible_with(self, compats):
+        """Check if top-level compatible contains a value from the list.
+        Returns True if the list is None or empty.
+
+        :compats: compatible, list
+        :returns: bool
+
+        """
+        if compats is None or len(compats) == 0:
+            return True
+
+        # Do the lists overlap?
+        return not set(compats).isdisjoint(self.get_compatible_list())
+
+    def get_model(self):
+        """Get model property from the top level node.
+        :returns: Model, string
+
+        """
+        root = self.path_offset('/')
+        return self.getprop(root, "model").as_str()
+
+
+class FdtGrove(libfdt.FdtSw):
+
+    """Class for a generated multi-dtb container"""
+
+    def __init__(self, dtbs, label=None, compress=True):
+        """Create and fill the container.
+        :dtbs: list of tuples (name, blob)
+        :label: A label to add to the container
+        """
+        # About 45K ~ 55K for a normal msm8916 dtb
+        libfdt.FdtSw.__init__(self, size_hint=len(dtbs) * 64 * 1024)
+        if label is None:
+            label = "Multi-DTB container"
+        self.label = label
+
+        self.finish_reservemap()
+        with self.add_node(""):
+            self.property_u32("grove,version", 1)
+            self.property_string("grove,label", self.label)
+
+            for blob_tuple in dtbs:
+                name, blob = blob_tuple
+                with self.add_node(name):
+                    compat = blob.get_compatible()
+                    self.property("compatible", bytes(compat))
+                    dtb_data = bytes(blob.as_bytearray())
+                    if compress:
+                        self.property_string("compression", "gzip")
+                        dtb_data = gzip.compress(dtb_data, mtime=0)
+                    else:
+                        self.property_string("compression", "none")
+                    self.property("dtb", dtb_data)
+
+
+def parse_args():
+    """Create ArgumentParser object for the programm and parse the arguments.
+    :returns: args
+
+    """
+    parser = argparse.ArgumentParser(description="Generate the multi-dtb container.")
+    parser.add_argument("dtb", nargs="+", type=argparse.FileType("br"),
+                        help="Device-Tree blobs to add to the container")
+    parser.add_argument("-o", "--output", type=str,
+                        required=True, help="Output file to store the container")
+    parser.add_argument("-l", "--label", type=str,
+                        help="specify the container label")
+    parser.add_argument("-c", "--compatible", action="append", type=str,
+                        help="Only append device-trees compatible with this value")
+    parser.add_argument("-C", "--compress", action="store_true",
+                        help="Compress the DTBs in the container")
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="increase output verbosity")
+    return parser.parse_args()
+
+def debug_print(args, text, verbosity=1):
+    """Print the message if verbosity exceeds the given level
+
+    :args: args namesace from argparse
+    :text: message
+    :verbosity: level of verbosity required
+
+    """
+    if args.verbose >= verbosity:
+        print(text)
+
+def main():
+    """Use application arguments to generate the container."""
+    args = parse_args()
+    dtbs = []
+    for dtb in args.dtb:
+        blob = FdtBlob(dtb.read())
+        if not blob.is_compatible_with(args.compatible):
+            debug_print(args, f"Ignoring: {blob.get_model()}", 2)
+            continue
+        debug_print(args, f"Appending: {blob.get_model()}")
+        dtbs.append((pathlib.Path(dtb.name).stem, blob))
+
+    grove = FdtGrove(dtbs, args.label, args.compress).as_fdt()
+    grove.pack()
+
+    with open(args.output, "wb") as ofile:
+        ofile.write(grove.as_bytearray())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
lk2nd already implements a lot of checks to definitively detect which specific device model it runs on.
This means that lk2nd could also use those checks to choose the DTB from a container instead of loading the single appended one. Implementing this would allow us to make more generic system images that could boot on all devices within a supported platform (platforms?).

The proposed approach is to use FDT based container for DTB images: This allows re-using libfdt to just select a node within the container by it's `compatible`. Then install this container as appended-dtb to re-use most of the boot path and just insert a check for unpacking the container.