### PR TITLE
Display Motorola radio/carrier on display menu

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -2126,6 +2126,9 @@ void read_device_info(device_info *dev)
 	if (lk2nd_dev.bootloader)
 		strlcpy(dev->bootloader_version, lk2nd_dev.bootloader,
 			sizeof(dev->bootloader_version));
+	if (lk2nd_dev.radio)
+		strlcpy(dev->radio_version, lk2nd_dev.radio,
+			sizeof(dev->radio_version));
 #endif
 }
 

--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -2124,7 +2124,8 @@ void read_device_info(device_info *dev)
 
 #if WITH_LK2ND
 	if (lk2nd_dev.bootloader)
-		strcpy(dev->bootloader_version, lk2nd_dev.bootloader);
+		strlcpy(dev->bootloader_version, lk2nd_dev.bootloader,
+			sizeof(dev->bootloader_version));
 #endif
 }
 

--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -477,13 +477,13 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 		msg_buf);
 	display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
 
-#if !WITH_LK2ND
 	memset(msg_buf, 0, sizeof(msg_buf));
 	get_baseband_version((unsigned char *) msg_buf);
 	snprintf(msg, sizeof(msg), "BASEBAND VERSION - %s\n",
 		msg_buf);
 	display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
-#else
+
+#if WITH_LK2ND
 	if (lk2nd_dev.panel.name) {
 		snprintf(msg, sizeof(msg), "PANEL - %s\n", lk2nd_dev.panel.name);
 		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);

--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -488,6 +488,11 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 	}
 
 #if WITH_LK2ND
+	if (lk2nd_dev.carrier) {
+		snprintf(msg, sizeof(msg), "CARRIER - %s\n", lk2nd_dev.carrier);
+		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
+	}
+
 	if (lk2nd_dev.panel.name) {
 		snprintf(msg, sizeof(msg), "PANEL - %s\n", lk2nd_dev.panel.name);
 		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);

--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -474,7 +474,7 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 	memset(msg_buf, 0, sizeof(msg_buf));
 	get_bootloader_version((unsigned char *) msg_buf);
 	if (msg_buf[0]) {
-		snprintf(msg, sizeof(msg), "BOOTLOADER VERSION - %s\n",
+		snprintf(msg, sizeof(msg), "BOOTLOADER - %s\n",
 			msg_buf);
 		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
 	}
@@ -482,7 +482,7 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 	memset(msg_buf, 0, sizeof(msg_buf));
 	get_baseband_version((unsigned char *) msg_buf);
 	if (msg_buf[0]) {
-		snprintf(msg, sizeof(msg), "BASEBAND VERSION - %s\n",
+		snprintf(msg, sizeof(msg), "BASEBAND - %s\n",
 			msg_buf);
 		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
 	}

--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -473,15 +473,19 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 
 	memset(msg_buf, 0, sizeof(msg_buf));
 	get_bootloader_version((unsigned char *) msg_buf);
-	snprintf(msg, sizeof(msg), "BOOTLOADER VERSION - %s\n",
-		msg_buf);
-	display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
+	if (msg_buf[0]) {
+		snprintf(msg, sizeof(msg), "BOOTLOADER VERSION - %s\n",
+			msg_buf);
+		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
+	}
 
 	memset(msg_buf, 0, sizeof(msg_buf));
 	get_baseband_version((unsigned char *) msg_buf);
-	snprintf(msg, sizeof(msg), "BASEBAND VERSION - %s\n",
-		msg_buf);
-	display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
+	if (msg_buf[0]) {
+		snprintf(msg, sizeof(msg), "BASEBAND VERSION - %s\n",
+			msg_buf);
+		display_fbcon_menu_message(msg, FBCON_COMMON_MSG, common_factor);
+	}
 
 #if WITH_LK2ND
 	if (lk2nd_dev.panel.name) {


### PR DESCRIPTION
Motorola has all these weird device configuration values (bootloader version, radio, carrier, ...) that are not too clear sometimes. Display them for debugging on the fastboot screen. Previously only bootloader version was shown.

![harpia-carrier](https://user-images.githubusercontent.com/3035868/140576298-85bead14-c2fc-4e6e-b92e-fb8acf5d76ab.png)
