### PR TITLE
dts: Add Samsung Galaxy A7 2015 (SM-A700YD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Motorola Moto G4 Play - harpia
 - Samsung Galaxy A3 (2015) - SM-A300F, SM-A300FU
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU, SM-A500YZ, SM-A500H
+- Samsung Galaxy A7 (2015) - SM-A700YD
 - Samsung Galaxy Core Max - SM-G5108Q (quirky - see comment in `dts/msm8916/msm8916-samsung-r08.dts`)
 - Samsung Galaxy Core Prime LTE - SM-G360F
 - Samsung Galaxy E7 - SM-E7000

--- a/dts/msm8916/msm8929-samsung-r04.dts
+++ b/dts/msm8916/msm8929-samsung-r04.dts
@@ -57,4 +57,14 @@
 		qcom,board-id = <0xCE08FF01 8>;
 		lk2nd,smd-rpm-hack-opening;
 	};
+
+	a7ltezt {
+		model = "Samsung Galaxy A7 (SM-A700YD)";
+		compatible = "samsung,a7ltezt", "qcom,msm8939", "lk2nd,device";
+		lk2nd,match-bootloader = "A700YD*";
+
+		qcom,msm-id = <239 0>;
+		qcom,board-id = <0xEF08FF1 1>;
+		lk2nd,smd-rpm-hack-opening;
+	};
 };

--- a/dts/msm8916/msm8939-samsung-r01.dts
+++ b/dts/msm8916/msm8939-samsung-r01.dts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <239 0>;
+	qcom,board-id = <0xEF08FF1 1>;
+
+	a7ltezt {
+		model = "Samsung Galaxy A7 (SM-A700YD)";
+		compatible = "samsung,a7ltezt", "qcom,msm8939", "lk2nd,device";
+		lk2nd,match-bootloader = "A700YD*";
+		lk2nd,smd-rpm-hack-opening;
+	};
+};

--- a/dts/msm8916/rules.mk
+++ b/dts/msm8916/rules.mk
@@ -36,4 +36,5 @@ DTBS += \
 	$(LOCAL_DIR)/msm8939-asus-z00t.dtb \
 	$(LOCAL_DIR)/msm8939-huawei-kiwi.dtb \
 	$(LOCAL_DIR)/msm8939-mtp.dtb \
-	$(LOCAL_DIR)/msm8939-qrd-skuk.dtb
+	$(LOCAL_DIR)/msm8939-qrd-skuk.dtb \
+	$(LOCAL_DIR)/msm8939-samsung-r01.dtb


### PR DESCRIPTION
```
~$ fastboot oem dump-smd-rpm
(bootloader) ch4: rpm_requests, cid: 0x4, flags: 0x20f, ref: 1
(bootloader) ch4: tx state: 0, tx fstate: 0, rx state: 4, rx fstate: 1
(bootloader) ch5: rpm_requests, cid: 0x5, flags: 0x210, ref: 1
(bootloader) ch6: rpm_requests, cid: 0x6, flags: 0x212, ref: 1
(bootloader) ch7: rpm_requests, cid: 0x7, flags: 0x213, ref: 1
OKAY [  0.006s]
Finished. Total time: 0.006s 
```

`lk2nd,smd-rpm-hack-opening;` is required to boot mainline. Otherwise the screen goes pitch black and no sign of further booting.