### PR TITLE
lk2nd: smp: spin-table: Add support for ARM32

### DIFF
--- a/include/lk2nd.h
+++ b/include/lk2nd.h
@@ -59,7 +59,7 @@ void lk2nd_smd_rpm_hack_opening(const void *fdt, int offset);
 
 void lk2nd_update_device_tree(void *fdt, const char *cmdline, bool arm64);
 void lk2nd_rproc_update_dev_tree(void *fdt);
-void smp_spin_table_setup(void *fdt);
+void smp_spin_table_setup(void *fdt, bool arm64);
 
 bool fdt_node_is_available(const void *fdt, int node);
 

--- a/include/lk2nd.h
+++ b/include/lk2nd.h
@@ -59,7 +59,9 @@ void lk2nd_smd_rpm_hack_opening(const void *fdt, int offset);
 
 void lk2nd_update_device_tree(void *fdt, const char *cmdline, bool arm64);
 void lk2nd_rproc_update_dev_tree(void *fdt);
-void smp_spin_table_setup(void *fdt, bool arm64);
+
+struct smp_spin_table;
+void smp_spin_table_setup(struct smp_spin_table *table, void *fdt, bool arm64);
 
 bool fdt_node_is_available(const void *fdt, int node);
 

--- a/include/lk2nd.h
+++ b/include/lk2nd.h
@@ -61,4 +61,6 @@ void lk2nd_update_device_tree(void *fdt, const char *cmdline, bool arm64);
 void lk2nd_rproc_update_dev_tree(void *fdt);
 void smp_spin_table_setup(void *fdt);
 
+bool fdt_node_is_available(const void *fdt, int node);
+
 #endif

--- a/lk2nd/lk2nd-device.c
+++ b/lk2nd/lk2nd-device.c
@@ -396,7 +396,6 @@ void lk2nd_update_device_tree(void *fdt, const char *cmdline, bool arm64)
 	lk2nd_rproc_update_dev_tree(fdt);
 
 #ifdef SMP_SPIN_TABLE_BASE
-	if (arm64)
-		smp_spin_table_setup(fdt);
+	smp_spin_table_setup(fdt, arm64);
 #endif
 }

--- a/lk2nd/lk2nd-device.c
+++ b/lk2nd/lk2nd-device.c
@@ -396,6 +396,6 @@ void lk2nd_update_device_tree(void *fdt, const char *cmdline, bool arm64)
 	lk2nd_rproc_update_dev_tree(fdt);
 
 #ifdef SMP_SPIN_TABLE_BASE
-	smp_spin_table_setup(fdt, arm64);
+	smp_spin_table_setup((struct smp_spin_table*)SMP_SPIN_TABLE_BASE, fdt, arm64);
 #endif
 }

--- a/lk2nd/lk2nd-fdt.c
+++ b/lk2nd/lk2nd-fdt.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <lk2nd.h>
+#include <libfdt.h>
+
+bool fdt_node_is_available(const void *fdt, int node)
+{
+	const char *prop;
+	int len;
+
+	prop = fdt_getprop(fdt, node, "status", &len);
+	if (len == -FDT_ERR_NOTFOUND)
+		return true;
+
+	return len == sizeof("okay") && memcmp(prop, "okay", sizeof("okay")) == 0;
+}

--- a/lk2nd/lk2nd-rproc.c
+++ b/lk2nd/lk2nd-rproc.c
@@ -52,18 +52,6 @@ static void lk2nd_disable_rproc(void *fdt, const char *name, int rproc, int rmem
 	lk2nd_delete_rmem(fdt, rmem, fdt_subnode_offset(fdt, rproc, "mba"));
 }
 
-static bool fdt_node_is_available(const void *fdt, int node)
-{
-	const char *prop;
-	int len;
-
-	prop = fdt_getprop(fdt, node, "status", &len);
-	if (len == -FDT_ERR_NOTFOUND)
-		return true;
-
-	return len == sizeof("okay") && memcmp(prop, "okay", sizeof("okay")) == 0;
-}
-
 /* From qcom,q6afe.h */
 #define PRIMARY_MI2S_RX		16
 #define PRIMARY_MI2S_TX		17

--- a/lk2nd/rules.mk
+++ b/lk2nd/rules.mk
@@ -2,6 +2,7 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 
 OBJS += \
 	$(LOCAL_DIR)/lk2nd-device.o \
+	$(LOCAL_DIR)/lk2nd-fdt.o \
 	$(LOCAL_DIR)/lk2nd-motorola.o \
 	$(LOCAL_DIR)/lk2nd-rproc.o \
 	$(LOCAL_DIR)/lk2nd-smd-rpm.o

--- a/lk2nd/smp/cpu-boot.c
+++ b/lk2nd/smp/cpu-boot.c
@@ -35,14 +35,15 @@ static inline uint32_t read_mpidr(void)
 	return res & 0x00ffffff;
 }
 
-int qcom_set_boot_addr(uint32_t addr)
+int qcom_set_boot_addr(uint32_t addr, bool arm64)
 {
+	uint32_t aarch64 = arm64 ? QCOM_SCM_BOOT_MC_FLAG_AARCH64 : 0;
 	scmcall_arg arg = {
 		MAKE_SIP_SCM_CMD(SCM_SVC_BOOT, QCOM_SCM_BOOT_SET_ADDR_MC),
 		MAKE_SCM_ARGS(6),
 		addr,
 		~0UL, ~0UL, ~0UL, ~0UL, /* All CPUs */
-		QCOM_SCM_BOOT_MC_FLAG_AARCH64 | QCOM_SCM_BOOT_MC_FLAG_COLDBOOT,
+		aarch64 | QCOM_SCM_BOOT_MC_FLAG_COLDBOOT,
 	};
 	return scm_call2(&arg, NULL);
 }

--- a/lk2nd/smp/cpu-boot.h
+++ b/lk2nd/smp/cpu-boot.h
@@ -3,7 +3,7 @@
 #ifndef __LK2ND_SMP_CPU_BOOT_H
 #define __LK2ND_SMP_CPU_BOOT_H
 
-int qcom_set_boot_addr(uint32_t addr);
+int qcom_set_boot_addr(uint32_t addr, bool arm64);
 void qcom_power_up_arm_cortex(uint32_t mpidr, uint32_t base);
 
 #endif

--- a/lk2nd/smp/spin-table.c
+++ b/lk2nd/smp/spin-table.c
@@ -137,6 +137,16 @@ void smp_spin_table_setup(void *fdt)
 		return;
 	}
 
+	offset = fdt_path_offset(fdt, "/psci");
+	if (offset < 0) {
+		dprintf(CRITICAL, "Cannot find /psci node: %d\n", offset);
+		return;
+	}
+
+	ret = fdt_setprop_string(fdt, offset, "status", "disabled");
+	if (ret)
+		dprintf(CRITICAL, "Failed to set psci to status = \"disabled\": %d\n", ret);
+
 	offset = fdt_path_offset(fdt, "/cpus");
 	if (offset < 0) {
 		dprintf(CRITICAL, "Cannot find /cpus node: %d\n", offset);
@@ -177,14 +187,4 @@ void smp_spin_table_setup(void *fdt)
 		dprintf(CRITICAL, "Failed to read /cpus subnodes: %d\n", node);
 		return;
 	}
-
-	offset = fdt_path_offset(fdt, "/psci");
-	if (offset < 0) {
-		dprintf(CRITICAL, "Cannot find /psci node: %d\n", offset);
-		return;
-	}
-
-	ret = fdt_setprop_string(fdt, offset, "status", "disabled");
-	if (ret)
-		dprintf(CRITICAL, "Failed to set psci to status = \"disabled\": %d\n", ret);
 }

--- a/lk2nd/smp/spin-table.c
+++ b/lk2nd/smp/spin-table.c
@@ -7,6 +7,11 @@
 
 #include "cpu-boot.h"
 
+struct smp_spin_table {
+	uint8_t code[4096];
+	uint64_t release_addr;
+};
+
 static uint8_t smp_spin_table_a64[] = {
 	0x5f, 0x20, 0x03, 0xd5,	/* wfe */
 	0xfe, 0x7f, 0x00, 0x58,	/* ldr	lr, 0x1000 */
@@ -20,7 +25,6 @@ static uint8_t smp_spin_table_a32[] = {
 	0xfb, 0xff, 0xff, 0x0a,	/* beq	0 */
 	0x1e, 0xff, 0x2f, 0xe1,	/* bx	lr */
 };
-#define SMP_SPIN_TABLE_RELEASE_ADDR	(SMP_SPIN_TABLE_BASE + 0x1000)
 
 static int fdt_lookup_phandle(void *fdt, int node, const char *prop_name)
 {
@@ -36,7 +40,8 @@ static int fdt_lookup_phandle(void *fdt, int node, const char *prop_name)
 	return fdt_node_offset_by_phandle(fdt, fdt32_to_cpu(*phandle));
 }
 
-static void smp_spin_table_setup_cpu(void *fdt, int cpu_node)
+static void smp_spin_table_setup_cpu(struct smp_spin_table *table,
+				     void *fdt, int cpu_node)
 {
 	const uint32_t *val;
 	int node, len, ret;
@@ -50,7 +55,8 @@ static void smp_spin_table_setup_cpu(void *fdt, int cpu_node)
 	cpu = fdt32_to_cpu(*val);
 	dprintf(INFO, "Booting CPU%x\n", cpu);
 
-	ret = fdt_setprop_u64(fdt, cpu_node, "cpu-release-addr", SMP_SPIN_TABLE_RELEASE_ADDR);
+	ret = fdt_setprop_u64(fdt, cpu_node, "cpu-release-addr",
+			      (uintptr_t)&table->release_addr);
 	if (ret) {
 		dprintf(CRITICAL, "Failed to set cpu-release-addr: %d\n", ret);
 		return;
@@ -126,7 +132,7 @@ static void smp_spin_table_setup_idle_states(void *fdt, int node)
  */
 extern void qhypstub_set_state_aarch64(void);
 
-void smp_spin_table_setup(void *fdt, bool arm64)
+void smp_spin_table_setup(struct smp_spin_table *table, void *fdt, bool arm64)
 {
 	int offset, node, ret;
 
@@ -172,13 +178,13 @@ void smp_spin_table_setup(void *fdt, bool arm64)
 	}
 
 	if (arm64)
-		memcpy((void*)SMP_SPIN_TABLE_BASE, smp_spin_table_a64, sizeof(smp_spin_table_a64));
+		memcpy(table->code, smp_spin_table_a64, sizeof(smp_spin_table_a64));
 	else
-		memcpy((void*)SMP_SPIN_TABLE_BASE, smp_spin_table_a32, sizeof(smp_spin_table_a32));
+		memcpy(table->code, smp_spin_table_a32, sizeof(smp_spin_table_a32));
 
-	*((uint64_t*)SMP_SPIN_TABLE_RELEASE_ADDR) = 0;
+	table->release_addr = 0;
 
-	ret = qcom_set_boot_addr(SMP_SPIN_TABLE_BASE, arm64);
+	ret = qcom_set_boot_addr((uint32_t)table, arm64);
 	if (ret) {
 		dprintf(CRITICAL, "Failed to set CPU boot address: %d\n", ret);
 		return;
@@ -197,7 +203,7 @@ void smp_spin_table_setup(void *fdt, bool arm64)
 		if (len < strlen("cpu@") || name[len])
 			continue;
 		if (strncmp(name, "cpu@", strlen("cpu@")) == 0)
-			smp_spin_table_setup_cpu(fdt, node);
+			smp_spin_table_setup_cpu(table, fdt, node);
 		if (strcmp(name, "idle-states") == 0)
 			smp_spin_table_setup_idle_states(fdt, node);
 	}

--- a/lk2nd/smp/spin-table.c
+++ b/lk2nd/smp/spin-table.c
@@ -9,15 +9,11 @@
 
 static uint8_t smp_spin_table_code[] = {
 	0x5f, 0x20, 0x03, 0xd5,	/* wfe */
-	0x7e, 0x00, 0x00, 0x58,	/* ldr	lr, 16 */
+	0xfe, 0x7f, 0x00, 0x58,	/* ldr	lr, 0x1000 */
 	0xde, 0xff, 0xff, 0xb4,	/* cbz	lr, 0 */
-	0xc0, 0x03, 0x5f, 0xd6,	/* ret */
-	0x00, 0x00, 0x00, 0x00,	/* Release address */
-	0x00, 0x00, 0x00, 0x00,	/* (0 by default) */
+	0xc0, 0x03, 0x1f, 0xd6,	/* br	lr */
 };
-#define SMP_SPIN_TABLE_RELEASE_ADDR	(SMP_SPIN_TABLE_BASE + \
-					 sizeof(smp_spin_table_code) - \
-					 sizeof(uint64_t))
+#define SMP_SPIN_TABLE_RELEASE_ADDR	(SMP_SPIN_TABLE_BASE + 0x1000)
 
 static int fdt_lookup_phandle(void *fdt, int node, const char *prop_name)
 {
@@ -153,6 +149,7 @@ void smp_spin_table_setup(void *fdt)
 	}
 
 	memcpy((void*)SMP_SPIN_TABLE_BASE, smp_spin_table_code, sizeof(smp_spin_table_code));
+	*((uint64_t*)SMP_SPIN_TABLE_RELEASE_ADDR) = 0;
 
 	ret = qcom_set_boot_addr(SMP_SPIN_TABLE_BASE);
 	if (ret) {


### PR DESCRIPTION
Add support for using the spin-table code to boot the CPUs in ARM32 mode instead of ARM64. This is typically not needed/usable without modifications in Linux ARM32 (since it uses custom SMP boot code that is already upstream). But it's still useful when booting something other than Linux for example (to avoid having to copy the CPU boot code).

The way this works at the moment is that spin table is skipped if the `/psci` device tree node is already disabled (which is the case on ARM32 Linux). Otherwise it's set up as usual. It also works on devices with 32-bit TZ.