### PR TITLE
dev_tree: Fix appending cmdline if "bootargs" is already in DT

### DIFF
--- a/platform/msm_shared/dev_tree.c
+++ b/platform/msm_shared/dev_tree.c
@@ -1413,6 +1413,13 @@ int update_device_tree(void *fdt, const char *cmdline,
 	offset = ret;
 	if (cmdline)
 	{
+		int len;
+		char *oldargs = fdt_getprop_w(fdt, offset, "bootargs", &len);
+
+		/* Replace old null terminator so the strings are concatenated */
+		if (oldargs && len >= 1 && oldargs[len-1] == '\0')
+			oldargs[len-1] = ' ';
+
 		/* Adding the cmdline to the chosen node */
 		ret = fdt_appendprop_string(fdt, offset, (const char*)"bootargs", (const void*)cmdline);
 		if (ret)


### PR DESCRIPTION
Downstream device trees contain bootargs = "sched_enable_hmp=1".
The original intention was that this would get prepended to the real
command line. However, this currently only works with a modification
in libfdt (see 5ac5542029fa0706829a30247445a998ad6cb93c) and has
therefore been broken since the libfdt update. Booting downstream was
effectively broken because the proper cmdline was missing.

Instead of modifying libfdt, fix this properly by replacing the null
terminator with a space.

Might fix #121