### PR TITLE
dev_tree: Allow mapping power key

### DIFF
--- a/dts/lk2nd.h
+++ b/dts/lk2nd.h
@@ -30,5 +30,6 @@
 #define GPIO_ACTIVE_HIGH (1 << 8)
 
 #define LK2ND_KEY_RESIN (2 << 16) 0
+#define LK2ND_KEY_PWR (3 << 16) 0
 
 #endif

--- a/dts/msm8226/apq8026-huawei-sturgeon.dts
+++ b/dts/msm8226/apq8026-huawei-sturgeon.dts
@@ -3,6 +3,7 @@
 /dts-v1/;
 
 #include <skeleton.dtsi>
+#include <lk2nd.h>
 
 / {
 	// This is used by the bootloader to find the correct DTB
@@ -11,4 +12,6 @@
 	qcom,board-id = <8 4>;
 
 	model = "Huawei Watch";
+
+	lk2nd,keys = <KEY_HOME LK2ND_KEY_PWR>;
 };

--- a/include/lk2nd.h
+++ b/include/lk2nd.h
@@ -22,6 +22,7 @@ struct lk2nd_keymap {
 		KEY_GPIO = 0,
 		KEY_PM_GPIO = 1,
 		KEY_RESIN = 2,
+		KEY_PWR = 3,
 	} type;
 	uint8_t pull;
 	uint8_t active;

--- a/target/target_keys_lk2nd.c
+++ b/target/target_keys_lk2nd.c
@@ -26,6 +26,7 @@ void target_init_keys(void)
 	while (keymap && keymap[i].key) {
 		switch (keymap[i].type) {
 			case KEY_RESIN:
+			case KEY_PWR:
 				break;
 			case KEY_GPIO:
 				gpio_tlmm_config(keymap[i].gpio, 0, GPIO_INPUT, keymap[i].pull, GPIO_2MA, GPIO_ENABLE);
@@ -53,6 +54,9 @@ int target_key_pressed(int key)
 			switch (keymap[i].type) {
 				case KEY_RESIN:
 					st = pm8x41_resin_status();
+					break;
+				case KEY_PWR:
+					st = pm8x41_get_pwrkey_is_pressed();
 					break;
 				case KEY_GPIO:
 					st = (gpio_status(keymap[i].gpio) == keymap[i].active);


### PR DESCRIPTION
Allows entering fastboot mode on the Huawei Watch using the (single) power button.