### PR TITLE
dts: msm8916: Added support for SM-J500M

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Samsung Galaxy Grand Prime - SM-G530W, SM-G530Y (quirky - see comment in `dts/msm8916/msm8916-samsung-r11.dts`)
 - Samsung Galaxy J3 (2016) - SM-J3109, SM-J320YZ
 - Samsung Galaxy J3 Pro - SM-J3110, SM-J3119
-- Samsung Galaxy J5 (2015) - SM-J5008, SM-J500F, SM-J500FN, SM-J500H
+- Samsung Galaxy J5 (2015) - SM-J5008, SM-J500F, SM-J500FN, SM-J500H, SM-J500M
 - Samsung Galaxy J5 (2016) - SM-J5108, SM-J510F, SM-J510FN
 - Samsung Galaxy J7 (2015) - SM-J7008, SM-J700P
 - Samsung Galaxy On7 (2015) - SM-G6000

--- a/dts/msm8916/msm8916-samsung-r05.dts
+++ b/dts/msm8916/msm8916-samsung-r05.dts
@@ -39,4 +39,14 @@
 			i2c-address = <0x25>;
 		};
 	};
+	
+	j5lte-latam {
+		model = "Samsung Galaxy J5 2015 (SM-J500M)";
+		compatible = "samsung,j5lte-latam", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "J500M*";
+		samsung,muic-reset {
+			i2c-gpio-pins = <105 106>;
+			i2c-address = <0x25>;
+		};
+	};
 };


### PR DESCRIPTION
This PR adds support for the Samsung Galaxy J5 2015 (SM-J500M). Check #134 for more info.

![IMG_20220115_190620](https://user-images.githubusercontent.com/26839383/149640268-49d71eed-d91d-40af-b4eb-2e42dc2d5270.jpg)

![IMG_20220115_191313](https://user-images.githubusercontent.com/26839383/149640272-f81551a7-ee89-4551-9eb1-0b825ed9125a.jpg)
