### PR TITLE
Add flash ID for Quectel EG25-G modem.

### DIFF
--- a/platform/msm_shared/qpic_nand.c
+++ b/platform/msm_shared/qpic_nand.c
@@ -80,6 +80,7 @@ static struct flash_id supported_flash[] = {
 	{0x2690A32C, 0x64,     0xFFFFFFFF, 0x0,      0x20000000,    0,  4096,   0x00040000,        0xE0,   1},
 	{0x2690AC98, 0x81676,  0xFFFFFFFF, 0x0,      0x20000000,    0,  4096,   0x00040000,        0xE0,   1},
 	{0x1580a1c2, 0x02,     0xFFFFFFFF, 0xFF,     0x08000000,    0,  2048,   0x00020000,        0x40,   0},
+	{0x1590AAAD, 0,        0xFFFFFFFF, 0x0,      0x10000000,    0,  2048,   0x00020000,        0x40,   0},
 	/* Note: Width flag is 0 for 8 bit Flash and 1 for 16 bit flash   */
 };
 


### PR DESCRIPTION
Add support for the NAND chip used by Quectel EG25-G (Pinephone and Pinephone Pro).