### PR TITLE
Add support for MSM8909

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ https://source.codeaurora.org/quic/la/kernel/lk/) (tag `LA.BR.1.2.9.1-02310-8x16
 which is a heavily modified version of the [Little Kernel Embedded Operating System].
 
 ## Supported SoCs
+- `lk2nd-msm8909`: APQ8009, MSM8909
 - `lk2nd-msm8916`: APQ8016, MSM8216, MSM8916, MSM8929, MSM8939
 - `lk2nd-msm8974`: MSM8974
 - `lk2nd-msm8226`: APQ8026, MSM8226, MSM8926
@@ -44,6 +45,10 @@ See [Chipsets](https://github.com/efidroid/projectmanagement/wiki/%5BReference%5
 page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 
 ## Supported devices
+### lk2nd-msm8909
+- Mobvoi TicWatch Pro - catfish
+- Qihoo W701
+
 ### lk2nd-msm8916
 - Alcatel OneTouch Idol 3 (4.7) - 6039*
 - Alcatel OneTouch Idol 3 (5.5) - 6045*

--- a/dev/fbcon/fbcon.c
+++ b/dev/fbcon/fbcon.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2008, Google Inc.
  * All rights reserved.
  *
- * Copyright (c) 2009-2015, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2009-2015, 2018 The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -509,7 +509,6 @@ void display_default_image_on_screen(void)
 	image_base = ((((total_y/2) - (SPLASH_IMAGE_HEIGHT / 2) - 1) *
 			(config->width)) + (total_x/2 - (SPLASH_IMAGE_WIDTH / 2)));
 
-#if DISPLAY_TYPE_MIPI
 	if (bytes_per_bpp == 3) {
 		for (i = 0; i < SPLASH_IMAGE_HEIGHT; i++) {
 			memcpy (config->base + ((image_base + (i * (config->width))) * bytes_per_bpp),
@@ -517,13 +516,7 @@ void display_default_image_on_screen(void)
 			SPLASH_IMAGE_WIDTH * bytes_per_bpp);
 		}
 	}
-	fbcon_flush();
-#if DISPLAY_MIPI_PANEL_NOVATEK_BLUE
-	if(is_cmd_mode_enabled())
-		mipi_dsi_cmd_mode_trigger();
-#endif
 
-#else
 	if (bytes_per_bpp == 2) {
 		for (i = 0; i < SPLASH_IMAGE_HEIGHT; i++) {
 			memcpy (config->base + ((image_base + (i * (config->width))) * bytes_per_bpp),
@@ -532,6 +525,10 @@ void display_default_image_on_screen(void)
 		}
 	}
 	fbcon_flush();
+
+#if DISPLAY_MIPI_PANEL_NOVATEK_BLUE
+	if(is_cmd_mode_enabled())
+		mipi_dsi_cmd_mode_trigger();
 #endif
 }
 

--- a/dev/gcdb/display/gcdb_display.c
+++ b/dev/gcdb/display/gcdb_display.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2013-2014, 2018 The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -374,6 +374,53 @@ static int mdss_dsi2HDMI_config (struct msm_panel_info *pinfo)
 	return target_display_dsi2hdmi_config(pinfo);
 }
 
+static int mdss_spi_bl_enable(uint8_t enable)
+{
+	int ret = NO_ERROR;
+
+	ret = panel_backlight_ctrl(enable);
+	if (ret)
+		dprintf(CRITICAL, "Backlight %s failed\n", enable ? "enable" : "disable");
+	return ret;
+}
+
+static int mdss_spi_panel_power(uint8_t enable, struct msm_panel_info *pinfo)
+{
+	int ret = NO_ERROR;
+
+	if (enable) {
+		ret = target_ldo_ctrl(enable, pinfo);
+		if (ret) {
+			dprintf(CRITICAL, "LDO control enable failed\n");
+			return ret;
+		}
+
+		/*Panel Reset*/
+		ret = target_panel_reset(enable,panelstruct.panelresetseq, &panel.panel_info);
+		if (ret) {
+			dprintf(CRITICAL, "panel reset failed\n");
+			return ret;
+		}
+		dprintf(INFO, "Panel power on done\n");
+	} else {
+		/*Disable panel and ldo*/
+		ret = target_panel_reset(enable, panelstruct.panelresetseq, &panel.panel_info);
+		if (ret) {
+			dprintf(CRITICAL, "panel reset disable failed \n");
+			return ret;
+		}
+
+		ret = target_ldo_ctrl(enable, pinfo);
+		if (ret) {
+			dprintf(CRITICAL, "panel reset disable failed \n");
+			return ret;
+		}
+		dprintf(INFO, "Panel power off done\n");
+	}
+
+	return ret;
+}
+
 int gcdb_display_init(const char *panel_name, uint32_t rev, void *base)
 {
 	int ret = NO_ERROR;
@@ -410,6 +457,18 @@ int gcdb_display_init(const char *panel_name, uint32_t rev, void *base)
                 panel.power_func = mdss_edp_panel_power;
 		panel.bl_func = mdss_edp_bl_enable;
                 panel.fb.format = FB_FORMAT_RGB888;
+	} else if (pan_type == PANEL_TYPE_SPI) {
+		panel.panel_info.xres = panelstruct.panelres->panel_width;
+		panel.panel_info.yres = panelstruct.panelres->panel_height;
+		panel.panel_info.bpp = panelstruct.color->color_format;
+		panel.power_func = mdss_spi_panel_power;
+		panel.bl_func = mdss_spi_bl_enable;
+		panel.fb.base = base;
+		panel.fb.width = panel.panel_info.xres;
+		panel.fb.height = panel.panel_info.yres;
+		panel.fb.bpp = panel.panel_info.bpp;
+		panel.fb.format = FB_FORMAT_RGB565;
+		panel.panel_info.type = SPI_PANEL;
 	} else {
 		dprintf(CRITICAL, "Target panel init not found!\n");
 		ret = ERR_NOT_SUPPORTED;

--- a/dev/gcdb/display/include/panel.h
+++ b/dev/gcdb/display/include/panel.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013-2015, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2013-2015, 2018, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,7 +48,8 @@ enum {
 	PANEL_TYPE_UNKNOWN,
 	PANEL_TYPE_DSI,
 	PANEL_TYPE_EDP,
-	PANEL_TYPE_HDMI
+	PANEL_TYPE_HDMI,
+	PANEL_TYPE_SPI
 };
 
 /*---------------------------------------------------------------------------*/

--- a/dev/gcdb/display/include/panel_st7789v2_qvga_spi_cmd.h
+++ b/dev/gcdb/display/include/panel_st7789v2_qvga_spi_cmd.h
@@ -1,0 +1,206 @@
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are
+* met:
+*    * Redistributions of source code must retain the above copyright
+*      notice, this list of conditions and the following disclaimer.
+*    * Redistributions in binary form must reproduce the above
+*      copyright notice, this list of conditions and the following
+*      disclaimer in the documentation and/or other materials provided
+*      with the distribution.
+*    * Neither the name of The Linux Foundation nor the names of its
+*      contributors may be used to endorse or promote products derived
+*      from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+* OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+* IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _PANEL_ST7789v2_QVGA_SPI_CMD_H_
+#define _PANEL_ST7789v2_QVGA_SPI_CMD_H_
+/*---------------------------------------------------------------------------*/
+/* HEADER files                                                              */
+/*---------------------------------------------------------------------------*/
+#include "panel.h"
+
+/*---------------------------------------------------------------------------*/
+/* Panel configuration                                                       */
+/*---------------------------------------------------------------------------*/
+static struct panel_config st7789v2_qvga_cmd_panel_data = {
+	"qcom,mdss_spi_st7789v2_qvga_cmd", "spi:0:", "qcom,mdss-spi-panel",
+	10, 0, "DISPLAY_1", 0, 0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+/*---------------------------------------------------------------------------*/
+/* Panel resolution                                                          */
+/*---------------------------------------------------------------------------*/
+static struct panel_resolution st7789v2_qvga_cmd_panel_res = {
+	240, 240, 79, 59, 60, 0, 7, 10, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+/*---------------------------------------------------------------------------*/
+/* Panel color information                                                   */
+/*---------------------------------------------------------------------------*/
+static struct color_info st7789v2_qvga_cmd_color = {
+	16, 0, 0xff, 0, 0, 0
+};
+
+/*---------------------------------------------------------------------------*/
+/* Panel on/off command information                                          */
+/*---------------------------------------------------------------------------*/
+static char st7789v2_qvga_cmd_on_cmd0[] = {
+	0x11,
+};
+
+static char st7789v2_qvga_cmd_on_cmd1[] = {
+	0x36, 0x00,
+};
+
+static char st7789v2_qvga_cmd_on_cmd2[] = {
+	0x3A, 0x05,
+};
+
+static char st7789v2_qvga_cmd_on_cmd3[] = {
+	0x35, 0x00,
+};
+
+static char st7789v2_qvga_cmd_on_cmd4[] = {
+	0xB2, 0x0C, 0x0C, 0x00,
+	0x33, 0x33,
+};
+
+static char st7789v2_qvga_cmd_on_cmd5[] = {
+	0xB7, 0x75,
+};
+
+static char st7789v2_qvga_cmd_on_cmd6[] = {
+	0xBB, 0x3D,
+};
+
+static char st7789v2_qvga_cmd_on_cmd7[] = {
+	0xC2, 0x01,
+};
+
+static char st7789v2_qvga_cmd_on_cmd8[] = {
+	0xC3, 0x19,
+};
+
+static char st7789v2_qvga_cmd_on_cmd9[] = {
+	0x04, 0x20,
+};
+
+static char st7789v2_qvga_cmd_on_cmd10[] = {
+	0xc6, 0x0F,
+};
+
+static char st7789v2_qvga_cmd_on_cmd11[] = {
+	0xD0, 0xA4, 0xA1,
+};
+
+static char st7789v2_qvga_cmd_on_cmd12[] = {
+	0xE0, 0x70, 0x04, 0x08,
+	0x09, 0x09, 0x05, 0x2A,
+	0x33, 0x41, 0x07, 0x13,
+	0x13, 0x29, 0x2F,
+};
+
+static char st7789v2_qvga_cmd_on_cmd13[] = {
+	0xE1, 0x70, 0x03, 0x09,
+	0x0A, 0x09, 0x06, 0x2B,
+	0x34, 0x41, 0x07, 0x12,
+	0x14, 0x28, 0x2E
+};
+
+static char st7789v2_qvga_cmd_on_cmd14[] = {
+	0x21,
+};
+
+static char st7789v2_qvga_cmd_on_cmd15[] = {
+	0x29,
+};
+
+static char st7789v2_qvga_cmd_on_cmd16[] = {
+	0x2A, 0x00, 0x00, 0x00, 0xEF
+};
+
+static char st7789v2_qvga_cmd_on_cmd17[] = {
+	0x2B, 0x00, 0x00, 0x00, 0xEF
+};
+
+static char st7789v2_qvga_cmd_on_cmd18[] = {
+	0x2c
+};
+
+static struct mdss_spi_cmd st7789v2_qvga_cmd_on_command[] = {
+	{0x01, st7789v2_qvga_cmd_on_cmd0, 0x78, 0},
+	{0x02, st7789v2_qvga_cmd_on_cmd1, 0x00, 0},
+	{0x02, st7789v2_qvga_cmd_on_cmd2, 0x00, 0},
+	{0x02, st7789v2_qvga_cmd_on_cmd3, 0x00, 0},
+	{0x06, st7789v2_qvga_cmd_on_cmd4, 0x00, 0},
+	{0x02, st7789v2_qvga_cmd_on_cmd5, 0x00, 0},
+	{0x02, st7789v2_qvga_cmd_on_cmd6, 0x00, 0},
+	{0x02, st7789v2_qvga_cmd_on_cmd7, 0x00, 0},
+	{0x02, st7789v2_qvga_cmd_on_cmd8, 0x00, 0},
+	{0x02, st7789v2_qvga_cmd_on_cmd9, 0x00, 0},
+	{0x02, st7789v2_qvga_cmd_on_cmd10, 0x00, 0},
+	{0x03, st7789v2_qvga_cmd_on_cmd11, 0x00, 0},
+	{0x0F, st7789v2_qvga_cmd_on_cmd12, 0x00, 0},
+	{0x0F, st7789v2_qvga_cmd_on_cmd13, 0x00, 0},
+	{0x01, st7789v2_qvga_cmd_on_cmd14, 0x00, 0},
+	{0x01, st7789v2_qvga_cmd_on_cmd15, 0x78, 0},
+	{0x05, st7789v2_qvga_cmd_on_cmd16, 0x00, 0},
+	{0x05, st7789v2_qvga_cmd_on_cmd17, 0x00, 0},
+	{0x01, st7789v2_qvga_cmd_on_cmd18, 0x00, 0},
+};
+
+#define ST7789v2_QVGA_CMD_ON_COMMAND 19
+
+
+static char st7789v2_qvga_cmdoff_cmd0[] = {
+	0x28,
+};
+
+static char st7789v2_qvga_cmdoff_cmd1[] = {
+	0x10,
+};
+
+static struct mipi_dsi_cmd st7789v2_qvga_cmd_off_command[] = {
+	{0x1, st7789v2_qvga_cmdoff_cmd0, 0x20},
+	{0x1, st7789v2_qvga_cmdoff_cmd1, 0x20}
+};
+
+#define ST7789v2_QVGA_CMD_OFF_COMMAND 2
+
+/*---------------------------------------------------------------------------*/
+/* Panel reset sequence                                                      */
+/*---------------------------------------------------------------------------*/
+static struct panel_reset_sequence st7789v2_qvga_cmd_reset_seq = {
+	{1, 0, 1, }, {20, 2, 20, }, 2
+};
+
+/*---------------------------------------------------------------------------*/
+/* Backlight setting                                                         */
+/*---------------------------------------------------------------------------*/
+static struct backlight st7789v2_qvga_cmd_backlight = {
+	1, 1, 4095, 100, 1, "PMIC_8941"
+};
+
+static uint8_t st7789v2_signature_addr = 0x04;
+
+static uint8_t st7789v2_signature_len = 3;
+
+static uint8_t st7789v2_signature[] = {
+	0x85, 0x85, 0x52
+};
+
+#endif /* PANEL_ST7789v2_QVGA_SPI_CMD_H */

--- a/dts/msm8909/msm8909-catfish.dts
+++ b/dts/msm8909/msm8909-catfish.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+
+/ {
+	qcom,msm-id = <265 0>, <301 0>;
+	qcom,board-id= <8 0x105>;
+	lk2nd,match-cmdline = "* mdss_mdp3.panel=1:dsi:0:qcom,mdss_dsi_rm67162_wqvga_cmd:1:none:cfg:single_dsi";
+
+	model = "Mobvoi TicWatch Pro";
+	compatible = "mobvoi,catfish", "qcom,msm8909", "lk2nd,device";
+};

--- a/dts/msm8909/msm8909-qihoo-w701.dts
+++ b/dts/msm8909/msm8909-qihoo-w701.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+
+/ {
+	qcom,msm-id = <0x12c 0x00>;
+	qcom,board-id = <0x0b 0x107>;
+	qcom,pmic-id = <0x1000b 0x00 0x00 0x00>;
+	lk2nd,match-cmdline = "* mdss_mdp3.panel=1:dsi:0:qcom,mdss_dsi_st7789h2_video:1:none";
+
+	model = "QIHOO W701";
+	compatible = "qihoo,w701", "qcom,msm8909", "lk2nd,device";
+};

--- a/dts/msm8909/rules.mk
+++ b/dts/msm8909/rules.mk
@@ -1,0 +1,4 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+DTBS += \
+	$(LOCAL_DIR)/msm8909-qihoo-w701.dtb

--- a/dts/msm8909/rules.mk
+++ b/dts/msm8909/rules.mk
@@ -1,4 +1,5 @@
 LOCAL_DIR := $(GET_LOCAL_DIR)
 
 DTBS += \
+	$(LOCAL_DIR)/msm8909-catfish.dtb \
 	$(LOCAL_DIR)/msm8909-qihoo-w701.dtb

--- a/platform/msm8909/include/platform/iomap.h
+++ b/platform/msm8909/include/platform/iomap.h
@@ -180,6 +180,12 @@
 #define DSI0_PLL_BASE               (0x1AC8300)
 #define DSI1_PLL_BASE               DSI0_PLL_BASE
 #define REG_DSI(off)                (MIPI_DSI_BASE + 0x04 + (off))
+#define MDP_VP_0_VIG_0_BASE                     REG_MDP(0x5000)
+#define MDP_VP_0_VIG_1_BASE                     REG_MDP(0x7000)
+#define MDP_VP_0_RGB_0_BASE                     REG_MDP(0x15000)
+#define MDP_VP_0_RGB_1_BASE                     REG_MDP(0x17000)
+#define MDP_VP_0_DMA_0_BASE                     REG_MDP(0x25000)
+#define MDP_VP_0_DMA_1_BASE                     REG_MDP(0x27000)
 
 
 /* MDP */

--- a/platform/msm_shared/display.c
+++ b/platform/msm_shared/display.c
@@ -68,6 +68,7 @@ int msm_display_config()
 	mdp_set_revision(panel->mdp_rev);
 
 	switch (pinfo->type) {
+#ifdef DISPLAY_TYPE_MDSS
 	case LVDS_PANEL:
 		dprintf(INFO, "Config LVDS_PANEL.\n");
 		ret = mdp_lcdc_config(pinfo, &(panel->fb));
@@ -127,6 +128,13 @@ int msm_display_config()
 		if (ret)
 			goto msm_display_config_out;
 		break;
+#endif
+#ifdef DISPLAY_TYPE_QPIC
+	case QPIC_PANEL:
+		dprintf(INFO, "Config QPIC_PANEL.\n");
+		qpic_init(pinfo, panel->fb.base);
+		break;
+#endif
 	default:
 		return ERR_INVALID_ARGS;
 	};
@@ -158,6 +166,7 @@ int msm_display_on()
 	}
 
 	switch (pinfo->type) {
+#ifdef DISPLAY_TYPE_MDSS
 	case LVDS_PANEL:
 		dprintf(INFO, "Turn on LVDS PANEL.\n");
 		ret = mdp_lcdc_on(panel);
@@ -221,6 +230,18 @@ int msm_display_on()
 		if (ret)
 			goto msm_display_on_out;
 		break;
+#endif
+#ifdef DISPLAY_TYPE_QPIC
+	case QPIC_PANEL:
+		dprintf(INFO, "Turn on QPIC_PANEL.\n");
+		ret = qpic_on();
+		if (ret) {
+			dprintf(CRITICAL, "QPIC panel on failed\n");
+			goto msm_display_on_out;
+		}
+		qpic_update();
+		break;
+#endif
 	default:
 		return ERR_INVALID_ARGS;
 	};
@@ -325,6 +346,7 @@ int msm_display_off()
 	}
 
 	switch (pinfo->type) {
+#ifdef DISPLAY_TYPE_MDSS
 	case LVDS_PANEL:
 		dprintf(INFO, "Turn off LVDS PANEL.\n");
 		mdp_lcdc_off();
@@ -357,6 +379,13 @@ int msm_display_off()
 		if (ret)
 			goto msm_display_off_out;
 		break;
+#endif
+#ifdef DISPLAY_TYPE_QPIC
+	case QPIC_PANEL:
+		dprintf(INFO, "Turn off QPIC_PANEL.\n");
+		qpic_off();
+		break;
+#endif
 	default:
 		return ERR_INVALID_ARGS;
 	};

--- a/platform/msm_shared/display.c
+++ b/platform/msm_shared/display.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2015, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2015, 2018 The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -13,6 +13,7 @@
  *       contributors may be used to endorse or promote products derived
  *       from this software without specific prior written permission.
  *
+ 
  * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
  * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
@@ -113,6 +114,15 @@ int msm_display_config()
 	case LCDC_PANEL:
 		dprintf(INFO, "Config LCDC PANEL.\n");
 		ret = mdp_lcdc_config(pinfo, &(panel->fb));
+		if (ret)
+			goto msm_display_config_out;
+		break;
+	case SPI_PANEL:
+		dprintf(INFO, "Config SPI PANEL.\n");
+		ret = mdss_spi_init();
+		if (ret)
+			goto msm_display_config_out;
+		ret = mdss_spi_panel_init(pinfo);
 		if (ret)
 			goto msm_display_config_out;
 		break;
@@ -227,6 +237,12 @@ int msm_display_on()
 	case EDP_PANEL:
 		dprintf(INFO, "Turn on EDP PANEL.\n");
 		ret = mdp_edp_on(pinfo);
+		if (ret)
+			goto msm_display_on_out;
+		break;
+	case SPI_PANEL:
+		dprintf(INFO, "Turn on SPI_PANEL.\n");
+		ret = mdss_spi_on(pinfo, &(panel->fb));
 		if (ret)
 			goto msm_display_on_out;
 		break;

--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -41,7 +41,7 @@
 #include <sys/types.h>
 #include <../../../app/aboot/devinfo.h>
 #include <lk2nd.h>
-#if TARGET_MSM8916
+#if TARGET_MSM8916 || TARGET_MSM8909
 #include <psci.h>
 #endif
 
@@ -365,7 +365,7 @@ void display_bootverify_option_menu_renew(struct select_msg_info *msg_info)
 
 static void display_fastboot_menu_print_fw_info(char *msg, size_t msg_size)
 {
-#if TARGET_MSM8916
+#if TARGET_MSM8916 || TARGET_MSM8909
 	bool armv8 = is_scm_armv8_support();
 	scmcall_arg arg = {0};
 	uint32_t psci_version = PSCI_RET_NOT_SUPPORTED;

--- a/platform/msm_shared/include/mdp4.h
+++ b/platform/msm_shared/include/mdp4.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2014, 2018 The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -117,4 +117,7 @@ int mdp_edp_config(struct msm_panel_info *pinfo, struct fbcon_config *fb);
 int mdp_edp_on(struct msm_panel_info *pinfo);
 int mdp_edp_off(void);
 
+int mdss_spi_init(void);
+int mdss_spi_panel_init(struct msm_panel_info *pinfo);
+int mdss_spi_on(struct msm_panel_info *pinfo, struct fbcon_config *fb);
 #endif

--- a/platform/msm_shared/include/msm_panel.h
+++ b/platform/msm_shared/include/msm_panel.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2016, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2016, 2018, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -51,6 +51,7 @@
 #define LVDS_PANEL		11	/* LVDS */
 #define EDP_PANEL		12	/* EDP */
 #define QPIC_PANEL		13	/* QPIC */
+#define SPI_PANEL		14
 
 enum mdss_mdp_pipe_type {
 	MDSS_MDP_PIPE_TYPE_VIG,
@@ -84,6 +85,21 @@ struct lcd_panel_info {
 	uint32_t hw_vsync_mode;
 	uint32_t vsync_notifier_period;
 	uint32_t rev;
+};
+
+struct mdss_spi_cmd {
+	int size;
+	char *payload;
+	int wait;
+	uint8_t cmds_post_tg;
+};
+
+struct spi_panel_info {
+	int num_of_panel_cmds;
+	struct mdss_spi_cmd *panel_cmds;
+	uint8_t *signature_addr;
+	uint8_t *signature;
+	uint8_t *signature_len;
 };
 
 struct hdmi_panel_info {
@@ -265,6 +281,7 @@ struct msm_panel_info {
 	struct lvds_panel_info lvds;
 	struct hdmi_panel_info hdmi;
 	struct edp_panel_info edp;
+	struct spi_panel_info spi;
 	struct dsi2HDMI_panel_info adv7533;
 
 	int (*on) (void);

--- a/platform/msm_shared/include/msm_panel.h
+++ b/platform/msm_shared/include/msm_panel.h
@@ -50,6 +50,7 @@
 #define WRITEBACK_PANEL		10	/* Wifi display */
 #define LVDS_PANEL		11	/* LVDS */
 #define EDP_PANEL		12	/* EDP */
+#define QPIC_PANEL		13	/* QPIC */
 
 enum mdss_mdp_pipe_type {
 	MDSS_MDP_PIPE_TYPE_VIG,

--- a/platform/msm_shared/include/qpic.h
+++ b/platform/msm_shared/include/qpic.h
@@ -1,0 +1,100 @@
+/* Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name of The Linux Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef MDSS_QPIC_H
+#define MDSS_QPIC_H
+
+#include "qpic_panel.h"
+
+#define QPIC_REG_QPIC_LCDC_CTRL				0x22000
+#define QPIC_REG_LCDC_VERSION				0x22004
+#define QPIC_REG_QPIC_LCDC_IRQ_EN			0x22008
+#define QPIC_REG_QPIC_LCDC_IRQ_STTS			0x2200C
+#define QPIC_REG_QPIC_LCDC_IRQ_CLR			0x22010
+#define QPIC_REG_QPIC_LCDC_STTS				0x22014
+#define QPIC_REG_QPIC_LCDC_CMD_DATA_CYCLE_CNT	0x22018
+#define QPIC_REG_QPIC_LCDC_CFG0				0x22020
+#define QPIC_REG_QPIC_LCDC_CFG1				0x22024
+#define QPIC_REG_QPIC_LCDC_CFG2				0x22028
+#define QPIC_REG_QPIC_LCDC_RESET			0x2202C
+#define QPIC_REG_QPIC_LCDC_FIFO_SOF			0x22100
+#define QPIC_REG_LCD_DEVICE_CMD0			0x23000
+#define QPIC_REG_QPIC_LCDC_FIFO_DATA_PORT0	0x22140
+#define QPIC_REG_QPIC_LCDC_FIFO_EOF			0x22180
+
+#define QPIC_OUTP(off, data) \
+	writel((data), qpic_res->qpic_base + (off))
+#define QPIC_OUTPW(off, data) \
+	writehw((data), qpic_res->qpic_base + (off))
+#define QPIC_INP(off) \
+	readl(qpic_res->qpic_base + (off))
+
+#define QPIC_MAX_VSYNC_WAIT_TIME			500
+#define QPIC_MAX_WAIT_CNT			1000
+#define QPIC_MAX_CMD_BUF_SIZE				512
+
+int mdss_qpic_init(void);
+int qpic_send_pkt(uint32_t cmd, uint8_t *param, uint32_t len);
+uint32_t qpic_read_data(uint32_t cmd_index, uint32_t size);
+int mdss_qpic_panel_on(struct qpic_panel_io_desc *panel_io);
+int mdss_qpic_panel_off(struct qpic_panel_io_desc *panel_io);
+
+struct qpic_data_type {
+	uint32_t rev;
+	size_t qpic_reg_size;
+	uint32_t qpic_phys;
+	uint32_t qpic_base;
+	uint32_t irq;
+	uint32_t irq_ena;
+	uint32_t res_init;
+	void *fb_virt;
+	uint32_t fb_phys;
+	void *cmd_buf_virt;
+	uint32_t cmd_buf_phys;
+	int qpic_endpt;
+	uint32_t sps_init;
+	uint32_t irq_requested;
+	struct qpic_panel_io_desc panel_io;
+	uint32_t bus_handle;
+	int fifo_eof_comp;
+	int fb_xres;
+	int fb_yres;
+	int fb_bpp;
+	int base;
+};
+
+uint32_t qpic_send_frame(
+		uint32_t x_start,
+		uint32_t y_start,
+		uint32_t x_end,
+		uint32_t y_end,
+		uint32_t *data,
+		uint32_t total_bytes);
+
+#endif /* MDSS_QPIC_H */

--- a/platform/msm_shared/include/qpic_panel.h
+++ b/platform/msm_shared/include/qpic_panel.h
@@ -1,0 +1,132 @@
+/* Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name of The Linux Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef MDSS_QPIC_PANEL_H
+#define MDSS_QPIC_PANEL_H
+
+#define LCDC_INTERNAL_BUFFER_SIZE   30
+
+/* Macros for coding MIPI commands */
+#define INV_SIZE             0xFFFF
+/* Size of argument to MIPI command is variable */
+#define OP_SIZE_PAIR(op, size)    ((op << 16) | size)
+/* MIPI {command, argument size} tuple */
+#define LCDC_EXTRACT_OP_SIZE(op_identifier)     ((op_identifier & 0xFFFF))
+/* extract size from command identifier */
+#define LCDC_EXTRACT_OP_CMD(op_identifier)  (((op_identifier >> 16) & 0xFFFF))
+/* extract command id from command identifier */
+
+/* MIPI standard efinitions */
+#define LCDC_ADDRESS_MODE_ORDER_BOTTOM_TO_TOP                0x80
+#define LCDC_ADDRESS_MODE_ORDER_RIGHT_TO_LEFT                0x40
+#define LCDC_ADDRESS_MODE_ORDER_REVERSE                      0x20
+#define LCDC_ADDRESS_MODE_ORDER_REFRESH_BOTTOM_TO_TOP        0x10
+#define LCDC_ADDRESS_MODE_ORDER_BGER_RGB                     0x08
+#define LCDC_ADDRESS_MODE_ORDER_REFERESH_RIGHT_TO_LEFT       0x04
+#define LCDC_ADDRESS_MODE_FLIP_HORIZONTAL                    0x02
+#define LCDC_ADDRESS_MODE_FLIP_VERTICAL                      0x01
+
+#define LCDC_PIXEL_FORMAT_3_BITS_PER_PIXEL    0x1
+#define LCDC_PIXEL_FORMAT_8_BITS_PER_PIXEL    0x2
+#define LCDC_PIXEL_FORMAT_12_BITS_PER_PIXEL   0x3
+#define LCDC_PIXEL_FORMAT_16_BITS_PER_PIXEL   0x5
+#define LCDC_PIXEL_FORMAT_18_BITS_PER_PIXEL   0x6
+#define LCDC_PIXEL_FORMAT_24_BITS_PER_PIXEL   0x7
+
+#define LCDC_CREATE_PIXEL_FORMAT(dpi_format, dbi_format) \
+	(dpi_format | (dpi_format << 4))
+
+#define POWER_MODE_IDLE_ON       0x40
+#define POWER_MODE_PARTIAL_ON    0x20
+#define POWER_MODE_SLEEP_ON      0x10
+#define POWER_MODE_NORMAL_ON     0x08
+#define POWER_MODE_DISPLAY_ON    0x04
+
+#define LCDC_DISPLAY_MODE_SCROLLING_ON       0x80
+#define LCDC_DISPLAY_MODE_INVERSION_ON       0x20
+#define LCDC_DISPLAY_MODE_GAMMA_MASK         0x07
+
+/* LDCc MIPI Type B supported commands */
+#define	OP_ENTER_IDLE_MODE      0x39
+#define	OP_ENTER_INVERT_MODE    0x21
+#define	OP_ENTER_NORMAL_MODE    0x13
+#define	OP_ENTER_PARTIAL_MODE   0x12
+#define	OP_ENTER_SLEEP_MODE     0x10
+#define	OP_EXIT_INVERT_MODE     0x20
+#define	OP_EXIT_SLEEP_MODE      0x11
+#define	OP_EXIT_IDLE_MODE       0x38
+#define	OP_GET_ADDRESS_MODE     0x0B /* size 1 */
+#define	OP_GET_BLUE_CHANNEL     0x08 /* size 1 */
+#define	OP_GET_DIAGNOSTIC       0x0F /* size 2 */
+#define	OP_GET_DISPLAY_MODE     0x0D /* size 1 */
+#define	OP_GET_GREEN_CHANNEL    0x07 /* size 1 */
+#define	OP_GET_PIXEL_FORMAT     0x0C /* size 1 */
+#define	OP_GET_POWER_MODE       0x0A /* size 1 */
+#define	OP_GET_RED_CHANNEL      0x06 /* size 1 */
+#define	OP_GET_SCANLINE         0x45 /* size 1 */
+#define	OP_GET_SIGNAL_MODE      0x0E /* size 1 */
+#define	OP_NOP                  0x00
+#define	OP_READ_DDB_CONTINUE    0xA8 /* size not fixed */
+#define	OP_READ_DDB_START       0xA1 /* size not fixed */
+#define	OP_READ_MEMORY_CONTINUE 0x3E /* size not fixed */
+#define	OP_READ_MEMORY_START    0x2E /* size not fixed */
+#define	OP_SET_ADDRESS_MODE     0x36 /* size 1 */
+#define	OP_SET_COLUMN_ADDRESS   0x2A /* size 4 */
+#define	OP_SET_DISPLAY_OFF      0x28
+#define	OP_SET_DISPLAY_ON       0x29
+#define	OP_SET_GAMMA_CURVE      0x26 /* size 1 */
+#define	OP_SET_PAGE_ADDRESS     0x2B /* size 4 */
+#define	OP_SET_PARTIAL_COLUMNS  0x31 /* size 4 */
+#define	OP_SET_PARTIAL_ROWS     0x30 /* size 4 */
+#define	OP_SET_PIXEL_FORMAT     0x3A /* size 1 */
+#define	OP_SOFT_RESET           0x01
+#define	OP_WRITE_MEMORY_CONTINUE  0x3C /* size not fixed */
+#define	OP_WRITE_MEMORY_START   0x2C /* size not fixed */
+
+/* ILI9341 commands */
+#define OP_ILI9341_INTERFACE_CONTROL	0xf6
+#define OP_ILI9341_TEARING_EFFECT_LINE_ON	0x35
+
+struct qpic_panel_io_desc {
+	int rst_gpio;
+	int cs_gpio;
+	int ad8_gpio;
+	int te_gpio;
+	int bl_gpio;
+	int vdd_vreg;
+	int avdd_vreg;
+	uint32_t init;
+};
+
+int mdss_qpic_panel_io_init(struct qpic_panel_io_desc *qpic_panel_io);
+uint32_t qpic_panel_get_cmd(uint32_t command, uint32_t size);
+int ili9341_on(struct qpic_panel_io_desc *qpic_panel_io);
+void ili9341_off(struct qpic_panel_io_desc *qpic_panel_io);
+
+#endif /* MDSS_QPIC_PANEL_H */

--- a/platform/msm_shared/include/qup.h
+++ b/platform/msm_shared/include/qup.h
@@ -1,0 +1,141 @@
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of The Linux Foundation, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef  __QUP__
+#define  __QUP__
+
+#include <stdint.h>
+
+/* QUP_IO_MODES fields */
+#define QUP_IO_MODES_OUTPUT_BIT_SHIFT_EN  0x00010000
+#define QUP_IO_MODES_PACK_EN              0x00008000
+#define QUP_IO_MODES_UNPACK_EN            0x00004000
+#define QUP_IO_MODES_INPUT_MODE           0x00003000
+#define QUP_IO_MODES_OUTPUT_MODE          0x00000C00
+#define QUP_IO_MODES_INPUT_FIFO_SIZE      0x00000380
+#define QUP_IO_MODES_INPUT_BLOCK_SIZE     0x00000060
+#define QUP_IO_MODES_OUTPUT_FIFO_SIZE     0x0000001C
+#define QUP_IO_MODES_OUTPUT_BLOCK_SIZE    0x00000003
+
+#define INPUT_BLOCK_SZ_SHIFT		5
+#define INPUT_FIFO_SZ_SHIFT			7
+#define OUTPUT_BLOCK_SZ_SHIFT		0
+#define OUTPUT_FIFO_SZ_SHIFT		2
+#define OUTPUT_MODE_SHIFT			10
+#define INPUT_MODE_SHIFT			12
+#define INPUT_MODE_MASK		(3 << INPUT_MODE_SHIFT)
+#define OUTPUT_MODE_MASK	(3 << OUTPUT_MODE_SHIFT)
+
+/* QUP_STATE fields */
+#define QUP_STATE_CLEAR_BITS		0x2
+
+/* QUP_ERROR_FLAGS fields */
+#define QUP_ERROR_OUTPUT_OVER_RUN	BIT(5)
+#define QUP_ERROR_INPUT_UNDER_RUN	BIT(4)
+#define QUP_ERROR_OUTPUT_UNDER_RUN	BIT(3)
+#define QUP_ERROR_INPUT_OVER_RUN	BIT(2)
+
+/* QUP_OPERATIONAL fields */
+#define QUP_OP_MAX_INPUT_DONE_FLAG	BIT(11)
+#define QUP_OP_MAX_OUTPUT_DONE_FLAG	BIT(10)
+#define QUP_OP_IN_SERVICE_FLAG		BIT(9)
+#define QUP_OP_OUT_SERVICE_FLAG		BIT(8)
+#define QUP_OP_IN_FIFO_FULL			BIT(7)
+#define QUP_OP_OUT_FIFO_FULL		BIT(6)
+#define QUP_OP_IN_FIFO_NOT_EMPTY	BIT(5)
+#define QUP_OP_OUT_FIFO_NOT_EMPTY	BIT(4)
+
+/* QUP_IO_MODES fields */
+#define QUP_IO_MODES_FIFO		0
+#define QUP_IO_MODES_BLOCK		1
+#define QUP_IO_MODES_DMOV		2
+#define QUP_IO_MODES_BAM		3
+
+/* QUP_CONFIG fields */
+#define QUP_CONFIG_SPI_MODE			(1 << 8)
+#define QUP_CONFIG_CLOCK_AUTO_GATE	BIT(13)
+#define QUP_CONFIG_NO_INPUT			BIT(7)
+#define QUP_CONFIG_NO_OUTPUT		BIT(6)
+#define QUP_CONFIG_N				0x001f
+
+/* QUP_MX_OUTPUT_CNT only supports
+ * 0:15 bits as Number of writes of
+ * size N to the mini-core per RUN state.
+ * And make the count be multiple of max bytes per word.
+ */
+#define MAX_QUP_MX_OUTPUT_COUNT 0xFFF8
+
+/* QUP Registers */
+enum {
+	QUP_CONFIG = 0x0,
+	QUP_STATE = 0x4,
+	QUP_IO_MODES = 0x8,
+	QUP_SW_RESET = 0xC,
+	QUP_OPERATIONAL = 0x18,
+	QUP_ERROR_FLAGS = 0x1C,
+	QUP_ERROR_FLAGS_EN = 0x20,
+	QUP_TEST_CTRL = 0x24,
+	QUP_OPERATIONAL_MASK = 0x28,
+	QUP_HW_VERSION = 0x30,
+	QUP_MX_READ_CNT = 0x208,
+	QUP_MX_INPUT_CNT = 0x200,
+	QUP_MX_OUTPUT_CNT = 0x100,
+	QUP_MX_OUTPUT_CNT_CURRENT = 0x104,
+	QUP_OUTPUT_DEBUG = 0x108,
+	QUP_OUTPUT_FIFO_WORD_CNT = 0x10C,
+	QUP_OUTPUT_FIFO_BASE = 0x110,
+	QUP_MX_WRITE_CNT = 0x150,
+	QUP_MX_WRITE_CNT_CURRENT = 0x154,
+	QUP_INPUT_READ_CUR = 0x20C,
+	QUP_INPUT_DEBUG = 0x210,
+	QUP_INPUT_FIFO_CNT = 0x214,
+	QUP_INPUT_FIFO_BASE = 0x218,
+	QUP_I2C_CLK_CTL = 0x400,
+	QUP_I2C_STATUS = 0x404,
+};
+
+/* QUP States and reset values */
+enum qup_state{
+	QUP_RESET_STATE = 0,
+	QUP_RUN_STATE = 1U,
+	QUP_STATE_MASK = 3U,
+	QUP_PAUSE_STATE = 3U,
+	QUP_STATE_VALID = 1U << 2,
+	QUP_I2C_MAST_GEN = 1U << 4,
+	QUP_OPERATIONAL_RESET = 0xFF0,
+	QUP_I2C_STATUS_RESET = 0xFFFFFC,
+};
+
+/* QUP OPERATIONAL FLAGS */
+enum {
+	QUP_OUT_SVC_FLAG = 1U << 8,
+	QUP_IN_SVC_FLAG = 1U << 9,
+	QUP_MX_INPUT_DONE = 1U << 11,
+};
+
+#endif				/* __QUP__ */

--- a/platform/msm_shared/include/qup.h
+++ b/platform/msm_shared/include/qup.h
@@ -31,6 +31,9 @@
 
 #include <stdint.h>
 
+#define MAX_READ_SPEED_HZ 9600000
+#define MAX_SPEED_HZ 50000000
+
 /* QUP_IO_MODES fields */
 #define QUP_IO_MODES_OUTPUT_BIT_SHIFT_EN  0x00010000
 #define QUP_IO_MODES_PACK_EN              0x00008000
@@ -89,6 +92,7 @@
  * And make the count be multiple of max bytes per word.
  */
 #define MAX_QUP_MX_OUTPUT_COUNT 0xFFF8
+#define MAX_QUP_MX_TRANSFER_COUNT 0xFFF8
 
 /* QUP Registers */
 enum {
@@ -104,6 +108,7 @@ enum {
 	QUP_HW_VERSION = 0x30,
 	QUP_MX_READ_CNT = 0x208,
 	QUP_MX_INPUT_CNT = 0x200,
+	QUP_MX_INPUT_CNT_CURRENT = 0x204,
 	QUP_MX_OUTPUT_CNT = 0x100,
 	QUP_MX_OUTPUT_CNT_CURRENT = 0x104,
 	QUP_OUTPUT_DEBUG = 0x108,

--- a/platform/msm_shared/include/regulator.h
+++ b/platform/msm_shared/include/regulator.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2015, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -30,6 +30,8 @@
 #ifndef __REGULATOR_H
 #define __REGULATOR_H
 
+#include <stdint.h>
+
 #define KEY_SOFTWARE_ENABLE                0x6E657773 // swen - software enable
 #define KEY_LDO_SOFTWARE_MODE              0X646D736C // lsmd - LDO software mode
 #define KEY_SMPS_SOFTWARE_MODE             0X646D7373 // ssmd - SMPS software mode
@@ -51,7 +53,14 @@
 #define LDOA_RES_TYPE 0x616F646C //aodl
 #define SMPS_RES_TYPE 0x61706D73 //apms
 
-void regulator_enable();
-void regulator_disable();
+#define REG_LDO2	BIT(1)
+#define REG_LDO6	BIT(5)
+#define REG_LDO12	BIT(11)
+#define REG_LDO14	BIT(13)
+#define REG_LDO17	BIT(16)
+#define REG_LDO28	BIT(27)
+
+void regulator_enable(uint32_t enable);
+void regulator_disable(uint32_t enable);
 
 #endif

--- a/platform/msm_shared/include/spi_qup.h
+++ b/platform/msm_shared/include/spi_qup.h
@@ -1,0 +1,113 @@
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of The Linux Foundation, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef  __SPI_QUP__
+#define  __SPI_QUP__
+
+#include <stdint.h>
+#include <qup.h>
+
+/* SPI_ERROR_FLAGS and SPI_ERROR_FLAGS_EN fields */
+#define SPI_ERROR_CLK_OVER_RUN		BIT(1)
+#define SPI_ERROR_CLK_UNDER_RUN		BIT(0)
+
+#define SPI_CONFIG                    0x0300
+#define SPI_IO_CONTROL                0x0304
+#define SPI_IO_MODES                  0x0008
+#define SPI_SW_RESET                  0x000C
+#define SPI_TIME_OUT_CURRENT          0x0014
+#define SPI_MX_OUTPUT_COUNT           0x0100
+#define SPI_MX_OUTPUT_CNT_CURRENT     0x0104
+#define SPI_MX_INPUT_COUNT            0x0200
+#define SPI_MX_INPUT_CNT_CURRENT      0x0204
+#define SPI_MX_READ_COUNT             0x0208
+#define SPI_MX_READ_CNT_CURRENT       0x020C
+#define SPI_OPERATIONAL               0x0018
+#define SPI_ERROR_FLAGS               0x001C
+#define SPI_ERROR_FLAGS_EN            0x0020
+#define SPI_DEASSERT_WAIT             0x0310
+#define SPI_OUTPUT_DEBUG              0x0108
+#define SPI_INPUT_DEBUG               0x0210
+#define SPI_TEST_CTRL                 0x0024
+#define SPI_OUTPUT_FIFO               0x0110
+#define SPI_INPUT_FIFO                0x0218
+#define SPI_STATE                     0x0004
+
+#define SPI_IO_C_NO_TRI_STATE		BIT(0)
+#define SPI_IO_C_CLK_ALWAYS_ON		BIT(9)
+#define SPI_IO_C_MX_CS_MODE			BIT(8)
+#define SPI_IO_C_CS0_ACTIVE_HIGH	BIT(4)
+#define SPI_IO_C_CS_SELECT_CS0		00 << 2
+#define SPI_IO_C_CLK_IDLE_HIGH		BIT(10)
+
+/* SPI_CONFIG fields */
+#define SPI_CONFIG_HS_MODE			BIT(10)
+#define SPI_CONFIG_INPUT_FIRST		BIT(9)
+#define SPI_CONFIG_LOOPBACK			BIT(8)
+
+#define DEFAULT_BYTES_PER_WORD	0x2
+
+#define BITS_PER_BYTE 	8
+
+#define EIO         5
+#define ENOMEM      12
+#define EBUSY       16
+#define ENODEV      19
+#define ENOSYS      38
+#define EPROTONOSUPPORT 93
+#define ETIMEDOUT   110
+
+struct spi_transfer {
+	const unsigned char	*tx_buf;
+	int	len;
+};
+
+/**
+ * qup_spi_dev - spi device config structure
+ * @ qup_base - base register address of QUP.
+ * @ qup_irq - irq number of QUP.
+ * @ tx_bytes - current transfered output data length in bytes
+ * @ bytes_per_word - bytes number per word write to FIFO, valid range [1-4]
+ * @ xfer - pointer to SPI transfer contents structure.
+ */
+struct qup_spi_dev {
+	unsigned int qup_base;
+	int qup_irq;
+	int tx_bytes;
+	unsigned int bytes_per_word;
+	unsigned int bit_shift_en;
+	unsigned int unpack_en;
+	struct spi_transfer *xfer;
+};
+
+/* Function Definitions */
+struct qup_spi_dev *qup_blsp_spi_init(uint8_t blsp_id, uint8_t qup_id);
+int qup_spi_deinit(struct qup_spi_dev *dev);
+int spi_qup_transfer(struct qup_spi_dev *dev, const unsigned char * tx_buf, unsigned int data_size);
+
+#endif				/* __SPI_QUP__ */

--- a/platform/msm_shared/include/spi_qup.h
+++ b/platform/msm_shared/include/spi_qup.h
@@ -64,6 +64,7 @@
 #define SPI_IO_C_CS0_ACTIVE_HIGH	BIT(4)
 #define SPI_IO_C_CS_SELECT_CS0		00 << 2
 #define SPI_IO_C_CLK_IDLE_HIGH		BIT(10)
+#define SPI_IO_C_FORCE_CS              BIT(11)
 
 /* SPI_CONFIG fields */
 #define SPI_CONFIG_HS_MODE			BIT(10)
@@ -85,6 +86,8 @@
 struct spi_transfer {
 	const unsigned char	*tx_buf;
 	int	len;
+	unsigned char *rx_buf;
+	unsigned int speed_hz;
 };
 
 /**
@@ -99,10 +102,14 @@ struct qup_spi_dev {
 	unsigned int qup_base;
 	int qup_irq;
 	int tx_bytes;
+	int rx_bytes;
 	unsigned int bytes_per_word;
 	unsigned int bit_shift_en;
 	unsigned int unpack_en;
 	struct spi_transfer *xfer;
+	unsigned int max_speed_hz;
+	uint8_t blsp_id;
+	uint8_t qup_id;
 };
 
 /* Function Definitions */

--- a/platform/msm_shared/include/splash.h
+++ b/platform/msm_shared/include/splash.h
@@ -33,7 +33,6 @@
 #define SPLASH_IMAGE_WIDTH     113
 #define SPLASH_IMAGE_HEIGHT    124
 
-#if (!DISPLAY_TYPE_MIPI)
 /* This image is (SPLASH_IMAGE_WIDTH x SPLASH_IMAGE_WIDTH) raw image */
 static char imageBuffer[] = {
 
@@ -3543,7 +3542,6 @@ static char imageBuffer[] = {
 
 };
 
-#else
 /* This image is 228x113 raw Image resembling QuIC logo*/
 
 static char imageBuffer_rgb888[] = {
@@ -8803,6 +8801,5 @@ static char imageBuffer_rgb888[] = {
 	0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00,
 };
-#endif
 
 #endif

--- a/platform/msm_shared/mdss_spi.c
+++ b/platform/msm_shared/mdss_spi.c
@@ -1,0 +1,173 @@
+/* Copyright (c) 2017-2018 The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <spi_qup.h>
+#include <msm_panel.h>
+#include <target/display.h>
+#include <platform/gpio.h>
+
+#define SUCCESS		0
+#define FAIL		1
+
+static struct qup_spi_dev *dev = NULL;
+
+static int mdss_spi_write_cmd(const char *buf)
+{
+	int ret = 0;
+
+	if (!dev) {
+		dprintf(CRITICAL, "SPI has not been initialized\n");
+		return -ENODEV;
+	}
+
+	dev->bytes_per_word = 1;
+	dev->bit_shift_en = 1;
+
+	gpio_set(spi_dc_gpio.pin_id, 0);
+	ret = spi_qup_transfer(dev, buf, 1);
+	gpio_set(spi_dc_gpio.pin_id, 2);
+	if (ret)
+		dprintf(CRITICAL, "Send SPI command to panel failed\n");
+
+	return ret;
+}
+
+static int mdss_spi_write_data(const char *buf, size_t len)
+{
+	int ret = 0;
+
+	if (!dev) {
+		dprintf(CRITICAL, "SPI has not been initialized\n");
+		return -ENODEV;
+	}
+
+	dev->bytes_per_word = 1;
+	dev->bit_shift_en = 1;
+
+	gpio_set(spi_dc_gpio.pin_id, 2);
+	ret = spi_qup_transfer(dev, buf, len);
+	if (ret)
+		dprintf(CRITICAL, "Send SPI parameters to panel failed\n");
+
+	return ret;
+}
+
+static int mdss_spi_write_frame(const char *buf, size_t len)
+{
+	int ret = 0;
+
+	if (!dev) {
+		dprintf(CRITICAL, "SPI has not been initialized\n");
+		return -ENODEV;
+	}
+
+	dev->bytes_per_word = 2;
+	dev->bit_shift_en = 1;
+	dev->unpack_en = 0;
+
+	gpio_set(spi_dc_gpio.pin_id, 2);
+	ret = spi_qup_transfer(dev, buf, len);
+
+	return ret;
+}
+
+static void spi_read_panel_data(unsigned char *buf,  int len)
+{
+	int ret = 0;
+
+	if (!dev) {
+		 dprintf(CRITICAL, "SPI has not been initialized\n");
+		 return -ENODEV;
+	}
+	dev->bytes_per_word = 1;
+	dev->bit_shift_en = 1;
+
+	gpio_set(spi_dc_gpio.pin_id, 0);
+	ret = spi_qup_transfer(dev, buf, len);
+	gpio_set(spi_dc_gpio.pin_id, 2);
+
+	if (ret)
+		dprintf(CRITICAL, "Send SPI command to panel failed\n");
+
+	return;
+}
+
+int mdss_spi_init(void)
+{
+	if (!dev) {
+		dev = qup_blsp_spi_init(SPI_BLSP_ID, SPI_QUP_ID);
+		if (!dev) {
+			dprintf(CRITICAL, "Failed initializing SPI\n");
+			return -ENODEV;
+		}
+	}
+
+	gpio_tlmm_config(spi_dc_gpio.pin_id, 0, spi_dc_gpio.pin_direction,
+			spi_dc_gpio.pin_pull, spi_dc_gpio.pin_strength,
+			spi_dc_gpio.pin_state);
+	return SUCCESS;
+}
+
+int mdss_spi_panel_init(struct msm_panel_info *pinfo)
+{
+	int cmd_count = 0;
+	int ret = 0;
+
+	while (cmd_count < pinfo->spi.num_of_panel_cmds) {
+		if (pinfo->spi.panel_cmds[cmd_count].cmds_post_tg){
+			cmd_count ++;
+			continue;
+		}
+
+		mdss_spi_write_cmd(pinfo->spi.panel_cmds[cmd_count].payload);
+		if (pinfo->spi.panel_cmds[cmd_count].size > 1)
+			mdss_spi_write_data(
+				pinfo->spi.panel_cmds[cmd_count].payload + 1,
+				pinfo->spi.panel_cmds[cmd_count].size - 1);
+
+		if (pinfo->spi.panel_cmds[cmd_count].wait)
+			mdelay(pinfo->spi.panel_cmds[cmd_count].wait);
+
+		cmd_count ++;
+	}
+	return SUCCESS;
+}
+
+int mdss_spi_on(struct msm_panel_info *pinfo, struct fbcon_config *fb)
+{
+	int buf_size = 0;
+	int ret = 0;
+
+	buf_size =  fb->width * fb->height * (fb->bpp / 8);
+	ret = mdss_spi_write_frame(fb->base, buf_size);
+	if (ret)
+		dprintf(CRITICAL, "Send SPI frame data to panel failed\n");
+
+	return ret;
+}

--- a/platform/msm_shared/qpic.c
+++ b/platform/msm_shared/qpic.c
@@ -1,0 +1,327 @@
+/* Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name of The Linux Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <debug.h>
+#include <err.h>
+#include <msm_panel.h>
+#include <platform/iomap.h>
+#include <reg.h>
+
+#include "qpic.h"
+#include "qpic_panel.h"
+
+int mdss_qpic_panel_init(struct qpic_panel_io_desc *panel_io);
+
+struct qpic_data_type qpic_data;
+struct qpic_data_type *qpic_res = &qpic_data;
+static int qpic_send_pkt_sw(uint32_t cmd, uint32_t len, uint8_t *param);
+
+/* for debugging */
+static uint32_t use_bam = false;
+static uint32_t use_irq = false;
+static uint32_t use_vsync;
+
+/* For compilation */
+void mdp_set_revision(int rev)
+{
+    return;
+}
+
+int qpic_on(void)
+{
+	int ret;
+	ret = mdss_qpic_panel_on(&qpic_res->panel_io);
+	return ret;
+}
+
+int qpic_off(void)
+{
+	int ret = NO_ERROR;
+
+	if (!target_cont_splash_screen()) {
+		ret = mdss_qpic_panel_off(&qpic_res->panel_io);
+	}
+
+	return ret;
+}
+
+void qpic_update()
+{
+	uint32_t fb_offset, size;
+
+	if (use_bam)
+		fb_offset = qpic_res->fb_phys + qpic_res->base;
+	else
+		fb_offset = qpic_res->fb_virt + qpic_res->base;
+
+	size = qpic_res->fb_xres * qpic_res->fb_yres * qpic_res->fb_bpp;
+
+	qpic_send_frame(0, 0, qpic_res->fb_xres - 1, qpic_res->fb_yres - 1,
+		(uint32_t *)fb_offset, size);
+}
+
+int mdss_qpic_alloc_fb_mem(struct msm_panel_info *pinfo, int base)
+{
+	qpic_res->fb_virt = 0;
+	qpic_res->fb_phys = 0;
+	qpic_res->fb_xres = pinfo->xres;
+	qpic_res->fb_yres = pinfo->yres;
+	qpic_res->fb_bpp = pinfo->bpp / 8;
+	qpic_res->base = base;
+
+	return 0;
+}
+
+void qpic_init(struct msm_panel_info *pinfo, int base)
+{
+	if (qpic_res->res_init)
+		return;
+
+	qpic_res->qpic_base = QPIC_BASE;
+	mdss_qpic_panel_init(&qpic_res->panel_io);
+	mdss_qpic_alloc_fb_mem(pinfo, base);
+	qpic_res->res_init = true;
+}
+
+int qpic_init_sps(void)
+{
+	return 0;
+}
+
+void mdss_qpic_reset(void)
+{
+	uint32_t cnt = 0;
+
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_RESET, 1 << 0);
+	/* wait 100 us after reset as suggested by hw */
+	udelay(100);
+	while (((QPIC_INP(QPIC_REG_QPIC_LCDC_STTS) & (1 << 8)) == 0)) {
+		if (cnt > QPIC_MAX_WAIT_CNT) {
+			dprintf(CRITICAL, "%s reset not finished\n", __func__);
+			break;
+		}
+		/* yield 100 us for next polling by experiment*/
+		udelay(100);
+		cnt++;
+	}
+}
+
+static int qpic_send_pkt_bam(uint32_t cmd, uint32_t len, uint8_t *param)
+{
+	return qpic_send_pkt_sw(cmd, len, param);
+}
+
+static void qpic_dump_reg(void)
+{
+	dprintf(INFO, "%s\n", __func__);
+	dprintf(INFO, "QPIC_REG_QPIC_LCDC_CTRL = %x\n",
+		QPIC_INP(QPIC_REG_QPIC_LCDC_CTRL));
+	dprintf(INFO, "QPIC_REG_QPIC_LCDC_CMD_DATA_CYCLE_CNT = %x\n",
+		QPIC_INP(QPIC_REG_QPIC_LCDC_CMD_DATA_CYCLE_CNT));
+	dprintf(INFO, "QPIC_REG_QPIC_LCDC_CFG0 = %x\n",
+		QPIC_INP(QPIC_REG_QPIC_LCDC_CFG0));
+	dprintf(INFO, "QPIC_REG_QPIC_LCDC_CFG1 = %x\n",
+		QPIC_INP(QPIC_REG_QPIC_LCDC_CFG1));
+	dprintf(INFO, "QPIC_REG_QPIC_LCDC_CFG2 = %x\n",
+		QPIC_INP(QPIC_REG_QPIC_LCDC_CFG2));
+	dprintf(INFO, "QPIC_REG_QPIC_LCDC_IRQ_EN = %x\n",
+		QPIC_INP(QPIC_REG_QPIC_LCDC_IRQ_EN));
+	dprintf(INFO, "QPIC_REG_QPIC_LCDC_IRQ_STTS = %x\n",
+		QPIC_INP(QPIC_REG_QPIC_LCDC_IRQ_STTS));
+	dprintf(INFO, "QPIC_REG_QPIC_LCDC_STTS = %x\n",
+		QPIC_INP(QPIC_REG_QPIC_LCDC_STTS));
+	dprintf(INFO, "QPIC_REG_QPIC_LCDC_FIFO_SOF = %x\n",
+		QPIC_INP(QPIC_REG_QPIC_LCDC_FIFO_SOF));
+}
+
+static int qpic_wait_for_fifo(void)
+{
+	uint32_t data, cnt = 0;
+	int ret = 0;
+
+	while (1) {
+		data = QPIC_INP(QPIC_REG_QPIC_LCDC_STTS);
+		data &= 0x3F;
+		if (data == 0)
+			break;
+		/* yield 10 us for next polling by experiment*/
+		udelay(10);
+		if (cnt > (QPIC_MAX_WAIT_CNT * 10)) {
+			dprintf(CRITICAL, "%s time out\n", __func__);
+			ret = -1;
+			break;
+		}
+		cnt++;
+	}
+	return ret;
+}
+
+static int qpic_wait_for_eof(void)
+{
+	uint32_t data, cnt = 0;
+	int ret = 0;
+
+	while (1) {
+		data = QPIC_INP(QPIC_REG_QPIC_LCDC_IRQ_STTS);
+		if (data & (1 << 2))
+			break;
+		/* yield 10 us for next polling by experiment*/
+		udelay(10);
+		if (cnt > (QPIC_MAX_WAIT_CNT * 10)) {
+			dprintf(CRITICAL, "%s wait for eof time out\n", __func__);
+			qpic_dump_reg();
+			ret = -1;
+			break;
+		}
+		cnt++;
+	}
+	return ret;
+}
+
+static int qpic_send_pkt_sw(uint32_t cmd, uint32_t len, uint8_t *param)
+{
+	uint32_t bytes_left, space, data, cfg2;
+	int i, ret = 0;
+
+	if (len && !param) {
+		dprintf(CRITICAL, "Null Pointer!\n");
+		return 0;
+	}
+	if (len <= 4) {
+		len = (len + 3) / 4; /* len in dwords */
+		data = 0;
+		for (i = 0; i < len; i++)
+			data |= (uint32_t)param[i] << (8 * i);
+		QPIC_OUTP(QPIC_REG_QPIC_LCDC_CMD_DATA_CYCLE_CNT, len);
+		QPIC_OUTP(QPIC_REG_LCD_DEVICE_CMD0 + (4 * cmd), data);
+		return 0;
+	}
+
+	if ((len & 0x1) != 0) {
+		dprintf(INFO, "%s: number of bytes needs be even\n", __func__);
+		len = (len + 1) & (~0x1);
+	}
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_IRQ_CLR, 0xff);
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_CMD_DATA_CYCLE_CNT, 0);
+	cfg2 = QPIC_INP(QPIC_REG_QPIC_LCDC_CFG2);
+	if ((cmd != OP_WRITE_MEMORY_START) &&
+		(cmd != OP_WRITE_MEMORY_CONTINUE))
+		cfg2 |= (1 << 24); /* transparent mode */
+	else
+		cfg2 &= ~(1 << 24);
+
+	cfg2 &= ~0xFF;
+	cfg2 |= cmd;
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_CFG2, cfg2);
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_FIFO_SOF, 0x0);
+	bytes_left = len;
+
+	while (bytes_left > 0) {
+		ret = qpic_wait_for_fifo();
+		if (ret)
+			goto exit_send_cmd_sw;
+
+		space = 16;
+
+		while ((space > 0) && (bytes_left > 0)) {
+			/* write to fifo */
+			if (bytes_left >= 4) {
+				QPIC_OUTP(QPIC_REG_QPIC_LCDC_FIFO_DATA_PORT0,
+					*(uint32_t *)param);
+				param += 4;
+				bytes_left -= 4;
+				space--;
+			} else if (bytes_left == 2) {
+				QPIC_OUTPW(QPIC_REG_QPIC_LCDC_FIFO_DATA_PORT0,
+					*(uint16_t *)param);
+				bytes_left -= 2;
+			}
+		}
+	}
+	/* finished */
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_FIFO_EOF, 0x0);
+	ret = qpic_wait_for_eof();
+exit_send_cmd_sw:
+	cfg2 &= ~(1 << 24);
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_CFG2, cfg2);
+	return ret;
+}
+
+int qpic_send_pkt(uint32_t cmd, uint8_t *param, uint32_t len)
+{
+	if (!use_bam || ((cmd != OP_WRITE_MEMORY_CONTINUE) &&
+		(cmd != OP_WRITE_MEMORY_START)))
+		return qpic_send_pkt_sw(cmd, len, param);
+	else
+		return qpic_send_pkt_bam(cmd, len, param);
+}
+
+int mdss_qpic_init(void)
+{
+	int ret = 0;
+	uint32_t data;
+	mdss_qpic_reset();
+
+	data = QPIC_INP(QPIC_REG_QPIC_LCDC_CTRL);
+	/* clear vsync wait , bam mode = 0 */
+	data &= ~(3 << 0);
+	data &= ~(0x1f << 3);
+	data |= (1 << 3); /* threshold */
+	data |= (1 << 8); /* lcd_en */
+	data &= ~(0x1f << 9);
+	data |= (1 << 9); /* threshold */
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_CTRL, data);
+
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_CFG0, 0x02108501);
+	data = QPIC_INP(QPIC_REG_QPIC_LCDC_CFG2);
+	data &= ~(0xFFF);
+	data |= 0x0; /* 565 */
+	data |= 0x2C;
+	QPIC_OUTP(QPIC_REG_QPIC_LCDC_CFG2, data);
+
+	/* TE enable */
+	if (use_vsync) {
+		data = QPIC_INP(QPIC_REG_QPIC_LCDC_CTRL);
+		data |= (1 << 0);
+		QPIC_OUTP(QPIC_REG_QPIC_LCDC_CTRL, data);
+	}
+
+	return ret;
+}
+
+uint32_t qpic_read_data(uint32_t cmd_index, uint32_t size)
+{
+	uint32_t data = 0;
+	if (size <= 4) {
+		QPIC_OUTP(QPIC_REG_QPIC_LCDC_CMD_DATA_CYCLE_CNT, size);
+		data = QPIC_INP(QPIC_REG_LCD_DEVICE_CMD0 + (cmd_index * 4));
+	}
+	return data;
+}
+

--- a/platform/msm_shared/qpic_panel.c
+++ b/platform/msm_shared/qpic_panel.c
@@ -1,0 +1,132 @@
+/* Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name of The Linux Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <debug.h>
+#include <err.h>
+#include <msm_panel.h>
+#include <platform/gpio.h>
+#include "qpic.h"
+#include "qpic_panel.h"
+#include <reg.h>
+
+static uint32_t panel_is_on;
+
+static int (*qpic_panel_on)(struct qpic_panel_io_desc *qpic_panel_io);
+static void (*qpic_panel_off)(struct qpic_panel_io_desc *qpic_panel_io);
+
+
+/* write a frame of pixels to a MIPI screen */
+uint32_t qpic_send_frame(uint32_t x_start,
+				uint32_t y_start,
+				uint32_t x_end,
+				uint32_t y_end,
+				uint32_t *data,
+				uint32_t total_bytes)
+{
+	uint8_t param[4];
+	uint32_t status;
+	uint32_t start_0_7;
+	uint32_t end_0_7;
+	uint32_t start_8_15;
+	uint32_t end_8_15;
+
+	/* convert to 16 bit representation */
+	x_start = x_start & 0xffff;
+	y_start = y_start & 0xffff;
+	x_end = x_end & 0xffff;
+	y_end = y_end & 0xffff;
+
+	/* set column/page */
+	start_0_7 = x_start & 0xff;
+	end_0_7 = x_end & 0xff;
+	start_8_15 = (x_start >> 8) & 0xff;
+	end_8_15 = (x_end >> 8) & 0xff;
+	param[0] = start_8_15;
+	param[1] = start_0_7;
+	param[2] = end_8_15;
+	param[3] = end_0_7;
+	status = qpic_send_pkt(OP_SET_COLUMN_ADDRESS, param, 4);
+	if (status) {
+		dprintf(CRITICAL, "Failed to set column address\n");
+		return status;
+	}
+
+	start_0_7 = y_start & 0xff;
+	end_0_7 = y_end & 0xff;
+	start_8_15 = (y_start >> 8) & 0xff;
+	end_8_15 = (y_end >> 8) & 0xff;
+	param[0] = start_8_15;
+	param[1] = start_0_7;
+	param[2] = end_8_15;
+	param[3] = end_0_7;
+	status = qpic_send_pkt(OP_SET_PAGE_ADDRESS, param, 4);
+	if (status) {
+		dprintf(CRITICAL, "Failed to set page address\n");
+		return status;
+	}
+
+	status = qpic_send_pkt(OP_WRITE_MEMORY_START, (uint8_t *)data, total_bytes);
+	if (status) {
+		dprintf(CRITICAL, "Failed to start memory write\n");
+		return status;
+	}
+	return 0;
+}
+
+int mdss_qpic_panel_on(struct qpic_panel_io_desc *panel_io)
+{
+	int rc = 0;
+
+	if (panel_is_on)
+		return 0;
+	mdss_qpic_init();
+
+	if (qpic_panel_on)
+		rc = qpic_panel_on(panel_io);
+
+	if (!rc)
+		panel_is_on = true;
+
+	return rc;
+}
+
+int mdss_qpic_panel_off(struct qpic_panel_io_desc *panel_io)
+{
+	if (qpic_panel_off)
+		qpic_panel_off(panel_io);
+
+	panel_is_on = false;
+	return 0;
+}
+
+int mdss_qpic_panel_init(struct qpic_panel_io_desc *panel_io)
+{
+	return 0;
+}
+

--- a/platform/msm_shared/rules.mk
+++ b/platform/msm_shared/rules.mk
@@ -498,7 +498,8 @@ DEFINES += DISPLAY_TYPE_MDSS=1
 			$(LOCAL_DIR)/certificate.o \
 			$(LOCAL_DIR)/image_verify.o \
 			$(LOCAL_DIR)/i2c_qup.o \
-                        $(LOCAL_DIR)/qseecom_lk.o \
+			$(LOCAL_DIR)/spi_qup.o \
+            $(LOCAL_DIR)/qseecom_lk.o \
 			$(LOCAL_DIR)/mdp3.o \
 			$(LOCAL_DIR)/display.o \
 			$(LOCAL_DIR)/mipi_dsi.o \

--- a/platform/msm_shared/rules.mk
+++ b/platform/msm_shared/rules.mk
@@ -504,7 +504,8 @@ DEFINES += DISPLAY_TYPE_MDSS=1
 			$(LOCAL_DIR)/display.o \
 			$(LOCAL_DIR)/mipi_dsi.o \
 			$(LOCAL_DIR)/mipi_dsi_phy.o \
-			$(LOCAL_DIR)/mipi_dsi_autopll.o
+			$(LOCAL_DIR)/mipi_dsi_autopll.o \
+			$(LOCAL_DIR)/mdss_spi.o
 endif
 
 

--- a/platform/msm_shared/rules.mk
+++ b/platform/msm_shared/rules.mk
@@ -343,6 +343,7 @@ ifeq ($(PLATFORM),mdm9x25)
 endif
 
 ifeq ($(PLATFORM),mdm9x35)
+DEFINES += DISPLAY_TYPE_QPIC=1
 	OBJS += $(LOCAL_DIR)/qgic.o \
 			$(LOCAL_DIR)/uart_dm.o \
 			$(LOCAL_DIR)/interrupts.o \
@@ -357,7 +358,10 @@ ifeq ($(PLATFORM),mdm9x35)
 			$(LOCAL_DIR)/clock.o \
 			$(LOCAL_DIR)/clock_pll.o \
 			$(LOCAL_DIR)/clock_lib2.o \
-			$(LOCAL_DIR)/qmp_usb30_phy.o
+			$(LOCAL_DIR)/qmp_usb30_phy.o \
+			$(LOCAL_DIR)/display.o \
+			$(LOCAL_DIR)/qpic.o \
+			$(LOCAL_DIR)/qpic_panel.o
 endif
 
 ifeq ($(PLATFORM),msmzirc)

--- a/platform/msm_shared/spi_qup.c
+++ b/platform/msm_shared/spi_qup.c
@@ -1,0 +1,449 @@
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of The Linux Foundation, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * QUP spi driver for Qualcomm MSM platforms
+ *
+ */
+
+#include <debug.h>
+#include <arch/arm.h>
+#include <reg.h>
+#include <kernel/thread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <gsbi.h>
+#include <spi_qup.h>
+#include <platform/irqs.h>
+#include <platform/iomap.h>
+#include <platform/gpio.h>
+#include <platform/clock.h>
+#include <platform/timer.h>
+#include <platform/interrupts.h>
+
+//#define DEBUGLEVEL 3
+
+static unsigned int spi_get_qup_hw_ver(struct qup_spi_dev *dev)
+{
+	unsigned int data = readl_relaxed(dev->qup_base + QUP_HW_VERSION);
+
+	dprintf(SPEW, "Qup hardware version is 0x%x\n", data);
+	return data;
+}
+
+static void qup_print_status(struct qup_spi_dev *dev)
+{
+	unsigned val;
+	val = readl(dev->qup_base + QUP_CONFIG);
+	dprintf(SPEW, "Qup config is :0x%x\n", val);
+	val = readl(dev->qup_base + QUP_STATE);
+	dprintf(SPEW, "Qup state is :0x%x\n", val);
+	val = readl(dev->qup_base + QUP_IO_MODES);
+	dprintf(SPEW, "Qup mode is :0x%x\n", val);
+	val = readl(dev->qup_base + SPI_IO_CONTROL);
+	dprintf(SPEW, "SPI_IO_CONTROL is :0x%x\n", val);
+	val = readl(dev->qup_base + SPI_CONFIG);
+	dprintf(SPEW, "SPI_CONFIG is :0x%x\n", val);
+	val = readl(dev->qup_base + QUP_MX_WRITE_CNT_CURRENT);
+	dprintf(SPEW, "QUP_MX_WRITE_CNT_CURRENT is :0x%x\n", val);
+	val = readl(dev->qup_base + QUP_MX_WRITE_CNT);
+	dprintf(SPEW, "QUP_MX_WRITE_CNT is :0x%x\n", val);
+	val = readl(dev->qup_base + QUP_MX_OUTPUT_CNT_CURRENT);
+	dprintf(SPEW, "QUP_MX_OUTPUT_CNT_CURRENT is :0x%x\n", val);
+	val = readl(dev->qup_base + QUP_MX_OUTPUT_CNT);
+	dprintf(SPEW, "QUP_MX_OUTPUT_CNT is :0x%x\n", val);
+	val = readl(dev->qup_base + QUP_OPERATIONAL);
+	dprintf(SPEW, "QUP_OPERATIONAL is :0x%x\n", val);
+	val = readl(dev->qup_base + QUP_OUTPUT_FIFO_WORD_CNT);
+	dprintf(SPEW, "QUP_OUTPUT_FIFO_WORD_CNT is :0x%x\n", val);
+}
+
+static inline bool qup_state_is_valid(struct qup_spi_dev *dev)
+{
+	unsigned int st = readl_relaxed(dev->qup_base + QUP_STATE);
+
+	return st & QUP_STATE_VALID;
+}
+
+static inline int qup_wait_state_valid(struct qup_spi_dev *dev)
+{
+	unsigned retries = 0xFFFF;
+
+	while (!qup_state_is_valid(dev) && (--retries != 0));
+
+	if(!retries)
+		return -ETIMEDOUT;
+
+	return 0;
+}
+
+static int qup_poll_state(struct qup_spi_dev *dev, unsigned state)
+{
+	int ret = 0;
+	unsigned int status;
+
+	ret = qup_wait_state_valid(dev);
+
+	if(ret)
+		goto exit;
+
+	status = readl(dev->qup_base + QUP_STATE);
+	if ((status & (QUP_STATE_VALID | state)) ==
+		(QUP_STATE_VALID | state))
+			return 0;
+
+exit:
+	dprintf(SPEW, "Polling fail for state:0x%x\n", state);
+	qup_print_status(dev);
+	return ret;
+}
+
+static inline int qup_set_state(struct qup_spi_dev *dev,
+				    enum qup_state state)
+{
+	enum qup_state cur_state;
+
+	if (qup_wait_state_valid(dev)) {
+		qup_print_status(dev);
+		return -EIO;
+	}
+
+	cur_state = readl_relaxed(dev->qup_base + QUP_STATE);
+
+	/* For PAUSE_STATE to RESET_STATE,
+	 * two writes of (0b10) are required.
+	 */
+	if (((cur_state & QUP_STATE_MASK) == QUP_PAUSE_STATE) &&
+			(state == QUP_RESET_STATE)) {
+		writel(QUP_STATE_CLEAR_BITS, dev->qup_base + QUP_STATE);
+		writel(QUP_STATE_CLEAR_BITS, dev->qup_base + QUP_STATE);
+	} else {
+		writel((cur_state & ~QUP_STATE_MASK) | state,
+		       dev->qup_base + QUP_STATE);
+	}
+
+	if (qup_poll_state(dev, state)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static inline void qup_register_init(struct qup_spi_dev *dev)
+{
+	/* Initialize QUP registers */
+	qup_set_state(dev, QUP_RESET_STATE);
+	writel(0x00000001, dev->qup_base + QUP_SW_RESET);
+	qup_wait_state_valid(dev);
+	qup_set_state(dev, QUP_RESET_STATE);
+
+	writel(0x00000000, dev->qup_base + QUP_CONFIG);
+	writel(0x00000000, dev->qup_base + QUP_IO_MODES);
+	writel(0xfff0, dev->qup_base + QUP_OPERATIONAL);
+	writel(0x7e, dev->qup_base + QUP_ERROR_FLAGS);
+	writel(0x00000000, dev->qup_base + QUP_TEST_CTRL);
+	writel(0x00000000, dev->qup_base + QUP_OPERATIONAL_MASK);
+	writel(0x0, dev->qup_base + QUP_MX_INPUT_CNT);
+	writel(0x1, dev->qup_base + QUP_MX_OUTPUT_CNT);
+	writel(0x0, dev->qup_base + QUP_MX_READ_CNT);
+}
+
+static inline void spi_register_init(struct qup_spi_dev *dev)
+{
+	/* Set SPI mini core to QUP config */
+	writel(QUP_CONFIG_SPI_MODE | QUP_CONFIG_NO_INPUT, dev->qup_base + QUP_CONFIG);
+
+	/* Initialize SPI mini core registers */
+	writel(0, dev->qup_base + SPI_CONFIG);
+	writel(SPI_IO_C_NO_TRI_STATE | SPI_IO_C_CS_SELECT_CS0 | SPI_IO_C_CLK_IDLE_HIGH,
+		dev->qup_base + SPI_IO_CONTROL);
+	writel(SPI_ERROR_CLK_OVER_RUN | SPI_ERROR_CLK_UNDER_RUN, dev->qup_base + SPI_ERROR_FLAGS_EN);
+	writel(0, dev->qup_base + SPI_DEASSERT_WAIT);
+
+	qup_print_status(dev);
+}
+
+static void spi_qup_io_config_block(struct qup_spi_dev *dev, int len)
+{
+	unsigned int config, iomode, mode;
+	unsigned int bits_per_word;
+
+	qup_register_init(dev);
+	spi_register_init(dev);
+
+	/* bytes_per_word valid range is [1-4].
+	 * Other value may not working as expected.
+	 */
+	dev->bytes_per_word = dev->bytes_per_word % 5;
+
+	/* If bytes_per_word not given, use DEFAULT_BYTES_PER_WORD.
+	 */
+	if(!dev->bytes_per_word)
+		dev->bytes_per_word = DEFAULT_BYTES_PER_WORD;
+
+	bits_per_word = dev->bytes_per_word * 8 - 1;
+
+	writel(len / dev->bytes_per_word, dev->qup_base + QUP_MX_OUTPUT_CNT);
+	writel(0, dev->qup_base + QUP_MX_INPUT_CNT);
+	writel(0, dev->qup_base + QUP_MX_READ_CNT);
+	writel(0, dev->qup_base + QUP_MX_WRITE_CNT);
+
+	mode = QUP_IO_MODES_BLOCK;
+	iomode = readl_relaxed(dev->qup_base + QUP_IO_MODES);
+	iomode &= ~(INPUT_MODE_MASK | OUTPUT_MODE_MASK);
+	if(dev->unpack_en)
+		iomode |= QUP_IO_MODES_UNPACK_EN;
+	else
+		iomode &= ~QUP_IO_MODES_UNPACK_EN;
+	iomode |= (mode << OUTPUT_MODE_SHIFT);
+	iomode |= (mode << INPUT_MODE_SHIFT);
+	if(dev->bit_shift_en)
+		iomode |= QUP_IO_MODES_OUTPUT_BIT_SHIFT_EN;
+	else
+		iomode &= ~QUP_IO_MODES_OUTPUT_BIT_SHIFT_EN;
+	writel(iomode, dev->qup_base + QUP_IO_MODES);
+
+	config = readl_relaxed(dev->qup_base + QUP_CONFIG);
+	config |= QUP_CONFIG_NO_INPUT;
+	config |= QUP_CONFIG_SPI_MODE;
+	config |= bits_per_word;
+	writel(config, dev->qup_base + QUP_CONFIG);
+
+	writel(0, dev->qup_base + QUP_OPERATIONAL_MASK);
+
+	unmask_interrupt(dev->qup_irq);
+}
+
+static void spi_qup_fifo_write(struct qup_spi_dev *dev, struct spi_transfer *xfer)
+{
+	const unsigned char *tx_buf = xfer->tx_buf;
+	unsigned int word, state, data;
+	unsigned int idx;
+
+	while (dev->tx_bytes < xfer->len) {
+
+		state = readl_relaxed(dev->qup_base + QUP_OPERATIONAL);
+		if (state & QUP_OP_OUT_FIFO_FULL)
+		{
+			dprintf(SPEW, "%s: oper QUP_OP_OUT_FIFO_FULL: 0x%x"
+				"dev->tx_bytes:0x%x, xfer->len:0x%x\n",
+				__func__, state, dev->tx_bytes, xfer->len);
+			break;
+		}
+
+		word = 0;
+		for (idx = 0; idx < dev->bytes_per_word; idx++, dev->tx_bytes++) {
+
+			if (!tx_buf) {
+				dprintf(CRITICAL, "%s: tx_buf null error.\n", __func__);
+				dev->tx_bytes += dev->bytes_per_word;
+				break;
+			}
+			data = dev->tx_bytes < xfer->len ? tx_buf[dev->tx_bytes] : 0;
+			word |= data << (BITS_PER_BYTE * idx);
+		}
+
+		writel(word, dev->qup_base + QUP_OUTPUT_FIFO_BASE);
+	}
+}
+
+int _spi_qup_transfer(struct qup_spi_dev *dev, struct spi_transfer *xfer)
+{
+	int ret = -EIO;
+	int retries = 0xFF;
+	unsigned val;
+
+	dev->xfer     = xfer;
+	dev->tx_bytes = 0;
+
+	spi_qup_io_config_block(dev, xfer->len);
+
+	ret = qup_set_state(dev, QUP_RUN_STATE);
+	if (ret) {
+		dprintf(CRITICAL, "%s: cannot set first RUN state\n", __func__);
+		goto exit;
+	}
+
+	while((readl(dev->qup_base + QUP_MX_OUTPUT_CNT)
+		!= readl(dev->qup_base + QUP_MX_OUTPUT_CNT_CURRENT))
+		&& retries--);
+
+	while(readl(dev->qup_base + QUP_MX_OUTPUT_CNT_CURRENT) ) {
+		val = readl(dev->qup_base + QUP_OPERATIONAL);
+		val &= ~QUP_OP_OUT_SERVICE_FLAG;
+		writel(val, dev->qup_base + QUP_OPERATIONAL);
+
+		ret = qup_set_state(dev, QUP_PAUSE_STATE);
+		if (ret) {
+			dprintf(CRITICAL, "%s: cannot set PAUSE state\n", __func__);
+			goto exit;
+		}
+
+		spi_qup_fifo_write(dev, xfer);
+
+		ret = qup_set_state(dev, QUP_RUN_STATE);
+		if (ret) {
+			dprintf(CRITICAL, "%s: cannot set RUN state\n", __func__);
+			goto exit;
+		}
+	}
+	dprintf(SPEW, "dev->tx_bytes:0x%x, xfer->len:0x%x\n",
+		dev->tx_bytes, xfer->len);
+
+exit:
+	qup_set_state(dev, QUP_RESET_STATE);
+	dev->xfer = NULL;
+	return ret;
+}
+
+/**
+ * @brief Transfer data_size bytes data from tx_buf via spi
+ * @param dev		SPI config structure initialized from qup_blsp_spi_init
+ * @param tx_buf	output buffer pointer
+ * @param data_size	Should be multiple of max bytes per word
+ */
+int spi_qup_transfer(struct qup_spi_dev *dev, const unsigned char * tx_buf, unsigned int data_size)
+{
+	unsigned int cur = 0;
+	struct spi_transfer s_xfer;
+	int ret = -EIO;
+
+	if(!tx_buf)
+		return ret;
+
+	while(data_size > MAX_QUP_MX_OUTPUT_COUNT + cur) {
+		s_xfer.len = MAX_QUP_MX_OUTPUT_COUNT;
+		s_xfer.tx_buf = tx_buf + cur;
+
+		ret = _spi_qup_transfer(dev, &s_xfer);
+		if (ret)
+			goto exit;
+
+		cur += MAX_QUP_MX_OUTPUT_COUNT;
+	}
+
+	s_xfer.len = data_size - cur;
+	s_xfer.tx_buf = tx_buf + cur;
+	ret = _spi_qup_transfer(dev, &s_xfer);
+	if (ret)
+			goto exit;
+	return ret;
+
+exit:
+	dprintf(CRITICAL, "%s: transfer error!\n", __func__);
+	return ret;
+}
+
+static enum handler_return qup_spi_interrupt(void *arg)
+{
+	struct qup_spi_dev *dev = (struct qup_spi_dev *)arg;
+	unsigned int opflags, qup_err, spi_err;
+
+	if (!dev) {
+		dprintf(CRITICAL,
+			"dev_addr is NULL, that means spi_qup_init failed...\n");
+		return INT_NO_RESCHEDULE;
+	}
+
+	qup_err = readl_relaxed(dev->qup_base + QUP_ERROR_FLAGS);
+	spi_err = readl_relaxed(dev->qup_base + SPI_ERROR_FLAGS);
+	opflags = readl_relaxed(dev->qup_base + QUP_OPERATIONAL);
+
+	/* Writing a 'one' to the error bit to clear it. */
+	writel(qup_err, dev->qup_base + QUP_ERROR_FLAGS);
+	writel(spi_err, dev->qup_base + SPI_ERROR_FLAGS);
+	writel(opflags, dev->qup_base + QUP_OPERATIONAL);
+
+	if (qup_err) {
+		if (qup_err & QUP_ERROR_OUTPUT_OVER_RUN)
+			dprintf(SPEW, "OUTPUT_OVER_RUN\n");
+		if (qup_err & QUP_ERROR_INPUT_UNDER_RUN)
+			dprintf(SPEW, "INPUT_UNDER_RUN\n");
+		if (qup_err & QUP_ERROR_OUTPUT_UNDER_RUN)
+			dprintf(SPEW, "OUTPUT_UNDER_RUN\n");
+		if (qup_err & QUP_ERROR_INPUT_OVER_RUN)
+			dprintf(SPEW, "INPUT_OVER_RUN\n");
+	}
+
+	if (spi_err) {
+		if (spi_err & SPI_ERROR_CLK_OVER_RUN)
+			dprintf(SPEW, "CLK_OVER_RUN\n");
+		if (spi_err & SPI_ERROR_CLK_UNDER_RUN)
+			dprintf(SPEW, "CLK_UNDER_RUN\n");
+	}
+
+	return INT_NO_RESCHEDULE;
+}
+
+static void qup_spi_sec_init(struct qup_spi_dev *dev)
+{
+	/* Get qup hw version */
+	spi_get_qup_hw_ver(dev);
+
+	qup_register_init(dev);
+	spi_register_init(dev);
+
+	/* Register the GSBIn QUP IRQ */
+	register_int_handler(dev->qup_irq, qup_spi_interrupt, dev);
+
+	/* Then disable it */
+	mask_interrupt(dev->qup_irq);
+}
+
+struct qup_spi_dev *qup_blsp_spi_init(uint8_t blsp_id, uint8_t qup_id)
+{
+	struct qup_spi_dev *dev;
+
+	dev = malloc(sizeof(struct qup_spi_dev));
+	if (!dev) {
+		return NULL;
+	}
+	dev = memset(dev, 0, sizeof(struct qup_spi_dev));
+
+	/* Platform uses BLSP */
+	dev->qup_irq = BLSP_QUP_IRQ(blsp_id, qup_id);
+	dev->qup_base = BLSP_QUP_BASE(blsp_id, qup_id);
+
+	/* Initialize the GPIO for BLSP spi */
+	gpio_config_blsp_spi(blsp_id, qup_id);
+
+	clock_config_blsp_spi(blsp_id, qup_id);
+
+	qup_spi_sec_init(dev);
+
+	return dev;
+}
+
+int qup_spi_deinit(struct qup_spi_dev *dev)
+{
+	/* Disable the qup_irq */
+	mask_interrupt(dev->qup_irq);
+	/* Free the memory used for dev */
+	free(dev);
+	return 0;
+}

--- a/project/lk2nd-msm8909.mk
+++ b/project/lk2nd-msm8909.mk
@@ -1,0 +1,8 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+include $(LOCAL_DIR)/lk2nd-defines.mk
+include $(LOCAL_DIR)/msm8909.mk
+include $(LOCAL_DIR)/lk2nd-base.mk
+
+APPSBOOTHEADER: $(OUTBOOTIMGADTB)
+ANDROID_BOOT_BASE := 0x00000000

--- a/target/msm8909/include/target/display.h
+++ b/target/msm8909/include/target/display.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2016, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2016, 2018 The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -49,12 +49,24 @@ static struct gpio_pin bkl_gpio = {
   "msmgpio", 37, 3, 1, 0, 1
 };
 
+static struct gpio_pin spi_bkl_gpio = {
+	"msmgpio", 60, 3, 1, 0, 1
+};
+
 static struct gpio_pin enp_gpio = {
   "msmgpio", 11, 3, 1, 0, 1
 };
 
 static struct gpio_pin enn_gpio = {
   "msmgpio", 10, 3, 1, 0, 1
+};
+
+static struct gpio_pin dc_gpio = {
+	"msmgpio", 52, 3, 1, 0, 1
+};
+
+static struct gpio_pin spi_dc_gpio = {
+        "msmgpio", 59, 3, 1, 0, 1
 };
 
 static struct gpio_pin te_gpio = {
@@ -107,5 +119,8 @@ static const uint32_t panel_physical_ctrl[] = {
 #define MIPI_VSYNC_PULSE_WIDTH       4
 #define MIPI_VSYNC_BACK_PORCH_LINES  3
 #define MIPI_VSYNC_FRONT_PORCH_LINES 9
+
+#define SPI_BLSP_ID                  1
+#define SPI_QUP_ID                   3
 
 #endif

--- a/target/msm8909/init.c
+++ b/target/msm8909/init.c
@@ -208,8 +208,12 @@ void *target_mmc_device()
 	return (void *) dev;
 }
 
+#if WITH_LK2ND
+int target_volume_up_old()
+#else
 /* Return 1 if vol_up pressed */
 int target_volume_up()
+#endif
 {
         static uint8_t first_time = 0;
 	uint8_t status = 0;
@@ -230,8 +234,12 @@ int target_volume_up()
 	return !status;
 }
 
+#if WITH_LK2ND
+uint32_t target_volume_down_old()
+#else
 /* Return 1 if vol_down pressed */
 uint32_t target_volume_down()
+#endif
 {
 	if ((board_hardware_id() == HW_PLATFORM_QRD) &&
 			(board_hardware_subtype() == SUB_TYPE_SKUT)) {
@@ -255,6 +263,7 @@ uint32_t target_volume_down()
 
 static void target_keystatus()
 {
+#if !WITH_LK2ND
 	keys_init();
 
 	if(target_volume_down())
@@ -262,7 +271,7 @@ static void target_keystatus()
 
 	if(target_volume_up())
 		keys_post_event(KEY_VOLUMEUP, 1);
-
+#endif
 }
 
 static void set_sdc_power_ctrl()

--- a/target/msm8909/oem_panel.c
+++ b/target/msm8909/oem_panel.c
@@ -49,6 +49,7 @@
 #include "include/panel_auo_qvga_cmd.h"
 #include "include/panel_auo_cx_qvga_cmd.h"
 #include "include/panel_hx8394f_720p_video.h"
+#include "include/panel_st7789v2_qvga_spi_cmd.h"
 
 #define DISPLAY_MAX_PANEL_DETECTION 0
 #define ILI9806E_FWVGA_VIDEO_PANEL_POST_INIT_DELAY 68
@@ -86,6 +87,7 @@ enum {
 	AUO_QVGA_CMD_PANEL,
 	AUO_CX_QVGA_CMD_PANEL,
 	HX8394F_720P_VIDEO_PANEL,
+	ST7789v2_QVGA_SPI_CMD_PANEL,
 	UNKNOWN_PANEL
 };
 
@@ -106,6 +108,7 @@ static struct panel_list supp_panels[] = {
 	{"auo_qvga_cmd", AUO_QVGA_CMD_PANEL},
 	{"auo_cx_qvga_cmd", AUO_CX_QVGA_CMD_PANEL},
 	{"hx8394f_720p_video", HX8394F_720P_VIDEO_PANEL},
+	{"ST7789V2_qvga_cmd", ST7789v2_QVGA_SPI_CMD_PANEL},
 };
 
 static uint32_t panel_id;
@@ -390,6 +393,19 @@ static int init_panel_data(struct panel_struct *panelstruct,
 		memcpy(phy_db->timing,
 					hx8394f_720p_video_timings, TIMING_SIZE);
 		pinfo->mipi.signature = HX8394F_720P_VIDEO_SIGNATURE;
+		break;
+	case ST7789v2_QVGA_SPI_CMD_PANEL:
+		panelstruct->paneldata		= &st7789v2_qvga_cmd_panel_data;
+		panelstruct->panelres		= &st7789v2_qvga_cmd_panel_res;
+		panelstruct->color			= &st7789v2_qvga_cmd_color;
+		panelstruct->panelresetseq	= &st7789v2_qvga_cmd_reset_seq;
+		panelstruct->backlightinfo	= &st7789v2_qvga_cmd_backlight;
+		pinfo->spi.panel_cmds		= st7789v2_qvga_cmd_on_command;
+		pinfo->spi.num_of_panel_cmds= ST7789v2_QVGA_CMD_ON_COMMAND;
+		pinfo->spi.signature_addr	= &st7789v2_signature_addr;
+		pinfo->spi.signature		= st7789v2_signature;
+		pinfo->spi.signature_len	= st7789v2_signature_len;
+		pan_type = PANEL_TYPE_SPI;
 		break;
 	case UNKNOWN_PANEL:
 	default:

--- a/target/msm8909/regulator.c
+++ b/target/msm8909/regulator.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2015, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,6 +29,7 @@
 
 #include <regulator.h>
 #include <rpm-smd.h>
+#include <bits.h>
 #include <debug.h>
 
 static uint32_t ldo2[][11]=
@@ -83,12 +84,17 @@ static uint32_t ldo17[][11]=
 	},
 };
 
-void regulator_enable()
+void regulator_enable(uint32_t enable)
 {
-	rpm_send_data(&ldo2[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
+	if (enable & REG_LDO2)
+		rpm_send_data(&ldo2[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
 
-	rpm_send_data(&ldo17[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
+	if (enable & REG_LDO17)
+		rpm_send_data(&ldo17[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
 
-	rpm_send_data(&ldo6[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
+	if (enable & REG_LDO6)
+		rpm_send_data(&ldo6[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
+
+
 
 }

--- a/target/msm8909/target_display.c
+++ b/target/msm8909/target_display.c
@@ -230,6 +230,15 @@ int target_backlight_ctrl(struct backlight *bl, uint8_t enable)
 				bkl_gpio.pin_strength, bkl_gpio.pin_state);
 				gpio_set(bkl_gpio.pin_id, 2);
 		}
+
+		if (HW_PLATFORM_SUBTYPE_8909_PM660_V1 == platform_subtype) {
+			gpio_tlmm_config(spi_bkl_gpio.pin_id, 0,
+				spi_bkl_gpio.pin_direction,
+				spi_bkl_gpio.pin_pull,
+				spi_bkl_gpio.pin_strength,
+				spi_bkl_gpio.pin_state);
+			gpio_set(spi_bkl_gpio.pin_id, 2);
+		}
 	}
 
 	return 0;

--- a/target/msm8909/target_display.c
+++ b/target/msm8909/target_display.c
@@ -40,6 +40,7 @@
 #include <platform/gpio.h>
 #include <platform/iomap.h>
 #include <target/display.h>
+#include <regulator.h>
 
 #include "include/panel.h"
 #include "include/display_resource.h"
@@ -364,7 +365,7 @@ int target_panel_reset(uint8_t enable, struct panel_reset_sequence *resetseq,
 int target_ldo_ctrl(uint8_t enable)
 {
 	if (enable)
-		regulator_enable();     /* L2, L6, and L17 */
+		regulator_enable(REG_LDO2 | REG_LDO6 | REG_LDO17);
 
 	return NO_ERROR;
 }

--- a/target/msm8994/regulator.c
+++ b/target/msm8994/regulator.c
@@ -99,18 +99,33 @@ static uint32_t ldo28[][11]=
 
 };
 
-void regulator_enable()
+void regulator_enable(uint32_t enable)
 {
-	rpm_send_data(&ldo2[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
+	if (enable & REG_LDO2)
+		rpm_send_data(&ldo2[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
 
-	rpm_send_data(&ldo12[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
+	if (enable & REG_LDO12)
+		rpm_send_data(&ldo12[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
 
-	rpm_send_data(&ldo14[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
-
-	rpm_send_data(&ldo28[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
+	if (enable & REG_LDO14)
+		rpm_send_data(&ldo14[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
+ 
+	if (enable & REG_LDO28)
+		rpm_send_data(&ldo28[GENERIC_ENABLE][0], 36, RPM_REQUEST_TYPE);
 }
 
-void regulator_disable()
-{
+void regulator_disable(uint32_t enable)
+ {
+	if (enable & REG_LDO2)
+		rpm_send_data(&ldo2[GENERIC_DISABLE][0], 36, RPM_REQUEST_TYPE);
 
-}
+	if (enable & REG_LDO12)
+		rpm_send_data(&ldo12[GENERIC_DISABLE][0], 36, RPM_REQUEST_TYPE);
+
+	if (enable & REG_LDO14)
+		rpm_send_data(&ldo14[GENERIC_DISABLE][0], 36, RPM_REQUEST_TYPE);
+
+	if (enable & REG_LDO28)
+		rpm_send_data(&ldo28[GENERIC_DISABLE][0], 36, RPM_REQUEST_TYPE);
+ }
+

--- a/target/msm8994/target_display.c
+++ b/target/msm8994/target_display.c
@@ -332,7 +332,8 @@ int target_panel_reset(uint8_t enable, struct panel_reset_sequence *resetseq,
 int target_ldo_ctrl(uint8_t enable, struct msm_panel_info *pinfo)
 {
 	if (enable) {
-		regulator_enable();	/* L2, L12, L14, and L28 */
+		regulator_enable(REG_LDO2 | REG_LDO12 |
+			REG_LDO14 | REG_LDO28);
 		mdelay(10);
 		qpnp_ibb_enable(true);	/* +5V and -5V */
 		mdelay(50);
@@ -343,7 +344,8 @@ int target_ldo_ctrl(uint8_t enable, struct msm_panel_info *pinfo)
 		if (pinfo->lcd_reg_en)
 			lcd_reg_disable();
 
-		regulator_disable();
+		regulator_disable(REG_LDO2 | REG_LDO12 |
+			REG_LDO14 | REG_LDO28);
 	}
 
 	return NO_ERROR;

--- a/target/target_display.c
+++ b/target/target_display.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2014, 2018 The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -112,6 +112,21 @@ __WEAK int target_hdmi_gpio_ctrl(bool enable)
 }
 
 __WEAK int target_display_dsi2hdmi_config(struct msm_panel_info *pinfo)
+{
+	return 0;
+}
+
+__WEAK int mdss_spi_init(void)
+{
+	return 0;
+}
+
+__WEAK int mdss_spi_panel_init(struct msm_panel_info *pinfo)
+{
+	return 0;
+}
+
+__WEAK int mdss_spi_on(struct msm_panel_info *pinfo, struct fbcon_config *fb)
 {
 	return 0;
 }


### PR DESCRIPTION
Boots fine on the devices (Qihoo W701 and Mobvoi TicWatch Pro) added, no display yet.

The W701 has a spi screen which I tried to implement, it no longer tells me that the display type is unknown.
The TicWatch Pro has a usual dsi display, still no display yet.
I have another msm8909 device with no display that I will try to implement as well.

We still need to think about how to handle buttons though, the TicWatch at least has two buttons but the W701 only has one.