### PR TITLE
Inital msm8x26 lumia support

### DIFF
--- a/dts/msm8226/msm8926-v1-mtp.dts
+++ b/dts/msm8226/msm8926-v1-mtp.dts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	qcom,msm-id = <200 0>;
+	qcom,board-id = <8 0>;
+
+	/* All the Nokia devices are expected to use lk1st, which passes the 
+	compatible to lk2nd, so no need for extra device matching. 
+	These nodes are listed in no particular order. */
+	nokia-tesla {
+		model = "Nokia Lumia 830";
+		compatible = "nokia,tesla", "qcom,msm8926", "lk2nd,device";
+
+		lk2nd,smd-rpm-hack-opening;
+		// 107 is actually KEY_CAMERA_SHOT but lk2nd doesn't support that
+		lk2nd,keys =
+			<KEY_VOLUMEUP   106 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_HOME   107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+
+	nokia-dempsey {
+		model = "Microsoft Lumia 640";
+		compatible = "nokia,dempsey", "qcom,msm8926", "lk2nd,device";
+
+		lk2nd,smd-rpm-hack-opening;
+		lk2nd,keys =
+			<KEY_VOLUMEUP   106 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+
+	nokia-moneypenny {
+		model = "Nokia Lumia 630";
+		compatible = "nokia,moneypenny", "qcom,msm8926", "lk2nd,device";
+
+		lk2nd,smd-rpm-hack-opening;
+		lk2nd,keys =
+			<KEY_VOLUMEUP   106 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+
+	nokia-superman {
+		model = "Nokia Lumia 730";
+		compatible = "nokia,superman", "qcom,msm8926", "lk2nd,device";
+
+		lk2nd,smd-rpm-hack-opening;
+		lk2nd,keys =
+			<KEY_VOLUMEUP   106 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+
+	nokia-makepeace {
+		model = "Microsoft Lumia 640 XL";
+		compatible = "nokia,makepeace", "qcom,msm8926", "lk2nd,device";
+
+		lk2nd,smd-rpm-hack-opening;
+		lk2nd,keys =
+			<KEY_VOLUMEUP   106 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+};

--- a/dts/msm8226/rules.mk
+++ b/dts/msm8226/rules.mk
@@ -4,4 +4,5 @@ DTBS += \
 	$(LOCAL_DIR)/apq8026-asus-sparrow.dtb \
 	$(LOCAL_DIR)/apq8026-huawei-sturgeon.dtb \
 	$(LOCAL_DIR)/apq8026-lg-lenok.dtb \
-	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb
+	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb \
+	$(LOCAL_DIR)/msm8926-v1-mtp.dtb

--- a/project/lk1st-msm8226.mk
+++ b/project/lk1st-msm8226.mk
@@ -1,0 +1,4 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+include $(LOCAL_DIR)/msm8226.mk
+include $(LOCAL_DIR)/lk2nd-base.mk


### PR DESCRIPTION
This PR includes Lk1st for msm8x26 along with a msm8926-v1-mtp dts with support for tesla, moneypenny, dempsey and superman. Makepeace is not included due to not having a tester who has one with msm8926.

The command mode autorefresh stuff is already enabled on tesla, whatever lk2nd does relating to this really messes tesla up. (I commented it out locally)

The membase must be changed for it to boot on our lumias for whatever reason, I used 0x07300000