### PR TITLE
Add initial support for Samsung Galaxy Ace 4

### DIFF
--- a/dts/msm8916/msm8916-samsung-r02.dts
+++ b/dts/msm8916/msm8916-samsung-r02.dts
@@ -29,4 +29,20 @@
 		lk2nd,match-bootloader = "G530W*";
 		#include "msm8916-samsung-gprime.dtsi"
 	};
+	
+	/*
+	 * Before building for G357FZ, please comment out all dtbs except
+	 * "$(LOCAL_DIR)/msm8916-samsung-r02.dtb" at './rules.mk'.
+	 * heatqlte doesn't work with multi-dtbs; only goes into "Download mode".
+	 */
+
+	heatqlte {
+		model = "Samsung Galaxy Ace 4";
+		compatible = "samsung,heatqlte", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "G357FZ*";
+		samsung,muic-reset {
+			i2c-gpio-pins = <2 3>;
+			i2c-address = <0x14>;
+		};		
+	};
 };


### PR DESCRIPTION
This PR includes changes for initial support for Samsung Galaxy Ace 4 (SM-G357Z) as worked through with others on the Matrix porting channel.