### PR TITLE
Add support for Samsung Galaxy Grand 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - ASUS ZenWatch 2 - sparrow
 - Huawei Watch - sturgeon
 - LG G Watch R - lenok
+- Samsung Galaxy Grand 2 - ms013g
 
 ## Installation
 1. Download `lk2nd.img` (available in [Releases](https://github.com/msm8916-mainline/lk2nd/releases))

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - ASUS ZenWatch 2 - sparrow
 - Huawei Watch - sturgeon
 - LG G Watch R - lenok
-- Samsung Galaxy Grand 2 - ms013g
+- Samsung Galaxy Grand 2 - SM-G7102
 
 ## Installation
 1. Download `lk2nd.img` (available in [Releases](https://github.com/msm8916-mainline/lk2nd/releases))

--- a/dts/msm8226/msm8226-samsung-ms013g.dts
+++ b/dts/msm8226/msm8226-samsung-ms013g.dts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id =  <0x9E00FF01 7 0x20000>,
+		       <0x9108FF01 7 0x20000>,
+	      	       <0x9E08FF01 7 0x20000>,
+	               <0x9F08FF01 7 0x20000>,
+	               <0xC608FF01 7 0x20000>,
+	               <0xC708FF01 7 0x20000>;
+	
+	ms013g {
+		model = "Samsung Galaxy Grand 2";
+		compatible = "samsung,ms013g", "qcom,msm8226", "lk2nd,device";
+		lk2nd,keys =
+			<KEY_VOLUMEDOWN 107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP   106 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};   
+};

--- a/dts/msm8226/msm8226-samsung-ms013g.dts
+++ b/dts/msm8226/msm8226-samsung-ms013g.dts
@@ -7,12 +7,7 @@
 
 / {
 	// This is used by the bootloader to find the correct DTB
-	qcom,msm-id =  <0x9E00FF01 7 0x20000>,
-		       <0x9108FF01 7 0x20000>,
-	      	       <0x9E08FF01 7 0x20000>,
-	               <0x9F08FF01 7 0x20000>,
-	               <0xC608FF01 7 0x20000>,
-	               <0xC708FF01 7 0x20000>;
+	qcom,msm-id = <0x9E08FF01 7 0x20000>;
 	
 	ms013g {
 		model = "Samsung Galaxy Grand 2";

--- a/dts/msm8226/rules.mk
+++ b/dts/msm8226/rules.mk
@@ -3,5 +3,5 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 DTBS += \
 	$(LOCAL_DIR)/apq8026-asus-sparrow.dtb \
 	$(LOCAL_DIR)/apq8026-huawei-sturgeon.dtb \
-	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb \
-	$(LOCAL_DIR)/apq8026-lg-lenok.dtb
+	$(LOCAL_DIR)/apq8026-lg-lenok.dtb \
+	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb

--- a/dts/msm8226/rules.mk
+++ b/dts/msm8226/rules.mk
@@ -3,4 +3,5 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 DTBS += \
 	$(LOCAL_DIR)/apq8026-asus-sparrow.dtb \
 	$(LOCAL_DIR)/apq8026-huawei-sturgeon.dtb \
+	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb \
 	$(LOCAL_DIR)/apq8026-lg-lenok.dtb


### PR DESCRIPTION
This PR includes changes for initial support for Samsung Galaxy Grand 2 (SM-G7102).