### PR TITLE
dts: msm8226: Add Huawei G6-L11

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 
 ### lk2nd-msm8226
 - ASUS ZenWatch 2 - sparrow
-- Huawei Ascend G6 4G - G6-L11
+- Huawei Ascend G6 4G - G6-L11 (quirky - see comment in `dts/msm8226/msm8926-huawei-g6-l11-vb.dts`)
 - Huawei Watch - sturgeon
 - LG G Watch R - lenok
 - Samsung Galaxy Grand 2 - SM-G7102

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 
 ### lk2nd-msm8226
 - ASUS ZenWatch 2 - sparrow
+- Huawei Ascend G6 4G - G6-L11
 - Huawei Watch - sturgeon
 - LG G Watch R - lenok
 - Samsung Galaxy Grand 2 - SM-G7102

--- a/dts/msm8226/msm8926-huawei-g6-l11-vb.dts
+++ b/dts/msm8226/msm8926-huawei-g6-l11-vb.dts
@@ -2,6 +2,13 @@
 
 /dts-v1/;
 
+/*
+ * To build for huawei-g6-l11, comment out all dtb targets except
+ * $(LOCAL_DIR)/msm8926-huawei-g6-l11-vb.dtb in rules.mk in this directory.
+ * the stock g6-l11 bootloader does will not match this dtb unless it is
+ * in first position in the appended dtb.
+ */
+
 #include <skeleton.dtsi>
 
 / {

--- a/dts/msm8226/msm8926-huawei-g6-l11-vb.dts
+++ b/dts/msm8226/msm8926-huawei-g6-l11-vb.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+
+/ {
+	model = "Huawei Ascend G6-L11 vb";
+	compatible = "huawei,g6-l11-vb", "qcom,msm8926", "lk2nd,device";
+
+	qcom,msm-id = <0xc8 0x1f51 0x00>;
+};

--- a/dts/msm8226/rules.mk
+++ b/dts/msm8226/rules.mk
@@ -4,4 +4,5 @@ DTBS += \
 	$(LOCAL_DIR)/apq8026-asus-sparrow.dtb \
 	$(LOCAL_DIR)/apq8026-huawei-sturgeon.dtb \
 	$(LOCAL_DIR)/apq8026-lg-lenok.dtb \
-	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb
+	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb \
+	$(LOCAL_DIR)/msm8926-huawei-g6-l11-vb.dtb


### PR DESCRIPTION
This patch adds minimal support for the MSM8926-based Huawei G6 4G (G6-L11).
The MSM8926 SoC being very close to MSM8226, I believe it does not need its own make target at this point.