### PR TITLE
Fix volume up/down button on asus z00l

### DIFF
--- a/dts/msm8916/msm8916-asus-z00l.dts
+++ b/dts/msm8916/msm8916-asus-z00l.dts
@@ -3,12 +3,17 @@
 /dts-v1/;
 
 #include <skeleton.dtsi>
+#include <lk2nd.h>
 
 / {
 	qcom,msm-id = <206 0>;
 	qcom,board-id = <21 0>;
 	model = "Asus Zenfone Laser 2 (720p)";
 	compatible = "asus,z00l", "qcom,msm8916", "lk2nd,device";
+
+	lk2nd,keys =
+		<KEY_VOLUMEDOWN 117 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+		<KEY_VOLUMEUP   107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 
 	panel {
 		compatible = "asus,z00l-panel";


### PR DESCRIPTION
This will make it possible to actually enter lk2nd on an asus zenphone 2 laser by pressing the volume down button right after the first vibration after turning it on