### PR TITLE
dts: msm8974: Add Sony Xperia Z3

### DIFF
--- a/dts/msm8974/msm8974pro-ac-pm8941-mtp.dts
+++ b/dts/msm8974/msm8974pro-ac-pm8941-mtp.dts
@@ -37,3 +37,12 @@
 			<KEY_VOLUMEDOWN PM_GPIO(2) PM_GPIO_PULL_UP_1_5>;
 	};
 };
+
+/*
+ * The stock bootloader of sony-leo uses parts of the dts to initialize the
+ * screen. So to get continous splash initialized by the first bootloader we
+ * need to include these dts parts here.
+ *
+ * FIXME: This won't work if more Sony devices are added here...
+ */
+#include "sony/msm8974pro-ac-shinano_leo-display.dtsi"

--- a/dts/msm8974/msm8974pro-ac-pm8941-mtp.dts
+++ b/dts/msm8974/msm8974pro-ac-pm8941-mtp.dts
@@ -22,4 +22,18 @@
 			<KEY_VOLUMEUP   PM_GPIO(5) PM_GPIO_PULL_UP_1_5>,
 			<KEY_VOLUMEDOWN PM_GPIO(2) PM_GPIO_PULL_UP_1_5>;
 	};
+
+	sony-leo {
+		model = "Sony Xperia Z3";
+		compatible = "sony,xperia-leo", "qcom,msm8974", "lk2nd,device";
+		/*
+		 * Probably matches other Sony devices as well, but good enough
+		 * for now.
+		 */
+		lk2nd,match-cmdline = "* androidboot.bootloader=s1 *";
+
+		lk2nd,keys =
+			<KEY_VOLUMEUP   PM_GPIO(5) PM_GPIO_PULL_UP_1_5>,
+			<KEY_VOLUMEDOWN PM_GPIO(2) PM_GPIO_PULL_UP_1_5>;
+	};
 };

--- a/dts/msm8974/sony/dsi-panel-leo.dtsi
+++ b/dts/msm8974/sony/dsi-panel-leo.dtsi
@@ -1,0 +1,775 @@
+/* Copyright (c) 2012, Code Aurora Forum. All rights reserved.
+ * Copyright (c) 2014 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&mdss_mdp {
+	qcom,mdss-ib-factor = <19 10>;
+	dsi_novatek_sharp_1080_vid: somc,novatek_sharp_1080p_video_panel {
+		qcom,mdss-dsi-panel-name = "sharp novatek 1080p video";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-type = "dsi_video_mode";
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-h-front-porch = <136>;
+		qcom,mdss-dsi-h-back-porch = <20>;
+		qcom,mdss-dsi-h-pulse-width = <60>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-v-back-porch = <3>;
+		qcom,mdss-dsi-v-front-porch = <4>;
+		qcom,mdss-dsi-v-pulse-width = <2>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		somc,mdss-dsi-init-command = [15 01 00 00 00 00 02 BB 03
+				39 01 00 00 00 00 06 3B 03 05 04 50 88
+				15 01 00 00 00 00 02 FF 24
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 C4 9A
+				15 01 00 00 00 00 02 FF 10];
+		qcom,mdss-dsi-on-command = [05 01 00 00 96 00 01 11
+				05 01 00 00 28 00 01 29];
+		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
+				05 01 00 00 14 00 01 28
+				05 01 00 00 50 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-t-clk-post = <0x02>;
+		qcom,mdss-dsi-t-clk-pre = <0x2B>;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-pan-enable-dynamic-fps;
+		qcom,mdss-dsi-pan-fps-update = "dfps_suspend_resume_mode";
+		qcom,cont-splash-enabled;
+		qcom,mdss-dsi-tx-eot-append;
+
+		somc,driver-ic = <0>;
+		somc,dric-gpio = <&msmgpio 26 0>;
+		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		somc,mul-channel-scaling = <3>;
+		somc,mdss-phy-size-mm = <64 114>;
+		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 02 45 00 00 00 00 01 97];
+		somc,mdss-dsi-disp-on-in-hs = <1>;
+		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
+		somc,lcd-id = <1>;
+		somc,lcd-id-adc = <215000 256000>;
+		somc,disp-en-on-pre = <200>;
+		somc,disp-en-on-post = <10>;
+		somc,pw-on-rst-seq = <1 1>, <0 1>, <1 20>;
+		somc,disp-en-off-post = <200>;
+		somc,pw-off-rst-seq = <0 5>;
+		somc,pw-down-period = <100>;
+
+		// [...]
+	};
+
+	dsi_novatek_sharp_1080_cmd: somc,novatek_sharp_1080p_cmd_panel {
+		qcom,mdss-dsi-panel-name = "sharp novatek 1080p cmd";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-h-front-porch = <56>;
+		qcom,mdss-dsi-h-back-porch = <8>;
+		qcom,mdss-dsi-h-pulse-width = <8>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-v-back-porch = <8>;
+		qcom,mdss-dsi-v-front-porch = <233>;
+		qcom,mdss-dsi-v-pulse-width = <2>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		somc,mdss-dsi-init-command = [15 01 00 00 00 00 02 BB 10
+				15 01 00 00 00 00 02 FF 24
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 C4 9A
+				15 01 00 00 00 00 02 85 05
+				15 01 00 00 00 00 02 93 02
+				15 01 00 00 00 00 02 94 08
+				15 01 00 00 00 00 02 92 95
+				15 01 00 00 00 00 02 FF 10
+				15 01 00 00 00 00 02 FF 20
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 58 82
+				15 01 00 00 00 00 02 59 02
+				15 01 00 00 00 00 02 5A 02
+				15 01 00 00 00 00 02 5B 02
+				15 01 00 00 00 00 02 5C 83
+				15 01 00 00 00 00 02 5D 83
+				15 01 00 00 00 00 02 5E 03
+				15 01 00 00 00 00 02 5F 03
+				15 01 00 00 00 00 02 6D 55
+				15 01 00 00 00 00 02 FF 10
+				15 01 00 00 00 00 02 FF 24
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 C4 02
+				15 01 00 00 00 00 02 FF 10
+				15 01 00 00 00 00 02 35 00
+				39 01 00 00 00 00 03 44 03 00
+				15 01 00 00 00 00 02 FF E0
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 B5 86
+				15 01 00 00 00 00 02 B6 77
+				15 01 00 00 00 00 02 B8 AD
+				15 01 00 00 00 00 02 FF 20
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 10 04
+				15 01 00 00 00 00 02 FF 10
+				05 01 00 00 1E 00 01 11];
+		qcom,mdss-dsi-on-command = [05 01 00 00 28 00 01 29];
+		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
+				05 01 00 00 14 00 01 28
+				05 01 00 00 50 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-te-pin-select = <1>;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
+		qcom,mdss-dsi-te-dcs-command = <1>;
+		qcom,mdss-dsi-te-check-enable;
+		qcom,mdss-dsi-te-using-te-pin;
+		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-t-clk-post = <0x21>;
+		qcom,mdss-dsi-t-clk-pre = <0x2B>;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-pan-enable-dynamic-fps;
+		qcom,mdss-dsi-pan-fps-update = "dfps_suspend_resume_mode";
+		qcom,cont-splash-enabled;
+		qcom,mdss-dsi-tx-eot-append;
+
+		somc,driver-ic = <0>;
+		somc,dric-gpio = <&msmgpio 26 0>;
+		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		somc,mul-channel-scaling = <3>;
+		somc,mdss-phy-size-mm = <64 114>;
+		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 02 45 00 00 00 00 01 97];
+		somc,mdss-dsi-disp-on-in-hs = <0>;
+		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
+		somc,lcd-id = <1>;
+		somc,lcd-id-adc = <0 57000>;
+		somc,disp-en-on-pre = <10>;
+		somc,disp-en-on-post = <20>;
+		somc,pw-on-rst-seq = <1 1>, <0 1>, <1 20>;
+		somc,disp-en-off-post = <200>;
+		somc,pw-off-rst-seq = <0 5>;
+		somc,pw-down-period = <100>;
+
+		// [...]
+	};
+
+	dsi_novatek_jdi_1080_vid: somc,novatek_jdi_1080p_video_panel {
+		qcom,mdss-dsi-panel-name = "jdi novatek 1080p video";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-type = "dsi_video_mode";
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-h-front-porch = <112>;
+		qcom,mdss-dsi-h-back-porch = <76>;
+		qcom,mdss-dsi-h-pulse-width = <4>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-v-back-porch = <4>;
+		qcom,mdss-dsi-v-front-porch = <8>;
+		qcom,mdss-dsi-v-pulse-width = <4>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		somc,mdss-dsi-init-command = [23 01 00 00 00 00 02 FF 10
+				05 01 00 00 14 00 01 01
+				15 01 00 00 00 00 02 BB 03
+				15 01 00 00 00 00 02 35 00
+				39 01 00 00 00 00 05 2A 00 00 04 37
+				39 01 00 00 00 00 05 2B 00 00 07 7F
+				39 01 00 00 00 00 04 3B 03 08 08];
+		qcom,mdss-dsi-on-command = [05 01 00 00 64 00 01 11
+				05 01 00 00 28 00 01 29];
+		qcom,mdss-dsi-off-command = [05 01 00 00 14 00 01 28
+				05 01 00 00 50 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6C 2A 3A 2C 03 04 00];
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-t-clk-post = <0x02>;
+		qcom,mdss-dsi-t-clk-pre = <0x2B>;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-pan-enable-dynamic-fps;
+		qcom,mdss-dsi-pan-fps-update = "dfps_suspend_resume_mode";
+		qcom,cont-splash-enabled;
+		qcom,mdss-dsi-tx-eot-append;
+
+		somc,driver-ic = <0>;
+		somc,dric-gpio = <&msmgpio 26 0>;
+		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		somc,mul-channel-scaling = <3>;
+		somc,mdss-phy-size-mm = <64 114>;
+		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 02 45 00 00 00 00 01 97];
+		somc,mdss-dsi-disp-on-in-hs = <1>;
+		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
+		somc,lcd-id = <1>;
+		somc,lcd-id-adc = <801000 917000>;
+		somc,disp-en-on-post = <10>;
+		somc,pw-on-rst-seq = <1 15>;
+		somc,disp-en-off-post = <200>;
+		somc,pw-off-rst-seq = <0 0>;
+		somc,pw-down-period = <100>;
+
+		// [...]
+	};
+
+	dsi_novatek_jdi_1080_cmd: somc,novatek_jdi_1080p_cmd_panel {
+		qcom,mdss-dsi-panel-name = "jdi novatek 1080p cmd";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-h-front-porch = <56>;
+		qcom,mdss-dsi-h-back-porch = <8>;
+		qcom,mdss-dsi-h-pulse-width = <8>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-v-back-porch = <8>;
+		qcom,mdss-dsi-v-front-porch = <233>;
+		qcom,mdss-dsi-v-pulse-width = <2>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		somc,mdss-dsi-init-command = [23 01 00 00 00 00 02 FF 10
+				05 01 00 00 14 00 01 01
+				23 01 00 00 00 00 02 FF 10
+				23 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 BB 10
+				15 01 00 00 00 00 02 35 00
+				15 01 00 00 00 00 02 44 03
+				23 01 00 00 00 00 02 FF E0
+				23 01 00 00 00 00 02 B5 86
+				23 01 00 00 00 00 02 B6 77
+				23 01 00 00 00 00 02 B8 AD
+				23 01 00 00 00 00 02 FB 01
+				23 01 00 00 00 00 02 FF 20
+				23 01 00 00 00 00 02 10 04
+				23 01 00 00 00 00 02 FB 01
+				23 01 00 00 00 00 02 FF 24
+				23 01 00 00 00 00 02 92 95
+				23 01 00 00 00 00 02 FB 01
+				23 01 00 00 00 00 02 C4 20
+				23 01 00 00 00 00 02 FF 10
+				23 01 00 00 00 00 02 FB 01
+				05 01 00 00 64 00 01 11];
+		qcom,mdss-dsi-on-command = [05 01 00 00 00 00 01 29];
+		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
+				05 01 00 00 14 00 01 28
+				05 01 00 00 50 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-te-pin-select = <1>;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
+		qcom,mdss-dsi-te-dcs-command = <1>;
+		qcom,mdss-dsi-te-check-enable;
+		qcom,mdss-dsi-te-using-te-pin;
+		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-t-clk-post = <0x21>;
+		qcom,mdss-dsi-t-clk-pre = <0x2B>;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-pan-enable-dynamic-fps;
+		qcom,mdss-dsi-pan-fps-update = "dfps_suspend_resume_mode";
+		qcom,cont-splash-enabled;
+		qcom,mdss-dsi-tx-eot-append;
+
+		somc,driver-ic = <0>;
+		somc,dric-gpio = <&msmgpio 26 0>;
+		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		somc,mul-channel-scaling = <3>;
+		somc,mdss-phy-size-mm = <64 114>;
+		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 02 45 00 00 00 00 01 97];
+		somc,mdss-dsi-disp-on-in-hs = <0>;
+		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
+		somc,lcd-id = <1>;
+		somc,lcd-id-adc = <565000 653000>;
+		somc,disp-en-on-post = <20>;
+		somc,pw-on-rst-seq = <1 15>;
+		somc,disp-en-off-post = <70>;
+		somc,pw-off-rst-seq = <0 0>;
+		somc,pw-down-period = <100>;
+
+		// [...]
+	};
+
+	dsi_novatek_auo_1080_cmd: somc,novatek_auo_1080p_cmd_panel {
+		qcom,mdss-dsi-panel-name = "auo novatek 1080p cmd";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-h-front-porch = <56>;
+		qcom,mdss-dsi-h-back-porch = <8>;
+		qcom,mdss-dsi-h-pulse-width = <8>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-v-back-porch = <8>;
+		qcom,mdss-dsi-v-front-porch = <233>;
+		qcom,mdss-dsi-v-pulse-width = <2>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		somc,mdss-dsi-init-command = [15 01 00 00 00 00 02 FF E0
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 B5 86
+				15 01 00 00 00 00 02 B6 77
+				15 01 00 00 00 00 02 B8 AD
+				15 01 00 00 00 00 02 FF 20
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 10 04
+				15 01 00 00 00 00 02 FF 24
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 C6 00
+				15 01 00 00 00 00 02 C5 32
+				15 01 00 00 00 00 02 92 92
+				15 01 00 00 00 00 02 FF 10
+				15 01 00 00 00 00 02 35 00
+				39 01 00 00 00 00 03 44 03 00
+				39 01 00 00 00 00 04 3B 03 30 06
+				15 01 00 00 01 00 02 BB 10
+				05 01 00 00 1E 00 01 11];
+		qcom,mdss-dsi-on-command = [05 01 00 00 28 00 01 29];
+		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
+				05 01 00 00 00 00 01 28
+				05 01 00 00 64 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-te-pin-select = <1>;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
+		qcom,mdss-dsi-te-dcs-command = <1>;
+		qcom,mdss-dsi-te-check-enable;
+		qcom,mdss-dsi-te-using-te-pin;
+		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-t-clk-post = <0x21>;
+		qcom,mdss-dsi-t-clk-pre = <0x2B>;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-pan-enable-dynamic-fps;
+		qcom,mdss-dsi-pan-fps-update = "dfps_suspend_resume_mode";
+		qcom,cont-splash-enabled;
+		qcom,mdss-dsi-tx-eot-append;
+
+		somc,driver-ic = <0>;
+		somc,dric-gpio = <&msmgpio 26 0>;
+		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		somc,mul-channel-scaling = <3>;
+		somc,mdss-phy-size-mm = <64 114>;
+		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 02 45 00 00 00 00 01 97];
+		somc,mdss-dsi-disp-on-in-hs = <0>;
+		somc,mdss-dsi-wait-time-before-on-cmd = <100>;
+		somc,lcd-id = <1>;
+		somc,lcd-id-adc = <1236000 1395000>;
+		somc,disp-en-on-post = <20>;
+		somc,pw-on-rst-seq = <1 10>;
+		somc,disp-en-off-post = <70>;
+		somc,pw-off-rst-seq = <0 0>;
+		somc,pw-down-period = <100>;
+
+		// [...]
+	};
+
+	dsi_novatek_lgd_1080_cmd: somc,novatek_lgd_1080p_cmd_panel {
+		qcom,mdss-dsi-panel-name = "lgd novatek 1080p cmd";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-h-front-porch = <56>;
+		qcom,mdss-dsi-h-back-porch = <8>;
+		qcom,mdss-dsi-h-pulse-width = <8>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-v-back-porch = <8>;
+		qcom,mdss-dsi-v-front-porch = <233>;
+		qcom,mdss-dsi-v-pulse-width = <2>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		somc,mdss-dsi-init-command = [15 01 00 00 00 00 02 FF 24
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 C6 00
+				15 01 00 00 00 00 02 92 94
+				15 01 00 00 00 00 02 FF E0
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 B8 AD
+				15 01 00 00 00 00 02 B5 86
+				15 01 00 00 00 00 02 B6 77
+				15 01 00 00 00 00 02 FF E0
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 10 00
+				15 01 00 00 00 00 02 FF 24
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 C4 24
+				15 01 00 00 00 00 02 FF 10
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 35 00
+				39 01 00 00 00 00 03 44 03 00
+				05 01 00 00 1E 00 01 11];
+		qcom,mdss-dsi-on-command = [05 01 00 00 00 00 01 29];
+		qcom,mdss-dsi-off-command = [05 01 00 00 14 00 01 28
+				05 01 00 00 64 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-te-pin-select = <1>;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
+		qcom,mdss-dsi-te-dcs-command = <1>;
+		qcom,mdss-dsi-te-check-enable;
+		qcom,mdss-dsi-te-using-te-pin;
+		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-t-clk-post = <0x21>;
+		qcom,mdss-dsi-t-clk-pre = <0x2B>;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-pan-enable-dynamic-fps;
+		qcom,mdss-dsi-pan-fps-update = "dfps_suspend_resume_mode";
+		qcom,cont-splash-enabled;
+		qcom,mdss-dsi-tx-eot-append;
+
+		somc,driver-ic = <0>;
+		somc,dric-gpio = <&msmgpio 26 0>;
+		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		somc,mul-channel-scaling = <3>;
+		somc,mdss-phy-size-mm = <64 114>;
+		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 02 45 00 00 00 00 01 97];
+		somc,mdss-dsi-disp-on-in-hs = <0>;
+		somc,mdss-dsi-wait-time-before-on-cmd = <100>;
+		somc,lcd-id = <1>;
+		somc,lcd-id-adc = <1420000 1594000>;
+		somc,disp-en-on-pre = <1>;
+		somc,pw-on-rst-seq = <0 20>, <1 10>, <0 1>, <1 20>;
+		somc,disp-en-off-post = <10>;
+		somc,pw-off-rst-seq = <0 1>;
+		somc,pw-down-period = <100>;
+
+		// [...]
+	};
+
+	dsi_default_gpio_0: somc,default_panel_0 {
+		qcom,mdss-dsi-panel-name = "default video 0";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-type = "dsi_video_mode";
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-h-front-porch = <136>;
+		qcom,mdss-dsi-h-back-porch = <20>;
+		qcom,mdss-dsi-h-pulse-width = <60>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-v-back-porch = <3>;
+		qcom,mdss-dsi-v-front-porch = <4>;
+		qcom,mdss-dsi-v-pulse-width = <2>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		somc,mdss-dsi-init-command = [15 01 00 00 00 00 02 BB 03
+				39 01 00 00 00 00 06 3B 03 05 04 50 88
+				15 01 00 00 00 00 02 FF 24
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 C4 9A
+				15 01 00 00 00 00 02 FF 10];
+		qcom,mdss-dsi-on-command = [05 01 00 00 96 00 01 11
+				05 01 00 00 28 00 01 29];
+		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
+				05 01 00 00 14 00 01 28
+				05 01 00 00 50 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-t-clk-post = <0x02>;
+		qcom,mdss-dsi-t-clk-pre = <0x2B>;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-pan-enable-dynamic-fps;
+		qcom,mdss-dsi-pan-fps-update = "dfps_suspend_resume_mode";
+		qcom,cont-splash-enabled;
+		qcom,mdss-dsi-tx-eot-append;
+
+		somc,driver-ic = <0>;
+		somc,dric-gpio = <&msmgpio 26 0>;
+		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		somc,mul-channel-scaling = <3>;
+		somc,mdss-phy-size-mm = <64 114>;
+		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 02 45 00 00 00 00 01 97];
+		somc,mdss-dsi-disp-on-in-hs = <1>;
+		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
+		somc,lcd-id = <0>;
+		somc,lcd-id-adc = <0 0x7fffffff>;
+		somc,disp-en-on-pre = <200>;
+		somc,disp-en-on-post = <10>;
+		somc,pw-on-rst-seq = <1 1>, <0 1>, <1 20>;
+		somc,disp-en-off-post = <200>;
+		somc,pw-off-rst-seq = <0 5>;
+		somc,pw-down-period = <100>;
+	};
+
+	dsi_default_gpio_1: somc,default_panel_1 {
+		qcom,mdss-dsi-panel-name = "default video 1";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-type = "dsi_video_mode";
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-h-front-porch = <136>;
+		qcom,mdss-dsi-h-back-porch = <20>;
+		qcom,mdss-dsi-h-pulse-width = <60>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-v-back-porch = <3>;
+		qcom,mdss-dsi-v-front-porch = <4>;
+		qcom,mdss-dsi-v-pulse-width = <2>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		somc,mdss-dsi-init-command = [15 01 00 00 00 00 02 BB 03
+				39 01 00 00 00 00 06 3B 03 05 04 50 88
+				15 01 00 00 00 00 02 FF 24
+				15 01 00 00 00 00 02 FB 01
+				15 01 00 00 00 00 02 C4 9A
+				15 01 00 00 00 00 02 FF 10];
+		qcom,mdss-dsi-on-command = [05 01 00 00 96 00 01 11
+				05 01 00 00 28 00 01 29];
+		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
+				05 01 00 00 14 00 01 28
+				05 01 00 00 50 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-t-clk-post = <0x02>;
+		qcom,mdss-dsi-t-clk-pre = <0x2B>;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-pan-enable-dynamic-fps;
+		qcom,mdss-dsi-pan-fps-update = "dfps_suspend_resume_mode";
+		qcom,cont-splash-enabled;
+		qcom,mdss-dsi-tx-eot-append;
+
+		somc,driver-ic = <0>;
+		somc,dric-gpio = <&msmgpio 26 0>;
+		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		somc,mul-channel-scaling = <3>;
+		somc,mdss-phy-size-mm = <64 114>;
+		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 c2 ef 00 00 00 00 01 ff
+				00 02 45 00 00 00 00 01 97];
+		somc,mdss-dsi-disp-on-in-hs = <1>;
+		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
+		somc,lcd-id = <1>;
+		somc,lcd-id-adc = <0 0x7fffffff>;
+		somc,disp-en-on-pre = <200>;
+		somc,disp-en-on-post = <10>;
+		somc,pw-on-rst-seq = <1 1>, <0 1>, <1 20>;
+		somc,disp-en-off-post = <200>;
+		somc,pw-off-rst-seq = <0 5>;
+		somc,pw-down-period = <100>;
+	};
+};

--- a/dts/msm8974/sony/msm8974-display-stubs.dtsi
+++ b/dts/msm8974/sony/msm8974-display-stubs.dtsi
@@ -1,0 +1,71 @@
+/* Copyright (c) 2012-2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/ {
+	soc {
+		msmgpio: gpio {
+			compatible = "qcom,msm-gpio";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		mdss_mdp: qcom,mdss_mdp {
+			compatible = "qcom,mdss_mdp";
+		};
+
+		mdss_dsi0: qcom,mdss_dsi {
+			compatible = "qcom,mdss-dsi-ctrl";
+			cell-index = <0>;
+			qcom,mdss-mdp = <&mdss_mdp>;
+			qcom,platform-reset-gpio = <&pm8941_gpios 19 0>;
+			qcom,platform-enable-gpio = <&msmgpio 58 0>;
+			qcom,platform-te-gpio = <&msmgpio 12 0>;
+			qcom,platform-strength-ctrl = [ff 06];
+			qcom,platform-bist-ctrl = [00 00 b1 ff 00 00];
+			qcom,platform-regulator-settings = [07 09 03 00 20 00 01];
+			qcom,platform-lane-config = [00 00 00 00 00 00 00 01 97
+				00 00 00 00 00 00 00 01 97
+				00 00 00 00 00 00 00 01 97
+				00 00 00 00 00 00 00 01 97
+				00 c0 00 00 00 00 00 01 bb];
+		};
+
+		spmi_bus: qcom,spmi {
+			compatible = "qcom,spmi-pmic-arb";
+			cell-index = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pm8941_lsid0: qcom,pm8941@0 {
+				reg = <0x0>;
+
+				pm8941_gpios: gpios {
+					compatible = "qcom,qpnp-pin";
+					gpio-controller;
+					#gpio-cells = <2>;
+				};
+			};
+
+			pm8941_lsid1: qcom,pm8941@1 {
+				reg = <0x1>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				pm8941_wled: qcom,leds@d800 {
+					compatible = "qcom,leds-qpnp";
+					reg = <0xd800 0x100>;
+					label = "wled";
+				};
+			};
+		};
+	};
+};

--- a/dts/msm8974/sony/msm8974pro-ac-shinano_leo-display.dtsi
+++ b/dts/msm8974/sony/msm8974pro-ac-shinano_leo-display.dtsi
@@ -1,0 +1,3 @@
+#include "msm8974-display-stubs.dtsi"
+#include "msm8974pro-ac-shinano_leo_common.dtsi"
+#include "dsi-panel-leo.dtsi"

--- a/dts/msm8974/sony/msm8974pro-ac-shinano_leo_common.dtsi
+++ b/dts/msm8974/sony/msm8974pro-ac-shinano_leo_common.dtsi
@@ -1,0 +1,87 @@
+/* arch/arm/boot/dts/msm8974pro-ac-shinano_leo_common.dtsi
+ *
+ * Copyright (C) 2015 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *
+ * NOTE: This file has been modified by Sony Mobile Communications Inc.
+ * Modifications are licensed under the License.
+ */
+
+// [...]
+&spmi_bus {
+	qcom,pm8941@1 {
+		// [...]
+		qcom,leds@d800 {
+			status = "okay";
+			qcom,wled_0 {
+				label = "wled";
+				//linux,name = "wled:backlight";
+				//linux,default-trigger = "bkl-trigger";
+				qcom,cs-out-en = <1>;
+				qcom,cabc-en = <0>;
+				qcom,op-fdbck = <0>;
+				qcom,default-state = "on";
+				qcom,max-current = <24>;
+				qcom,init-br = <1706>;
+				somc-s1,br-power-save = <136>;
+				qcom,ctrl-delay-us = <0>;
+				qcom,boost-curr-lim = <3>;
+				qcom,cp-sel = <0>;
+				qcom,switch-freq = <11>;
+				qcom,ovp-val = <2>;
+				qcom,num-strings = <2>;
+				qcom,id = <0>;
+				// [...]
+			};
+		};
+	};
+};
+
+&mdss_dsi0 {
+	qcom,dsi-pref-prim-pan = <&dsi_default_gpio_0>;
+	//vdd-supply = <&pm8941_lvs3>;
+	qcom,platform-enable-gpio = <&pm8941_gpios 20 0>;
+	qcom,platform-lane-config = [];
+	qcom,platform-supply-entry1 {
+			qcom,supply-name = "vdd";
+			qcom,supply-min-voltage = <0>;
+			qcom,supply-max-voltage = <0>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+			qcom,supply-pre-on-sleep = <0>;
+			qcom,supply-post-on-sleep = <0>;
+			qcom,supply-pre-off-sleep = <0>;
+			qcom,supply-post-off-sleep = <0>;
+	};
+	qcom,platform-supply-entry2 {
+			qcom,supply-name = "vddio";
+			qcom,supply-min-voltage = <1800000>;
+			qcom,supply-max-voltage = <1800000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+			qcom,supply-pre-on-sleep = <0>;
+			qcom,supply-post-on-sleep = <0>;
+			qcom,supply-pre-off-sleep = <0>;
+			qcom,supply-post-off-sleep = <0>;
+	};
+	qcom,platform-supply-entry3 {
+			qcom,supply-name = "vdda";
+			qcom,supply-min-voltage = <1200000>;
+			qcom,supply-max-voltage = <1200000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+			qcom,supply-pre-on-sleep = <0>;
+			qcom,supply-post-on-sleep = <0>;
+			qcom,supply-pre-off-sleep = <0>;
+			qcom,supply-post-off-sleep = <0>;
+	};
+};


### PR DESCRIPTION
The bootloader seems to use the dts of the boot partition to initialize
the panel, so a bunch of panel dts is included here.

---
![IMG_20220602_190657](https://user-images.githubusercontent.com/3768500/171685420-e2bec8fe-eac4-4dfd-a896-fa375dc73d87.jpg)

Unfortunately booting something from lk2nd doesn't seem to work, it just boots into "S1 Service" which seems to be some kind of crashdump mode (among others). Also e.g. `fastboot oem lk_log && fastboot get_staged /dev/stdout` just hangs (at the get_staged command)

Others work just fine though:
```
$ fastboot oem dump-speedbin
(bootloader) PVS valid: 1, Redundant fuse select: 0
(bootloader) Speed bin: 3, PVS: 5, PVS version: 1 (speed3-pvs5-v1)
```

Maybe some buffer is smaller on this device compared to other msm8974? (side note but I also saw super weird behavior in the scratch buffer on msm8226 htc-memul so seems some OEMs love modifying core stuff)