### PR TITLE
dts: msm8226: new device (LG Fx0, lg-madai)

### DIFF
--- a/dts/msm8226/msm8926-lg-madai.dts
+++ b/dts/msm8226/msm8926-lg-madai.dts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <200 0>;
+	qcom,board-id = <150 0>;
+
+	model = "LG Fx0";
+	compatible = "lg,madai", "qcom,msm8926", "lk2nd,device";
+	lk2nd,keys =
+		<KEY_HOME       107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+		<KEY_VOLUMEDOWN 106 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+		<KEY_VOLUMEUP   108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+};

--- a/dts/msm8226/rules.mk
+++ b/dts/msm8226/rules.mk
@@ -6,4 +6,5 @@ DTBS += \
 	$(LOCAL_DIR)/apq8026-lg-lenok.dtb \
 	$(LOCAL_DIR)/apq8026-samsung-r03.dtb \
 	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb \
-	$(LOCAL_DIR)/msm8926-huawei-g6-l11-vb.dtb
+	$(LOCAL_DIR)/msm8926-huawei-g6-l11-vb.dtb \
+	$(LOCAL_DIR)/msm8926-lg-madai.dtb


### PR DESCRIPTION
This is an initial attempt to port lk2nd to Fx0. Although it can enter the fastboot mode, booting any vendor kernel image leads to "TZ Crash" screen and directs to some internal debugging mode. If I boot the same kernel image through the device's native bootloader or fastboot then it boots fine. Currently I am experimenting with mainline kernel.

Also lk2nd doesn't look to correctly detect internal eMMC: when it is booted Variant says "Unknown eMMC".

Edit: it was my fault, at least flashing lk2nd within lk2nd works.