### PR TITLE
Add support for OPPO devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Motorola Moto E (2015) - surnia
 - Motorola Moto G (2015) - osprey
 - Motorola Moto G4 Play - harpia
+- OPPO A31t - a31t (use `lk2nd-msm8916-appended-dtb.img`)
+- OPPO A33 - a33 (use `lk2nd-msm8916-appended-dtb.img`)
+- OPPO A37 - a37 (use `lk2nd-msm8916-appended-dtb.img`)
+- OPPO F1f - f1f (use `lk2nd-msm8916-appended-dtb.img`)
+- OPPO Mirror 5s - a51f (use `lk2nd-msm8916-appended-dtb.img`)
+- OPPO R1c - r1c (use `lk2nd-msm8916-appended-dtb.img`)
+- OPPO R5 - r5 (use `lk2nd-msm8916-appended-dtb.img`)
+- OPPO R7f - r7f (use `lk2nd-msm8916-appended-dtb.img`)
+- OPPO R7/R7s Plus - r7plus (use `lk2nd-msm8916-appended-dtb.img`)
+- OPPO R7sf - r7sf (use `lk2nd-msm8916-appended-dtb.img`)
 - Samsung Galaxy A3 (2015) - SM-A300F, SM-A300FU
 - Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU, SM-A500H, SM-A500YZ
 - Samsung Galaxy A7 (2015) - SM-A700YD

--- a/dts/msm8916/msm8916-mtp.dts
+++ b/dts/msm8916/msm8916-mtp.dts
@@ -7,6 +7,12 @@
 / {
 	compatible = "qcom,msm8916-mtp", "qcom,msm8916";
 
+	qcom,msm-id = <206 0>, <248 0>, <249 0>, <250 0>; // Provide a set of msm-id for passing dtbTool
+	qcom,board-id = <8 0 15005>, /* OPPO board-id hax */
+					<8 0 15009>,
+					<8 0 15035>,
+					<8 0 15399>;
+
 	// There are devices that identify themselves as qcom,msm8916-mtp,
 	// even when they are really not (at least physically).
 	// Therefore we need other things we can match on (e.g. the cmdline).
@@ -38,5 +44,67 @@
 		model = "Asus Zenfone Max ZC550KL";
 		compatible = "asus,z010d", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_r69339_720p_video:1:none";
+	};
+
+	oppo-a31t { /* 15005 */
+		model = "OPPO A31t";
+		compatible = "oppo,a31t", "qcom,msm8916", "lk2nd,device";
+		/* FIXME: Add panel match info */
+	};
+
+	oppo-a51f { /* 15009 */
+		model = "OPPO Mirror 5s";
+		compatible = "oppo,a51f", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-panel;
+
+		panel {
+			qcom,mdss_dsi_oppo15009jdi_nt35592_720p_video {
+				compatible = "oppo,jdi-nt35592-15009";
+			};
+
+			qcom,mdss_dsi_oppo15009tm_nt35521_720p_video {
+				compatible = "oppo,tianma-nt35521-15009";
+			};
+
+			qcom,mdss_dsi_oppo15009tm_nt35592_720p_video {
+				compatible = "oppo,tianma-nt35592-15009";
+			};
+		};
+	};
+
+	oppo-a33 { /* 15035 */
+		model = "OPPO A33";
+		compatible = "oppo,a33", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-panel;
+
+		panel {
+			qcom,mdss_dsi_oppo15035tm_otm9605a_540p_video {
+				compatible = "oppo,tianma-tm9605a-15035";
+			};
+
+			qcom,mdss_dsi_oppo15035truly_hx8389c_540p_video {
+				compatible = "oppo,turly-hx8389c-15035";
+			};
+		};
+	};
+
+	oppo-a37 { /* 15399 */
+		model = "OPPO A37";
+		compatible = "oppo,a37", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-panel;
+
+		panel {
+			qcom,mdss_dsi_oppo15399boe_ili9881c_720p_video {
+				compatible = "oppo,boe-ili9881c-15399";
+			};
+
+			qcom,mdss_dsi_oppo15399tm_nt35521s_720p_video {
+				compatible = "oppo,tianma-nt35521s-15399";
+			};
+
+			qcom,mdss_dsi_oppo15399truly_nt35521s_720p_video {
+				compatible = "oppo,turly-nt35521s-15399";
+			};
+		};
 	};
 };

--- a/dts/msm8916/msm8916-mtp.dts
+++ b/dts/msm8916/msm8916-mtp.dts
@@ -3,6 +3,7 @@
 /dts-v1/;
 
 #include <skeleton.dtsi>
+#include <lk2nd.h>
 
 / {
 	compatible = "qcom,msm8916-mtp", "qcom,msm8916";
@@ -71,6 +72,9 @@
 	oppo-a51f { /* 15009 */
 		model = "OPPO Mirror 5s";
 		compatible = "oppo,a51f", "qcom,msm8916", "lk2nd,device";
+		lk2nd,keys =
+			<KEY_VOLUMEDOWN 108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP   107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		lk2nd,match-panel;
 
 		panel {
@@ -91,6 +95,9 @@
 	oppo-a33 { /* 15035 */
 		model = "OPPO A33";
 		compatible = "oppo,a33", "qcom,msm8916", "lk2nd,device";
+		lk2nd,keys =
+			<KEY_VOLUMEDOWN 108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP   107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		lk2nd,match-panel;
 
 		panel {
@@ -107,6 +114,9 @@
 	oppo-a37 { /* 15399 */
 		model = "OPPO A37";
 		compatible = "oppo,a37", "qcom,msm8916", "lk2nd,device";
+		lk2nd,keys =
+			<KEY_VOLUMEDOWN 108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP   107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		lk2nd,match-panel;
 
 		panel {

--- a/dts/msm8916/msm8916-mtp.dts
+++ b/dts/msm8916/msm8916-mtp.dts
@@ -49,7 +49,29 @@
 	oppo-a31t { /* 15005 */
 		model = "OPPO A31t";
 		compatible = "oppo,a31t", "qcom,msm8916", "lk2nd,device";
-		/* FIXME: Add panel match info */
+		lk2nd,match-panel;
+
+		panel {
+			qcom,mdss_dsi_oppo15005tm_fwvga_video {
+				compatible = "oppo,tianma-hx8379-15005";
+			};
+
+			qcom,mdss_dsi_oppo15005boe_fwvga_video {
+				compatible = "oppo,boe-hx8379c-15005";
+			};
+
+			qcom,mdss_dsi_oppo15005truly_fwvga_video {
+				compatible = "oppo,truly-hx8379c-15005";
+			};
+
+			qcom,mdss_dsi_oppo15005tm_nt35512s_fwvga_video {
+				compatible = "oppo,tianma-nt35512s-15005";
+			};
+
+			qcom,mdss_dsi_oppo15005tm_nt35512s_otp_fwvga_video {
+				compatible = "oppo,tianma-otp-nt35512s-15005";
+			};
+		};
 	};
 
 	oppo-a51f { /* 15009 */

--- a/dts/msm8916/msm8916-mtp.dts
+++ b/dts/msm8916/msm8916-mtp.dts
@@ -7,12 +7,6 @@
 / {
 	compatible = "qcom,msm8916-mtp", "qcom,msm8916";
 
-	qcom,msm-id = <206 0>, <248 0>, <249 0>, <250 0>; // Provide a set of msm-id for passing dtbTool
-	qcom,board-id = <8 0 15005>, /* OPPO board-id hax */
-					<8 0 15009>,
-					<8 0 15035>,
-					<8 0 15399>;
-
 	// There are devices that identify themselves as qcom,msm8916-mtp,
 	// even when they are really not (at least physically).
 	// Therefore we need other things we can match on (e.g. the cmdline).

--- a/dts/msm8916/msm8939-mtp.dts
+++ b/dts/msm8916/msm8939-mtp.dts
@@ -61,7 +61,25 @@
 	oppo-r1c { /* 14045 */
 		model = "OPPO R1c";
 		compatible = "oppo,r1c", "qcom,msm8939", "lk2nd,device";
-		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_oppo14017_720p_cmd*";
+		lk2nd,match-panel;
+
+		panel {
+			qcom,mdss_dsi_jdi_720p_video {
+				compatible = "oppo,jdi-td4291";
+			};
+
+			qcom,mdss_dsi_oppo14017_720p_cmd {
+				compatible = "oppo,jdi-otm1282c-14045";
+			};
+
+			qcom,mdss_dsi_oppo14017synaptics_720p_video {
+				compatible = "oppo,jdi-otm1282c-synaptics-14045";
+			};
+
+			qcom,mdss_dsi_oppo14045_720p_cmd {
+				compatible = "oppo,synaptics-14045";
+			};
+		};
 	};
 
 	oppo-r7f { /* 15011 */

--- a/dts/msm8916/msm8939-mtp.dts
+++ b/dts/msm8916/msm8939-mtp.dts
@@ -3,6 +3,7 @@
 /dts-v1/;
 
 #include <skeleton.dtsi>
+#include <lk2nd.h>
 
 / {
 	compatible = "qcom,msm8939-mtp", "qcom,msm8939";
@@ -48,6 +49,9 @@
 	oppo-r5 { /* 14005 */
 		model = "OPPO R5";
 		compatible = "oppo,r5", "qcom,msm8939", "lk2nd,device";
+		lk2nd,keys =
+			<KEY_VOLUMEDOWN 108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP   107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_samsung_ams520bq04_s6e3fa2x01_1080p_cmd*";
 	};
 
@@ -78,24 +82,36 @@
 	oppo-r7f { /* 15011 */
 		model = "OPPO R7f";
 		compatible = "oppo,r7f", "qcom,msm8939", "lk2nd,device";
+		lk2nd,keys =
+			<KEY_VOLUMEDOWN	108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP	107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_oppo15011samsung_s6e3fa3_1080p_cmd*";
 	};
 
 	oppo-r7plus { /* 15018 */
 		model = "OPPO R7/R7s Plus";
 		compatible = "oppo,r7plus", "qcom,msm8939", "lk2nd,device";
+		lk2nd,keys =
+			<KEY_VOLUMEDOWN	108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP	107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_oppo15018samsung_s6e3fa3_1080p_cmd*";
 	};
 
 	oppo-r7sf { /* 15022 */
 		model = "OPPO R7sf";
 		compatible = "oppo,r7sf", "qcom,msm8939", "lk2nd,device";
+		lk2nd,keys =
+			<KEY_VOLUMEDOWN	108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP	107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_oppo15023samsung_s6e3fa3_1080p_cmd*";
 	};
 
 	oppo-f1f { /* 15109 */
 		model = "OPPO F1f";
 		compatible = "oppo,f1f", "qcom,msm8939", "lk2nd,device";
+		lk2nd,keys =
+			<KEY_VOLUMEDOWN	108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP	107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		lk2nd,match-panel;
 
 		panel {

--- a/dts/msm8916/msm8939-mtp.dts
+++ b/dts/msm8916/msm8939-mtp.dts
@@ -7,14 +7,7 @@
 / {
 	compatible = "qcom,msm8939-mtp", "qcom,msm8939";
 	qcom,msm-id = <239 0>;
-	qcom,board-id = <8 0>,
-					/* OPPO board-id hax */
-					<8 0 14005>,
-					<8 0 14045>,
-					<8 0 15011>,
-					<8 0 15018>,
-					<8 0 15022>,
-					<8 0 15109>;
+	qcom,board-id = <8 0>;
 
 	alcatel-idol3 {
 		model = "Alcatel OneTouch Idol 3 (5.5)";

--- a/dts/msm8916/msm8939-mtp.dts
+++ b/dts/msm8916/msm8939-mtp.dts
@@ -7,7 +7,14 @@
 / {
 	compatible = "qcom,msm8939-mtp", "qcom,msm8939";
 	qcom,msm-id = <239 0>;
-	qcom,board-id = <8 0>;
+	qcom,board-id = <8 0>,
+					/* OPPO board-id hax */
+					<8 0 14005>,
+					<8 0 14045>,
+					<8 0 15011>,
+					<8 0 15018>,
+					<8 0 15022>,
+					<8 0 15109>;
 
 	alcatel-idol3 {
 		model = "Alcatel OneTouch Idol 3 (5.5)";
@@ -41,6 +48,64 @@
 
 			qcom,mdss_dsi_jdi_nt35595_1080p_video {
 				compatible = "xiaomi,jdi-nt35595";
+			};
+		};
+	};
+
+	oppo-r5 { /* 14005 */
+		model = "OPPO R5";
+		compatible = "oppo,r5", "qcom,msm8939", "lk2nd,device";
+		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_samsung_ams520bq04_s6e3fa2x01_1080p_cmd*";
+	};
+
+	oppo-r1c { /* 14045 */
+		model = "OPPO R1c";
+		compatible = "oppo,r1c", "qcom,msm8939", "lk2nd,device";
+		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_oppo14017_720p_cmd*";
+	};
+
+	oppo-r7f { /* 15011 */
+		model = "OPPO R7f";
+		compatible = "oppo,r7f", "qcom,msm8939", "lk2nd,device";
+		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_oppo15011samsung_s6e3fa3_1080p_cmd*";
+	};
+
+	oppo-r7plus { /* 15018 */
+		model = "OPPO R7/R7s Plus";
+		compatible = "oppo,r7plus", "qcom,msm8939", "lk2nd,device";
+		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_oppo15018samsung_s6e3fa3_1080p_cmd*";
+	};
+
+	oppo-r7sf { /* 15022 */
+		model = "OPPO R7sf";
+		compatible = "oppo,r7sf", "qcom,msm8939", "lk2nd,device";
+		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_oppo15023samsung_s6e3fa3_1080p_cmd*";
+	};
+
+	oppo-f1f { /* 15109 */
+		model = "OPPO F1f";
+		compatible = "oppo,f1f", "qcom,msm8939", "lk2nd,device";
+		lk2nd,match-panel;
+
+		panel {
+			qcom,mdss_dsi_hx8394d_720p_video {
+				compatible = "oppo,turly-hx8394d";
+			};
+
+			qcom,mdss_dsi_hx8394h_720p_video {
+				compatible = "oppo,tianma-hx8394h";
+			};
+
+			qcom,mdss_dsi_oppo15109boe_ili9881c_720p_video {
+				compatible = "oppo,boe-ili9881c-15109";
+			};
+
+			qcom,mdss_dsi_oppo15109tm_nt35592_720p_video {
+				compatible = "oppo,tianma-nt35592-15109";
+			};
+
+			qcom,mdss_dsi_oppo15109truly_hx8394f_720p_video {
+				compatible = "oppo,turly-hx8394f-15109";
 			};
 		};
 	};


### PR DESCRIPTION
* Supported devices newly added in this commit includes:
  OPPO A31t
  OPPO A33
  OPPO A37
  OPPO F1f
  OPPO Mirror 5s
  OPPO R1c
  OPPO R5
  OPPO R7f
  OPPO R7/R7s Plus
  OPPO R7sf