### PR TITLE
README.md: Building: Add Alpine Linux and postmarketOS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,15 +156,20 @@ $ make TOOLCHAIN_PREFIX=arm-none-eabi- lk2nd-msmXXXX
 **Requirements:**
 - ARM (32 bit) GCC tool chain
   - Arch Linux: `arm-none-eabi-gcc`
+  - Alpine Linux and postmarketOS: `gcc-arm-none-eabi`
   - Debian and Ubuntu: `gcc-arm-none-eabi`
   - Fedora: `arm-none-eabi-gcc-cs`
 - [Device Tree Compiler](https://git.kernel.org/pub/scm/utils/dtc/dtc.git)
   - Arch Linux: `dtc`
+  - Alpine Linux and postmarketOS: `dtc`
   - Debian and Ubuntu: `device-tree-compiler`
   - Fedora: `dtc`
 - libfdt
+  - Alpine Linux and postmarketOS: `dtc-dev`
   - Debian and Ubuntu: `libfdt-dev`
   - Fedora: `libfdt-devel`
+- GNU tar
+  - Alpine Linux and postmarketOS: `tar`
 
 Replace `TOOLCHAIN_PREFIX` with the path to your tool chain.
 `lk2nd.img` is built and placed into `build-lk2nd-msmXXXX/lk2nd.img`.


### PR DESCRIPTION
busybox tar doesn't unrecognize option sort=name.
Add GNU tar into the dependencies in addition.