### PR TITLE
dts: msm8916: a5ltezt: move to msm8916-samsung-r11

### DIFF
--- a/dts/msm8916/msm8916-samsung-r08.dts
+++ b/dts/msm8916/msm8916-samsung-r08.dts
@@ -16,14 +16,6 @@
 		lk2nd,match-bootloader = "A500F*";
 	};
 
-	a5ltezt {
-		// In the downstream dts it is called Samsung A5 PROJECT Rev02
-		model = "Samsung Galaxy A5 (SM-A500YZ)";
-		compatible = "samsung,a5u-eur", "qcom,msm8916", "lk2nd,device";
-		lk2nd,match-bootloader = "A500YZ*";
-		lk2nd,smd-rpm-hack-opening;
-	};
-
 	gt510lte {
 		model = "Samsung Galaxy Tab A 9.7 LTE (2015) (SM-T555)";
 		compatible = "samsung,gt510lte", "qcom,msm8916", "lk2nd,device";

--- a/dts/msm8916/msm8916-samsung-r11.dts
+++ b/dts/msm8916/msm8916-samsung-r11.dts
@@ -10,6 +10,13 @@
 	qcom,msm-id = <206 0>;
 	qcom,board-id = <0xCE08FF01 11>;
 
+	a5ltezt {
+		model = "Samsung Galaxy A5 (SM-A500YZ)";
+		compatible = "samsung,a5u-eur", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "A500YZ*";
+		lk2nd,smd-rpm-hack-opening;
+	};
+
 	/*
 	 * Before building for G530Y, please comment out all dtbs except
 	 * "$(LOCAL_DIR)/msm8916-samsung-r11.dtb" at './rules.mk'.

--- a/dts/msm8916/msm8929-samsung-r04.dts
+++ b/dts/msm8916/msm8929-samsung-r04.dts
@@ -61,13 +61,12 @@
 	};
 
 	a5ltezt {
-		// In the downstream dts it is called Samsung A5 PROJECT Rev02
 		model = "Samsung Galaxy A5 (SM-A500YZ)";
 		compatible = "samsung,a5u-eur", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "A500YZ*";
 
 		qcom,msm-id = <206 0>;
-		qcom,board-id = <0xCE08FF01 8>;
+		qcom,board-id = <0xCE08FF01 11>;
 		lk2nd,smd-rpm-hack-opening;
 	};
 


### PR DESCRIPTION
The latest revision of SM-A500YZ (a5ltezt) should be r11.
Move it to msm8916-samsung-r11.