### PR TITLE
dts: msm8974: samsung-klte: panel selection

### DIFF
--- a/dts/msm8974/msm8974-samsung-r14.dts
+++ b/dts/msm8974/msm8974-samsung-r14.dts
@@ -12,5 +12,25 @@
 		model = "Samsung Galaxy S5 (SM-G900F)";
 		compatible = "samsung,klte", "qcom,msm8974", "lk2nd,device";
 		lk2nd,match-bootloader = "G900F*";
+
+		/*
+		* samsung-klte has at least 2 known panel variations:
+		* - S6E3FA2 (mdss_mdp.panel=1:dsi:0:mdss_dsi_samsung_1080p_cmd_fa2)
+		* - EA8064G (mdss_mdp.panel=1:dsi:0:mdss_dsi_samsung_1080p_cmd_mag)
+		* Upstream mainline kernel already has "samsung,s6e3fa2" compatible set
+		* for panel in dts, and we'll not change that. We'll only do
+		* replacement for ea8064g one (replace samsung,s6e3fa2 to
+		* samsung,ea8064g).
+		*/
+		panel {
+			/* Default is Samsung S6E3FA2 */
+			compatible = "samsung,s6e3fa2";
+			replace-compatible;
+
+			/* MagnaChip EA8064G */
+			mdss_dsi_samsung_1080p_cmd_mag {
+				compatible = "samsung,ea8064g";
+			};
+		};
 	};
 };

--- a/lk2nd/lk2nd-device.c
+++ b/lk2nd/lk2nd-device.c
@@ -257,6 +257,7 @@ static void lk2nd_parse_panels(const void *fdt, int offset)
 	struct lk2nd_panel *panel = &lk2nd_dev.panel;
 	const char *old, *new, *ts;
 	int old_len, new_len, ts_len;
+	bool replace_mode = false;
 
 	offset = fdt_subnode_offset(fdt, offset, "panel");
 	if (offset < 0)
@@ -265,6 +266,8 @@ static void lk2nd_parse_panels(const void *fdt, int offset)
 	old = lkfdt_getprop_str(fdt, offset, "compatible", &old_len);
 	if (!old || old_len < 1)
 		return;
+
+	replace_mode = !!fdt_getprop(fdt, offset, "replace-compatible", NULL);
 
 	offset = fdt_subnode_offset(fdt, offset, panel->name);
 	if (offset < 0) {
@@ -285,6 +288,9 @@ static void lk2nd_parse_panels(const void *fdt, int offset)
 
 	strlcpy((char*) panel->compatible, new, new_len);
 	strlcpy((char*) panel->old_compatible, old, old_len);
+
+	if (replace_mode)
+		panel->compatible_size = new_len;
 
 	ts = lkfdt_getprop_str(fdt, offset, "touchscreen-compatible", &ts_len);
 	if (!ts || ts_len < 1)


### PR DESCRIPTION
Add support for overwriting panel compatible for Samsung Galaxy S5 for 2nd variation of the panel.

Default is considered to be s6e3fa2; add support for detecting ea8064g.

This is needed to submit panel drivers to mainline, as upstream requires them to be separate and not one combined driver.