### PR TITLE
dts: fairphone-fp2: Use touchscreen selection

### DIFF
--- a/dts/msm8974/msm8974pro-ab-pm8941-mtp.dts
+++ b/dts/msm8974/msm8974pro-ab-pm8941-mtp.dts
@@ -33,9 +33,11 @@
 
 			qcom,mdss_dsi_otm1902b_1080p_cmd {
 				compatible = "fairphone,fp2-panel-otm1902b";
+				touchscreen-compatible = "syna,rmi4-i2c";
 			};
 			qcom,mdss_dsi_s6d6fa1_1080p_video {
 				compatible = "fairphone,fp2-panel-s6d6fa1";
+				touchscreen-compatible = "ilitek,ili2120";
 			};
 		};
 	};


### PR DESCRIPTION
Use the new touchscreen-compatible suppport to associate rmi4-i2c with otm1902b panel and ili2120 with s6d6fa1 panel.