### PR TITLE
dts: msm8974: Add OnePlus One

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -639,7 +639,9 @@ unsigned char *update_cmdline(const char *cmdline)
 	bool lk2nd = lk2nd_cmdline_scan(cmdline, "lk2nd");
 
 	/* Only add to cmdline if downstream or lk2nd */
-	if (!lk2nd_cmdline_scan(cmdline, "androidboot.hardware=qcom") && !lk2nd)
+	if (!lk2nd_cmdline_scan(cmdline, "androidboot.hardware=qcom") &&
+	    !lk2nd_cmdline_scan(cmdline, "androidboot.hardware=bacon") &&
+	    !lk2nd)
 		return strdup(cmdline);
 
 	/* Use cmdline from original bootloader if available */

--- a/dts/msm8974/msm8974pro-ac-pm8941-mtp.dts
+++ b/dts/msm8974/msm8974pro-ac-pm8941-mtp.dts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	// There are devices that identify themselves as msm8974pro-ac-pm8941-mtp,
+	// even when they are really not (at least physically).
+	// Therefore we need other things we can match on (e.g. the cmdline).
+	compatible = "qcom,msm8974-mtp", "qcom,msm8974";
+	qcom,msm-id = <194 0x10000>;
+	qcom,board-id = <8 0>;
+
+	oneplus-bacon {
+		model = "OnePlus One";
+		compatible = "oneplus,bacon", "qcom,msm8974", "lk2nd,device";
+		lk2nd,match-cmdline = "* androidboot.hardware=bacon *";
+
+		lk2nd,keys =
+			<KEY_VOLUMEUP   PM_GPIO(5) PM_GPIO_PULL_UP_1_5>,
+			<KEY_VOLUMEDOWN PM_GPIO(2) PM_GPIO_PULL_UP_1_5>;
+	};
+};

--- a/dts/msm8974/rules.mk
+++ b/dts/msm8974/rules.mk
@@ -5,4 +5,5 @@ DTBS += \
 	$(LOCAL_DIR)/msm8974-lge-hammerhead.dtb \
 	$(LOCAL_DIR)/msm8974-samsung-r10.dtb \
 	$(LOCAL_DIR)/msm8974-samsung-r14.dtb \
-	$(LOCAL_DIR)/msm8974pro-ab-pm8941-mtp.dtb
+	$(LOCAL_DIR)/msm8974pro-ab-pm8941-mtp.dtb \
+	$(LOCAL_DIR)/msm8974pro-ac-pm8941-mtp.dtb

--- a/lk2nd/lk2nd-device.c
+++ b/lk2nd/lk2nd-device.c
@@ -520,6 +520,7 @@ void lk2nd_update_device_tree(void *fdt, const char *cmdline, bool arm64)
 {
 	/* Don't touch lk2nd/downstream dtb */
 	if (lk2nd_cmdline_scan(cmdline, "androidboot.hardware=qcom") ||
+	    lk2nd_cmdline_scan(cmdline, "androidboot.hardware=bacon") ||
 	    lk2nd_cmdline_scan(cmdline, "lk2nd"))
 		return;
 

--- a/project/lk2nd-msm8974.mk
+++ b/project/lk2nd-msm8974.mk
@@ -6,7 +6,7 @@ include $(LOCAL_DIR)/lk2nd-base.mk
 
 DEFINES += WITH_DEBUG_LOG_BUF=1
 
-APPSBOOTHEADER: $(OUTBOOTIMG) $(OUTODINTAR)
+APPSBOOTHEADER: $(OUTBOOTIMG) $(OUTBOOTIMGADTB) $(OUTODINTAR)
 ANDROID_BOOT_BASE := 0x00000000
 
 # Memory usually reserved for RMTFS, should be fine for early SMP bring-up


### PR DESCRIPTION
This device needs to use lk2nd-appended-dtb.img, the other one fails with 'dtb not found'.

---

Not sure if we should call this "msm8974" or "msm8974pro". Linux now has both file names and compatibles adjusted for Snapdragon 801 (vs 800) devices to use msm8974pro. Shall we follow with this here?