### PR TITLE
Add dts for 4G modem stick ufi-001c/ufi-001b

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Xiaomi Mi 4i - ferrari
 - Xiaomi Redmi 2 - wt86047, wt88047
 - Yamada EveryPad III (rebrand of Lenovo PHAB Plus)
+- Zhihe-series 4G Modem Stick - ufi-001c(b)
 
 ### lk2nd-msm8974
 - Fairphone 2 - FP2

--- a/dts/msm8916/msm8916-512mb-mtp.dts
+++ b/dts/msm8916/msm8916-512mb-mtp.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	compatible = "qcom,msm8916-512mb-mtp", "qcom,msm8916";
+	qcom,msm-id = <206 0>;
+	qcom,board-id = <8 0x100>;
+	
+	zhihe-ufi-001c {
+		model = "ufi-001b/ufi-001c 4G Modem Stick";
+		compatible = "zhihe,ufi-001c", "qcom,msm8916", "lk2nd,device";
+
+		/* Register EDL button as HOME button */
+		/* This is the only button on this device */
+		lk2nd,keys = <KEY_HOME 37 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+	};
+};

--- a/dts/msm8916/rules.mk
+++ b/dts/msm8916/rules.mk
@@ -8,6 +8,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8216-samsung-r05.dtb \
 	$(LOCAL_DIR)/msm8216-samsung-r07.dtb \
 	$(LOCAL_DIR)/msm8216-samsung-r08.dtb \
+	$(LOCAL_DIR)/msm8916-512mb-mtp.dtb \
 	$(LOCAL_DIR)/msm8916-asus-z00l.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-g7-l01.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-hwt1a21l.dtb \


### PR DESCRIPTION
It's a cheap 4G modem stick mainly sold in China with 512MB RAM and 4GB ROM.
The manufacturer is unknown and the vendor is meaningless, because many vendors just share the same board.
The vendor name "zhihe(纸盒/芷荷)" is got from a Chinese forum and is commonly used to refer to such boards(There are some boards similar to this one, but they are almost the same with tiny differences).
Confirmed to work.