### PR TITLE
app: aboot: Also try fsboot with "fastboot continue"

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -3343,6 +3343,15 @@ void cmd_continue(const char *arg, void *data, unsigned sz)
 		/* Exit keys' detection thread firstly */
 		exit_menu_keys_detection();
 #endif
+
+		/* Try to boot from first fs we can find */
+		ssize_t loaded_file = fsboot_boot_first(target_get_scratch_address(), target_get_max_flash_size());
+
+		if (loaded_file > 0)
+			cmd_boot(NULL, target_get_scratch_address(), target_get_max_flash_size());
+
+		dprintf(CRITICAL, "Unable to load boot.img from ext2. Continuing legacy boot\n");
+
 		boot_linux_from_mmc();
 	}
 	else


### PR DESCRIPTION
Copy the relevant code from aboot_init function so fs-boot also works in this case also.