### PR TITLE
dts: msm8916: Add support for 4G UFI stick (UFI003_MB_V02)

### DIFF
--- a/dts/msm8916/msm8916-unknow-ufi003mb.dts
+++ b/dts/msm8916/msm8916-unknow-ufi003mb.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+ 	model= "Unbranded 4G UFI stick (UFI003_MB_V02)";
+	compatible = "unknow,ufi003-mb", "qcom,msm8916", "lk2nd,device";
+ 	qcom,board-id = <0x08 0x100>;
+ 	qcom,msm-id = <0xce 0x00 0xf8 0x00 0xf9 0x00 0xfa 0x00>;
+	//Register EDL button as HOME button in order to use the only button on the board into fastboot
+ 	lk2nd,keys = <KEY_HOME 37 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+};

--- a/dts/msm8916/rules.mk
+++ b/dts/msm8916/rules.mk
@@ -36,6 +36,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-samsung-r06.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r08.dtb \
 	$(LOCAL_DIR)/msm8916-samsung-r11.dtb \
+	$(LOCAL_DIR)/msm8916-unknow-ufi003mb.dtb \
 	$(LOCAL_DIR)/msm8929-qrd-wt82918.dtb \
 	$(LOCAL_DIR)/msm8929-samsung-r00.dtb \
 	$(LOCAL_DIR)/msm8929-samsung-r04.dtb \


### PR DESCRIPTION
UFI003_MB_V02 is a tiny 4G-WiFi-USB-Router based on msm8916.

Specification:

- System-On-Chip: msm8916
- Flash size: 4 GiB
- RAM: 512 MiB
- 1x male USB 2.0 port
- An EDL button on board

Reference:
https://forum.openwrt.org/t/uf896-qualcomm-msm8916-lte-router-384mib-ram-2-4gib-flash-android-openwrt/131712 https://hackaday.com/2022/08/03/hackable-20-modem-combines-lte-and-pi-zero-w2-power/