### PR TITLE
target: msm8916: meminfo: reduce max download size to 192 MiB

### DIFF
--- a/target/msm8916/meminfo.c
+++ b/target/msm8916/meminfo.c
@@ -81,5 +81,6 @@ void *target_get_scratch_address(void)
 
 unsigned target_get_max_flash_size(void)
 {
-	return (256 * 1024 * 1024);
+	// 256 MiB breaks some low-memory devices, 192 MiB should be sufficient.
+	return (192 * 1024 * 1024);
 }


### PR DESCRIPTION
256 MiB is too big for some low-memory devices and cause crashes.
Tested on a LTE dongle.

Resolve #239 