### PR TITLE
dts: msm8916: Add Galaxy A5U CAN (SM-A500W)

### DIFF
--- a/dts/msm8916/msm8916-samsung-r11.dts
+++ b/dts/msm8916/msm8916-samsung-r11.dts
@@ -16,6 +16,13 @@
 		lk2nd,match-bootloader = "A500YZ*";
 		lk2nd,smd-rpm-hack-opening;
 	};
+	
+	a5u-canbmc {
+		// In downstream it is called Samsung A5U CAN PROJECT Rev01
+		model = "Samsung Galaxy A5U (CAN)";
+		compatible = "samsung,a5u-canbmc", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "A500W*";
+	};
 
 	/*
 	 * Before building for G530Y, please comment out all dtbs except

--- a/dts/msm8916/msm8916-samsung-r11.dts
+++ b/dts/msm8916/msm8916-samsung-r11.dts
@@ -22,6 +22,8 @@
 		model = "Samsung Galaxy A5U (CAN)";
 		compatible = "samsung,a5u-canbmc", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "A500W*";
+		qcom,msm-id = <206 0>;
+		qcom,board-id = <0xCE08FF01 1>;
 	};
 
 	/*


### PR DESCRIPTION
Add dts support for galaxy a5u canbmc (a500w)
its just a5u with different firmware, picks strange dts tho.
[downstream dts](https://github.com/Galaxy-MSM8916/android_kernel_samsung_msm8916/blob/lineage-17.1/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-a5u-canbmc-r01.dts)