### PR TITLE
dts: msm8916: msm8916-512mb-mtp: Add 4G modem stick mf601xx variants

### DIFF
--- a/dts/msm8916/msm8916-512mb-mtp.dts
+++ b/dts/msm8916/msm8916-512mb-mtp.dts
@@ -10,13 +10,19 @@
 	qcom,msm-id = <206 0>;
 	qcom,board-id = <8 0x100>;
 	
+	// Also supports UFI003_MB_V02 and MF601 variants
 	zhihe-ufi-001c {
 		model = "ufi-001b/ufi-001c 4G Modem Stick";
 		compatible = "zhihe,ufi-001c", "qcom,msm8916", "lk2nd,device";
 
 		/* Register EDL button as HOME button */
-		/* This is the only button on this device */
-		lk2nd,keys = <KEY_HOME 37 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+		/* This is the only button on UFI-001C */
+		lk2nd,keys = <KEY_HOME 37 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+		// The following keys are found on MF601
+		// RESET button on the back of the device
+			     <KEY_HOME 34 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+		// WPS button near the power button(may not exist on some variants)
+			     <KEY_HOME 107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		lk2nd,match-cmdline = "* mdss_mdp.panel=1:spi:0:qcom,mdss_spi_st7735s_128128_cmd";
 	};
 


### PR DESCRIPTION
This series of devices shares the same board-id and kernel command line arguments with ufi-001c, so the support for them is on top of ufi-001c.

WPS button is not tested because mine doesn't have one, but I think it probably works. Tested both on MF601SL(lk2nd, lk1st) and UFI-001C(lk1st).