### PR TITLE
dts: Add Samssung A5 (Duos) (SM-A5000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Motorola Moto G (2015) - osprey
 - Motorola Moto G4 Play - harpia
 - Samsung Galaxy A3 (2015) - SM-A300F, SM-A300FU
-- Samsung Galaxy A5 (2015) - SM-A500F, SM-A500FU, SM-A500H, SM-A500YZ
+- Samsung Galaxy A5 (Duos) (2015) - SM-A5000, SM-A500F, SM-A500FU, SM-A500H, SM-A500YZ
 - Samsung Galaxy A7 (2015) - SM-A700YD
 - Samsung Galaxy Ace 4 - SM-G357FZ (quirky - see comment in `dts/msm8916/msm8916-samsung-r02.dts`)
 - Samsung Galaxy Core Max - SM-G5108Q (quirky - see comment in `dts/msm8916/msm8916-samsung-r08.dts`)

--- a/dts/msm8916/msm8916-samsung-r11.dts
+++ b/dts/msm8916/msm8916-samsung-r11.dts
@@ -9,6 +9,13 @@
 	// This is used by the bootloader to find the correct DTB
 	qcom,msm-id = <206 0>;
 	qcom,board-id = <0xCE08FF01 11>;
+	
+	// In downstream it is called Samsung A5 PROJECT Rev11 and its marketing name is Samsung Galaxy A5 Duos
+	a5ltechn {
+		model = "Samsung Galaxy A5 Duos (SM-A5000)";
+		compatible = "samsung,a5ltechn", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "A5000*";
+	};
 
 	a5ltezt {
 		model = "Samsung Galaxy A5 (SM-A500YZ)";


### PR DESCRIPTION

![aa](https://github.com/msm8916-mainline/lk2nd/assets/70055899/731c6989-b628-458b-9f92-bf1c83d9929d)



it is likely an china variant or a hk variant of a5 because there are seem to be only hk and cn version of stock firmw
      are for it. 
[build.prop.txt](https://github.com/msm8916-mainline/lk2nd/files/11614522/build.prop.txt)
There are 2 code name beibg found in the /system/build.prop (a5ltechn and a5ltezc) of the stock rom 

a5ltechn should be the code name of it bc the hostname of the stock rom is a5ltechn 