### PR TITLE
dts: msm8926: add support for Coolpad 8730L

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 
 ### lk2nd-msm8226
 - ASUS ZenWatch 2 - sparrow
+- Coolpad 8730L - 8730l
 - Huawei Ascend G6 4G - G6-L11 (quirky - see comment in `dts/msm8226/msm8926-huawei-g6-l11-vb.dts`)
 - Huawei Watch - sturgeon
 - LG G Watch R - lenok (use `lk2nd-appended-dtb.img`)

--- a/dts/msm8226/msm8926-v2-720p-mtp.dts
+++ b/dts/msm8226/msm8926-v2-720p-mtp.dts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	compatible = "qcom,msm8926-mtp", "qcom,msm8926";
+
+	qcom,msm-id = <200 0>;
+	qcom,board-id = <8 0>;
+
+	coolpad-8730l {
+		model = "Coolpad 8730L";
+		compatible = "coolpad,8730l", "qcom,msm8926", "lk2nd,device";
+		lk2nd,match-panel;
+
+		panel {
+			qcom,mdss_dsi_otm1283a_boyi_hd_video {};
+			qcom,mdss_dsi_hx8394a_lide_hd_video {};
+			qcom,mdss_dsi_hx8394a_yashi_hd_video {};
+			qcom,mdss_dsi_hx8394a_yashi_cmi_hd_video {};
+			qcom,mdss_dsi_otm1283a_boyi_auo_hd_video {};
+			qcom,mdss_dsi_otm1283a_lide_cpt_hd_video {};
+		};
+	};
+};

--- a/dts/msm8226/rules.mk
+++ b/dts/msm8226/rules.mk
@@ -9,4 +9,5 @@ DTBS += \
 	$(LOCAL_DIR)/msm8226-motorola-falcon.dtb \
 	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb \
 	$(LOCAL_DIR)/msm8926-huawei-g6-l11-vb.dtb \
-	$(LOCAL_DIR)/msm8926-samsung-r02.dtb
+	$(LOCAL_DIR)/msm8926-samsung-r02.dtb \
+	$(LOCAL_DIR)/msm8926-v2-720p-mtp.dtb


### PR DESCRIPTION
![8730l](https://github.com/msm8916-mainline/lk2nd/assets/43387518/85a97c28-adfd-42b9-bacd-99ad3b522ab8)

Tried with downstream kernel, vol-down gets into fastboot mode.

~TODO: add gpio definition for HOME button.~