### PR TITLE
dts: msm8916: add support for Asus ZE500KL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - ARK Benefit A3 - peach
 - Asus Zenfone 2 Laser (720p) - Z00L
 - Asus Zenfone 2 Laser (1080p) - Z00T
+- Asus Zenfone 2 Laser ZE500KL - Z00E
 - Asus Zenfone Max ZC550KL (2016) - Z010D
 - BQ Aquaris M5 - piccolo (use `lk2nd-msm8916-appended-dtb.img`)
 - BQ Aquaris X5 - paella, picmt

--- a/dts/msm8916/msm8916-asus-z00e.dts
+++ b/dts/msm8916/msm8916-asus-z00e.dts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	qcom,msm-id = <206 0>;
+	qcom,board-id = <24 0>;
+	model = "Asus Zenfone 2 Laser ZE500KL";
+	compatible = "asus,z00e", "qcom,msm8916", "lk2nd,device";
+
+	lk2nd,keys =
+		<KEY_VOLUMEDOWN 117 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+		<KEY_VOLUMEUP   107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+
+	panel {
+		compatible = "asus,z00e-panel";
+
+		qcom,mdss_dsi_otm1284a_720p_video {
+			compatible = "asus,z00e-otm1284a";
+		};
+		qcom,mdss_dsi_auo_rm68200_720p_video {
+			compatible = "asus,z00e-auo-rm68200";
+		};
+	};
+};

--- a/dts/msm8916/rules.mk
+++ b/dts/msm8916/rules.mk
@@ -10,6 +10,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8216-samsung-r08.dtb \
 	$(LOCAL_DIR)/msm8916-512mb-mtp.dtb \
 	$(LOCAL_DIR)/msm8916-asus-z00l.dtb \
+        $(LOCAL_DIR)/msm8916-asus-z00e.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-g7-l01.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-hwt1a21l.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-y635-l01.dtb \


### PR DESCRIPTION
adapted from Asus z00l, and changed the 2nd panel to one that my unit has, as first panel from z00l is found on z00e aswell.