### PR TITLE
Huawei GX8 (RIO-L01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - GPLUS FL8005A
 - HTC One M8s - m8qlul (quirky - see comment in `dts/msm8916/msm8939-htc-m8qlul.dts`)
 - Huawei Ascend G7 - G7-L01
+- Huawei G8 / GX8 / RIO-L01 - rio
 - Huawei Honor 5X / GR5 (2016) - kiwi
 - Huawei Y635 - Y635-L01 (quirky - see comment in `dts/msm8916/msm8916-huawei-y635-l01.dts`)
 - Lenovo A6000

--- a/dts/msm8916/msm8939-huawei-kiwi.dts
+++ b/dts/msm8916/msm8939-huawei-kiwi.dts
@@ -7,12 +7,27 @@
 / {
 	qcom,msm-id = <239 0>;
 	qcom,board-id =
-		<8001 4>, <8007 4>, <8017 4>, <8019 4>,
-		<8023 4>, <8033 4>, <8039 4>, <8049 4>,
-		<8051 4>, <8054 4>, <8065 4>, <8067 4>,
-		<8070 4>, <8081 4>, <8083 4>, <8086 4>,
-		<8097 4>, <8099 4>, <8103 4>, <8115 4>,
-		<8116 4>, <8119 4>, <8131 4>;
+		<8001 4>, // huawei_kiw_al10_va.dts
+		<8003 4>, // huawei_kiw_al10_vb.dts
+		<8007 4>, // huawei_kiw_cl00_vc.dts
+		<8017 4>, // huawei_kiw_ul00_va.dts
+		<8019 4>, // huawei_kiw_ul00_vb.dts
+		<8023 4>, // huawei_kiw_tl00h_vc.dts
+		<8033 4>, // huawei_kiw_cl00_va.dts
+		<8035 4>, // huawei_kiw_cl00_vb.dts
+		<8039 4>, // huawei_kiw_l21_vc.dts
+		<8049 4>, // huawei_kiw_tl00h_va.dts
+		<8051 4>, // huawei_kiw_tl00h_vb.dts
+		<8065 4>, // huawei_kiw_l21_va.dts
+		<8067 4>, // huawei_kiw_l21_vb.dts
+		<8081 4>, // huawei_kiw_l22_va.dts
+		<8083 4>, // huawei_kiw_l22_vb.dts
+		<8097 4>, // huawei_kiw_l23_va.dts
+		<8099 4>, // huawei_kiw_l23_vb.dts
+		<8103 4>, // huawei_kiw_l22_vc.dts
+		<8115 4>, // huawei_kiw_al10_vc.dts
+		<8119 4>, // huawei_kiw_l23_vc.dts
+		<8131 4>; // huawei_kiw_ul00_vc.dts
 
 	model = "Huawei Honor 5X / GR5 (2016)";
 	compatible = "huawei,kiwi", "qcom,msm8939", "lk2nd,device";

--- a/dts/msm8916/msm8939-huawei-kiwi.dts
+++ b/dts/msm8916/msm8939-huawei-kiwi.dts
@@ -7,27 +7,12 @@
 / {
 	qcom,msm-id = <239 0>;
 	qcom,board-id =
-		<8001 4>, // huawei_kiw_al10_va.dts
-		<8003 4>, // huawei_kiw_al10_vb.dts
-		<8007 4>, // huawei_kiw_cl00_vc.dts
-		<8017 4>, // huawei_kiw_ul00_va.dts
-		<8019 4>, // huawei_kiw_ul00_vb.dts
-		<8023 4>, // huawei_kiw_tl00h_vc.dts
-		<8033 4>, // huawei_kiw_cl00_va.dts
-		<8035 4>, // huawei_kiw_cl00_vb.dts
-		<8039 4>, // huawei_kiw_l21_vc.dts
-		<8049 4>, // huawei_kiw_tl00h_va.dts
-		<8051 4>, // huawei_kiw_tl00h_vb.dts
-		<8065 4>, // huawei_kiw_l21_va.dts
-		<8067 4>, // huawei_kiw_l21_vb.dts
-		<8081 4>, // huawei_kiw_l22_va.dts
-		<8083 4>, // huawei_kiw_l22_vb.dts
-		<8097 4>, // huawei_kiw_l23_va.dts
-		<8099 4>, // huawei_kiw_l23_vb.dts
-		<8103 4>, // huawei_kiw_l22_vc.dts
-		<8115 4>, // huawei_kiw_al10_vc.dts
-		<8119 4>, // huawei_kiw_l23_vc.dts
-		<8131 4>; // huawei_kiw_ul00_vc.dts
+		<8001 4>, <8003 4>, <8007 4>, <8017 4>,
+		<8019 4>, <8023 4>, <8033 4>, <8035 4>,
+		<8039 4>, <8049 4>, <8051 4>, <8065 4>,
+		<8067 4>, <8081 4>, <8083 4>, <8097 4>,
+		<8099 4>, <8103 4>, <8115 4>, <8119 4>,
+		<8131 4>;
 
 	model = "Huawei Honor 5X / GR5 (2016)";
 	compatible = "huawei,kiwi", "qcom,msm8939", "lk2nd,device";

--- a/dts/msm8916/msm8939-huawei-rio.dts
+++ b/dts/msm8916/msm8939-huawei-rio.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+
+/ {
+	qcom,msm-id = <239 0>;
+	qcom,board-id =
+		<8054 0>, <8054 4>, // huawei_rio_cl00_va.dts
+		<8055 0>, <8055 4>, // huawei_rio_l02_va.dts
+		<8070 0>, <8070 4>, // huawei_rio_al00_va.dts
+		<8071 0>, <8071 4>, // huawei_rio_al00_vb.dts
+		<8086 0>, <8086 4>, // huawei_rio_l01_va.dts
+		<8087 0>, <8087 4>, // huawei_rio_l01_vb.dts
+		<8102 0>, <8102 4>, // huawei_rio_tl00_va.dts
+		<8134 0>, <8134 4>, // huawei_rio_cl00_vb.dts
+		<8135 0>, <8135 4>, // huawei_rio_cl00_vc.dts
+		<8118 0>, <8118 4>; // huawei_rio_l03_va.dts
+	model = "Huawei RIO";
+	compatible = "huawei,rio", "qcom,msm8939", "lk2nd,device";
+};

--- a/dts/msm8916/msm8939-huawei-rio.dts
+++ b/dts/msm8916/msm8939-huawei-rio.dts
@@ -17,6 +17,6 @@
 		<8134 0>, <8134 4>, // huawei_rio_cl00_vb.dts
 		<8135 0>, <8135 4>, // huawei_rio_cl00_vc.dts
 		<8118 0>, <8118 4>; // huawei_rio_l03_va.dts
-	model = "Huawei RIO";
+	model = "Huawei G8 / GX8 / RIO-L01";
 	compatible = "huawei,rio", "qcom,msm8939", "lk2nd,device";
 };

--- a/dts/msm8916/msm8939-huawei-rio.dts
+++ b/dts/msm8916/msm8939-huawei-rio.dts
@@ -7,16 +7,10 @@
 / {
 	qcom,msm-id = <239 0>;
 	qcom,board-id =
-		<8054 0>, <8054 4>, // huawei_rio_cl00_va.dts
-		<8055 0>, <8055 4>, // huawei_rio_l02_va.dts
-		<8070 0>, <8070 4>, // huawei_rio_al00_va.dts
-		<8071 0>, <8071 4>, // huawei_rio_al00_vb.dts
-		<8086 0>, <8086 4>, // huawei_rio_l01_va.dts
-		<8087 0>, <8087 4>, // huawei_rio_l01_vb.dts
-		<8102 0>, <8102 4>, // huawei_rio_tl00_va.dts
-		<8134 0>, <8134 4>, // huawei_rio_cl00_vb.dts
-		<8135 0>, <8135 4>, // huawei_rio_cl00_vc.dts
-		<8118 0>, <8118 4>; // huawei_rio_l03_va.dts
+		<8054 4>, <8055 4>, <8070 4>, <8071 4>,
+		<8086 4>, <8087 4>, <8102 4>, <8134 4>, 
+		<8135 4>, <8118 4>;
+		
 	model = "Huawei G8 / GX8 / RIO-L01";
 	compatible = "huawei,rio", "qcom,msm8939", "lk2nd,device";
 };

--- a/dts/msm8916/rules.mk
+++ b/dts/msm8916/rules.mk
@@ -42,6 +42,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8929-samsung-r04.dtb \
 	$(LOCAL_DIR)/msm8939-asus-z00t.dtb \
 	$(LOCAL_DIR)/msm8939-huawei-kiwi.dtb \
+	$(LOCAL_DIR)/msm8939-huawei-rio.dtb \
 	$(LOCAL_DIR)/msm8939-xiaomi-ido.dtb \
 	$(LOCAL_DIR)/msm8939-mtp.dtb \
 	$(LOCAL_DIR)/msm8939-qrd-skuk.dtb \


### PR DESCRIPTION
Adds support for the Huawei G8/GX8. Tested with (RIO-L01).
Removed some board-id entries from `kiwi` that are now conflicting with `rio` .
For reference I mentioned the files in Huawei's downstream kernel sources containing those IDs.