### PR TITLE
dts: msm8916: qrd/7+12-v1: Also match qrd/7-v1.1

### DIFF
--- a/dts/msm8916/msm8916-qrd7+12-v1.dts
+++ b/dts/msm8916/msm8916-qrd7+12-v1.dts
@@ -6,7 +6,8 @@
 
 / {
 	/* The device is usually qrd/7, but the stock bootloader selects qrd/12 */
-	compatible = "qcom,msm8916-v1-qrd/7-v1", "qcom,msm8916-v1-qrd/12-v1", "qcom,msm8916";
+	compatible = "qcom,msm8916-v1-qrd/7-v1", "qcom,msm8916-v1-qrd/7-v1.1",
+		     "qcom,msm8916-v1-qrd/12-v1", "qcom,msm8916";
 
 	wingtech-wt88047 {
 		compatible = "wingtech,wt88047", "qcom,msm8916", "lk2nd,device";


### PR DESCRIPTION
The stock Kitkat bootloader selects qrd/7-v1.1.

Cc: @TravMurav 