### PR TITLE
[experimental-tmp3] Add partial goods support

### DIFF
--- a/lk2nd/partial-goods/partial-goods.c
+++ b/lk2nd/partial-goods/partial-goods.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright (c) 2022-2023, Otto Pflüger <affenull2345@gmail.com> */
+
+#include <platform/partial_goods.h>
+#include <boot.h>
+#include <libfdt.h>
+#include <lk2nd/util/lkfdt.h>
+
+#if !TARGET_MSM8909
+#error partial-goods not supported for this platform
+#endif
+
+static void cpu_disable(void *dtb, const char *path, bool is_downstream)
+{
+	int tmp, offset = fdt_path_offset(dtb, path);
+
+	if (offset < 0)
+		return;
+
+	if (is_downstream) {
+		fdt_setprop_string(dtb, offset, "device_type", "nak");
+	} else {
+		fdt_setprop_string(dtb, offset, "status", "fail");
+
+		tmp = lkfdt_lookup_phandle(dtb, offset, "qcom,acc");
+		if (tmp >= 0)
+			fdt_setprop_string(dtb, tmp, "status", "fail");
+
+		tmp = lkfdt_lookup_phandle(dtb, offset, "qcom,saw");
+		if (tmp >= 0)
+			fdt_setprop_string(dtb, tmp, "status", "fail");
+	}
+}
+
+static int lk2nd_partial_goods_dt_update(void *dtb, const char *cmdline,
+					 enum boot_type boot_type)
+{
+	bool is_downstream = boot_type & BOOT_DOWNSTREAM;
+
+	if (boot_type & BOOT_LK2ND)
+		return 0;
+
+	switch (platform_partial_goods_val()) {
+		case 0:
+		case 1:
+			break;
+		default:
+			/* full-featured SoC, no CPUs disabled */
+			return 0;
+	}
+
+	cpu_disable(dtb, "/cpus/cpu@2", is_downstream);
+	cpu_disable(dtb, "/cpus/cpu@3", is_downstream);
+
+	return 0;
+}
+DEV_TREE_UPDATE(lk2nd_partial_goods_dt_update);

--- a/lk2nd/partial-goods/rules.mk
+++ b/lk2nd/partial-goods/rules.mk
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+LOCAL_DIR := $(GET_LOCAL_DIR)
+MODULES += lib/libfdt
+
+OBJS += \
+	$(LOCAL_DIR)/partial-goods.o \

--- a/lk2nd/project/base.mk
+++ b/lk2nd/project/base.mk
@@ -55,4 +55,11 @@ DEFINES := $(filter-out USER_FORCE_RESET_SUPPORT=1, $(DEFINES))
 # Allow flashing independent of battery voltage
 DEFINES := $(filter-out CHECK_BAT_VOLTAGE=1, $(DEFINES))
 
+# lk2nd provides its own mainline-friendly partial-goods implementation
+ifeq ($(TARGET), msm8909)
+ENABLE_PARTIAL_GOODS_SUPPORT := 0
+DEFINES := $(filter-out ENABLE_PARTIAL_GOODS_SUPPORT=1, $(DEFINES))
+MODULES += lk2nd/partial-goods
+endif
+
 include $(if $(filter msm8660 msm8960, $(TARGET)), lk2nd/project/msm8x60.mk)


### PR DESCRIPTION
Add code to disable unavailable CPU cores on MSM8905 and disable Qualcomm's original code that does this because it is broken on mainline.

Suggested changes from #214 applied.