### PR TITLE
dts: Add support for Samsung Tab A 8.0 2014

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Motorola Moto G 2013 - falcon
 - Samsung Galaxy Grand 2 - SM-G7102
 - Samsung Galaxy Tab 4 10.1 (2014) - SM-T530, SM-T535
+- Samsung Galaxy Tab 4 8.0 (2014) - SM-T330, SM-T330NU
 
 ## Installation
 1. Download `lk2nd.img` (available in [Releases](https://github.com/msm8916-mainline/lk2nd/releases))

--- a/dts/msm8226/apq8026-samsung-r09.dts
+++ b/dts/msm8226/apq8026-samsung-r09.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+#include <lk2nd.h>
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <0xC708FF01 9 0x20000>;
+
+	milletwifi {
+		model = "Samsung Galaxy Tab 4 8.0 WiFi (SM-T330)";
+		compatible = "samsung,milletwifi", "qcom,apq8026", "lk2nd,device";
+		lk2nd,match-bootloader = "T330*";
+
+		lk2nd,keys =
+			<KEY_HOME       108 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEDOWN 107 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			<KEY_VOLUMEUP   106 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+};

--- a/dts/msm8226/rules.mk
+++ b/dts/msm8226/rules.mk
@@ -6,6 +6,7 @@ DTBS += \
 	$(LOCAL_DIR)/apq8026-asus-sparrow.dtb \
 	$(LOCAL_DIR)/apq8026-huawei-sturgeon.dtb \
 	$(LOCAL_DIR)/apq8026-samsung-r03.dtb \
+	$(LOCAL_DIR)/apq8026-samsung-r09.dtb \
 	$(LOCAL_DIR)/msm8226-motorola-falcon.dtb \
 	$(LOCAL_DIR)/msm8226-samsung-ms013g.dtb \
 	$(LOCAL_DIR)/msm8926-huawei-g6-l11-vb.dtb \


### PR DESCRIPTION
Very similar to the existing SM-T530 support, but went with a separate dts file for clarity.

Couldn't find documentation on how the `-r*` suffixes are chosen for `dts` files, so I just incremented it for Samsung. Let me know if it should be something else.