### PR TITLE
x86: include/ops.h: Fix a typo in include guard

### DIFF
--- a/arch/x86/include/arch/x86/ops.h
+++ b/arch/x86/include/arch/x86/ops.h
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 #ifndef __ARCH_X86_OPS_H
-#define __ARHC_X86_OPS_H
+#define __ARCH_X86_OPS_H
 
 #if 0
 #include <compiler.h>


### PR DESCRIPTION
Similar to fix c35069a8e ("arm: include/ops.h: Fix a typo").

Although lk2nd does not support QEMU, thus this header is unsupported, it's better to fix it.