### PR TITLE
add support for the Samsung Galaxy On7 2015 (SM-G600FY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Samsung Galaxy J5 (2015) - SM-J5007, SM-J5008, SM-J500F, SM-J500FN, SM-J500H, SM-J500M
 - Samsung Galaxy J5 (2016) - SM-J5108, SM-J510F, SM-J510FN, SM-J510MN, SM-J510UN
 - Samsung Galaxy J7 (2015) - SM-J7008, SM-J700P
-- Samsung Galaxy On7 (2015) - SM-G6000, SM-G600S
+- Samsung Galaxy On7 (2015) - SM-G6000, SM-G600FY, SM-G600S
 - Samsung Galaxy S4 Mini Value Edition - GT-I9195I
 - Samsung Galaxy Tab 4 10.1 (2015) - SM-T533
 - Samsung Galaxy Tab A 8.0 (2015) - SM-T350, SM-T355, SM-T355Y, SM-T357W

--- a/dts/msm8916/msm8916-samsung-r03.dts
+++ b/dts/msm8916/msm8916-samsung-r03.dts
@@ -70,6 +70,17 @@
 		};
 	};
 
+	on7lte-swa {
+		model = "Samsung Galaxy On7 2015 (SM-G600FY)";
+		compatible = "samsung,o7lte-swa", "qcom,msm8916", "lk2nd,device";
+		lk2nd,match-bootloader = "G600FY*";
+
+		samsung,muic-reset {
+			i2c-gpio-pins = <105 106>;
+			i2c-address = <0x25>;
+		};
+	};
+
 	/*
 	 * Before building for rossaltezt, please comment out all dtbs except
 	 * "$(LOCAL_DIR)/msm8916-samsung-r03.dtb" at './rules.mk'.


### PR DESCRIPTION
![SM-G600FY](https://github.com/msm8916-mainline/lk2nd/assets/25590950/adb9adc4-c3a9-4e43-a836-9df6a4966893)

I don't know anything about Linux kernel internals, but was able to get this working.