### PR TITLE
Add Samsung Galaxy S5 China Mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - LG Google Nexus 5 - hammerhead D820, D821
 - OnePlus One - bacon (use `lk2nd-msm8974-appended-dtb.img`)
 - Samsung Galaxy S5 - SM-G900F
-- Samsung Galaxy S5 China Unicom (Duos) - SM-G9006V/W
+- Samsung Galaxy S5 China Unicom / Mobile (Duos) - SM-G9006V/W, SM-G9008V/W
 - Sony Xperia Z3 - leo
 
 ### lk2nd-msm8226

--- a/dts/msm8974/msm8974-samsung-r10.dts
+++ b/dts/msm8974/msm8974-samsung-r10.dts
@@ -9,8 +9,8 @@
 	qcom,msm-id = <0xC208FF01 10 0x10000>;
 
 	kltechn {
-		model = "Samsung Galaxy S5 China Unicom (Duos) (SM-G9006V/W)";
+		model = "Samsung Galaxy S5 China Unicom/Mobile (Duos) (SM-G9006V/W,SM-G9008V/W)";
 		compatible = "samsung,klte", "qcom,msm8974", "lk2nd,device";
-		lk2nd,match-bootloader = "G9006*";
+		lk2nd,match-bootloader = "G9006*", "G9008*";
 	};
 };

--- a/lk2nd/lk2nd-device.c
+++ b/lk2nd/lk2nd-device.c
@@ -183,6 +183,21 @@ static bool match_string(const char *s, const char *match, size_t len)
 	return strncmp(s, match, len + 1) == 0;
 }
 
+static bool match_strings(const char *s, const char *match, size_t len)
+{
+	size_t entry_len, used_len = 0;
+
+	while (used_len < len) {
+		entry_len = strnlen(match + used_len, len - used_len);
+		if (match_string(s, match + used_len, entry_len))
+			return true;
+
+		used_len += entry_len + 1;
+	}
+
+	return false;
+}
+
 static bool match_panel(const void *fdt, int offset, const char *panel_name)
 {
 	offset = fdt_subnode_offset(fdt, offset, "panel");
@@ -206,14 +221,14 @@ static bool lk2nd_device_match(const void *fdt, int offset)
 	if (val && len > 0) {
 		if (!lk2nd_dev.bootloader)
 			return false;
-		return match_string(lk2nd_dev.bootloader, val, len);
+		return match_strings(lk2nd_dev.bootloader, val, len);
 	}
 
 	val = fdt_getprop(fdt, offset, "lk2nd,match-cmdline", &len);
 	if (val && len > 0) {
 		if (!lk2nd_dev.cmdline)
 			return false;
-		return match_string(lk2nd_dev.cmdline, val, len);
+		return match_strings(lk2nd_dev.cmdline, val, len);
 	}
 
 	fdt_getprop(fdt, offset, "lk2nd,match-panel", &len);


### PR DESCRIPTION
#165 introduced kltechn(duo).
This PR adds SM-G9008V/W, Samsung Galaxy S5 China Mobile, which is for China Mobile.
SM-G9008V is the single-sim and W for double-sims.

![IMG_20240114_115055](https://github.com/msm8916-mainline/lk2nd/assets/46394906/ec2acdcb-1d88-4273-9274-ecbe33b94dce)
^ SM-G9008W

Bootloader: G9008WZMS1CRH1
[lk_log](https://envs.sh/FIb.txt)