### PR TITLE
dts: msm8974: add other carrier variants of kltechn

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - LG Google Nexus 5 - hammerhead D820, D821
 - OnePlus One - bacon (use `lk2nd-msm8974-appended-dtb.img`)
 - Samsung Galaxy S5 - SM-G900F
-- Samsung Galaxy S5 China Unicom (Duos) - SM-G9006V/W
+- Samsung Galaxy S5 China LTE (Duos) - SM-G9006V/W, SM-G9008V/W, SM-G9009W
 - Sony Xperia Z3 - leo
 
 ### lk2nd-msm8226

--- a/dts/msm8974/msm8974-samsung-r10.dts
+++ b/dts/msm8974/msm8974-samsung-r10.dts
@@ -8,9 +8,27 @@
 	// This is used by the bootloader to find the correct DTB
 	qcom,msm-id = <0xC208FF01 10 0x10000>;
 
-	kltechn {
+	kltechn-unicom {
 		model = "Samsung Galaxy S5 China Unicom (Duos) (SM-G9006V/W)";
-		compatible = "samsung,klte", "qcom,msm8974", "lk2nd,device";
+		compatible = "samsung,kltechn-unicom",
+			     "samsung,kltechn", "samsung,klte",
+			     "qcom,msm8974", "lk2nd,device";
 		lk2nd,match-bootloader = "G9006*";
+	};
+
+	kltechn-mobile {
+		model = "Samsung Galaxy S5 China Mobile (Duos) (SM-G9008V/W)";
+		compatible = "samsung,kltechn-mobile",
+			     "samsung,kltechn", "samsung,klte",
+			     "qcom,msm8974", "lk2nd,device";
+		lk2nd,match-bootloader = "G9008*";
+	};
+
+	kltechn-telecom {
+		model = "Samsung Galaxy S5 China Telecom LTE (SM-G9009W)";
+		compatible = "samsung,kltechn-telecom",
+			     "samsung,kltechn", "samsung,klte",
+			     "qcom,msm8974", "lk2nd,device";
+		lk2nd,match-bootloader = "G9009W*";
 	};
 };


### PR DESCRIPTION
The Chinese editions of Galaxy S5 (kltechn) are customized for all 3 carriers in China at that time, but currently only the Unicom one is tested and added.

Add the other two carrier editions.

Tested-by: Icenowy Zheng <uwu@icenowy.me> # for Telecom

==================
Test for G9008 is wanted, if @xtexChooser could do this thus thanks.