### PR TITLE
dts: msm8916: samsung-j5x3gjv: rename from j5xn3g

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ page on the EFIDroid wiki for an exact mapping of LK targets to SoCs.
 - Samsung Galaxy J3 (2016) - SM-J3109, SM-J320YZ
 - Samsung Galaxy J3 Pro - SM-J3110, SM-J3119
 - Samsung Galaxy J5 (2015) - SM-J5007, SM-J5008, SM-J500F, SM-J500FN, SM-J500H, SM-J500M
-- Samsung Galaxy J5 (2016) - SM-J5108, SM-J510F, SM-J510FN, SM-J510MN, SM-J510UN, SMJ510H
+- Samsung Galaxy J5 (2016) - SM-J5108, SM-J510F, SM-J510FN, SM-J510H, SM-J510MN, SM-J510UN
 - Samsung Galaxy J7 (2015) - SM-J7008, SM-J700P
 - Samsung Galaxy On7 (2015) - SM-G6000, SM-G600FY, SM-G600S
 - Samsung Galaxy S4 Mini Value Edition - GT-I9195I

--- a/dts/msm8916/msm8216-samsung-r05.dts
+++ b/dts/msm8916/msm8216-samsung-r05.dts
@@ -16,9 +16,10 @@
 
 		#include "msm8916-samsung-j5.dtsi"
 	};
-	j5xn3g {
+
+	j5x3gjv {
 		model = "Samsung Galaxy J5 2016 (SM-J510H)";
-		compatible = "samsung,j5xn3g", "qcom,msm8916", "lk2nd,device";
+		compatible = "samsung,j5x3g", "qcom,msm8916", "lk2nd,device";
 		lk2nd,match-bootloader = "J510H*";
 
 		#include "msm8916-samsung-j5.dtsi"


### PR DESCRIPTION
J5 2016 3G (SM-J510H) doesn't support NFC, thus j5x+3g.