### PR TITLE
dts: msm8916-samsung: drop panel selection for fortunaltezt

### DIFF
--- a/dts/msm8916/msm8916-samsung-gprime.dtsi
+++ b/dts/msm8916/msm8916-samsung-gprime.dtsi
@@ -8,10 +8,6 @@ samsung,muic-reset {
 panel {
 	compatible = "samsung,gprime-panel";
 
-	qcom,mdss_dsi_hx8389c_qhd_video {
-		compatible = "samsung,hx8389c-gh9607501a";
-	};
-
 	ss_dsi_panel_HX8389C_GH9607501A_QHD {
 		compatible = "samsung,hx8389c-gh9607501a";
 	};

--- a/dts/msm8916/msm8916-samsung-r11.dts
+++ b/dts/msm8916/msm8916-samsung-r11.dts
@@ -45,3 +45,10 @@
 		#include "msm8916-samsung-gprime.dtsi"
 	};
 };
+
+/ {
+	fortunaltezt {
+		/* Actually hx8389c without PWM. There is no other variant */
+		/delete-node/ panel;
+	};
+};


### PR DESCRIPTION
fortunaltezt uses hx8389c without PWM, which is not used on most of the variants.