### PR TITLE
[rebase/dts] dts: msm8916-samsung: drop panel selection for fortunaltezt

### DIFF
--- a/lk2nd/device/dts/msm8916/msm8216-samsung.dts
+++ b/lk2nd/device/dts/msm8916/msm8216-samsung.dts
@@ -73,9 +73,6 @@
 		panel {
 			compatible = "samsung,gprime-panel", "lk2nd,panel";
 
-			qcom,mdss_dsi_hx8389c_qhd_video {
-				compatible = "samsung,hx8389c-gh9607501a";
-			};
 			ss_dsi_panel_HX8389C_GH9607501A_QHD {
 				compatible = "samsung,hx8389c-gh9607501a";
 			};

--- a/lk2nd/device/dts/msm8916/msm8916-samsung.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-samsung.dts
@@ -246,9 +246,6 @@
 		panel {
 			compatible = "samsung,gprime-panel", "lk2nd,panel";
 
-			qcom,mdss_dsi_hx8389c_qhd_video {
-				compatible = "samsung,hx8389c-gh9607501a";
-			};
 			ss_dsi_panel_HX8389C_GH9607501A_QHD {
 				compatible = "samsung,hx8389c-gh9607501a";
 			};
@@ -278,9 +275,6 @@
 		panel {
 			compatible = "samsung,gprime-panel", "lk2nd,panel";
 
-			qcom,mdss_dsi_hx8389c_qhd_video {
-				compatible = "samsung,hx8389c-gh9607501a";
-			};
 			ss_dsi_panel_HX8389C_GH9607501A_QHD {
 				compatible = "samsung,hx8389c-gh9607501a";
 			};
@@ -825,20 +819,6 @@
 			i2c-reg = <0x25>;
 			i2c-sda-gpios = <&tlmm 2 I2C_GPIO_FLAGS>;
 			i2c-scl-gpios = <&tlmm 3 I2C_GPIO_FLAGS>;
-		};
-
-		panel {
-			compatible = "samsung,gprime-panel", "lk2nd,panel";
-
-			qcom,mdss_dsi_hx8389c_qhd_video {
-				compatible = "samsung,hx8389c-gh9607501a";
-			};
-			ss_dsi_panel_HX8389C_GH9607501A_QHD {
-				compatible = "samsung,hx8389c-gh9607501a";
-			};
-			ss_dsi_panel_S6D78A0_GH9607501A_QHD {
-				compatible = "samsung,s6d78a0-gh9607501a";
-			};
 		};
 	};
 };

--- a/lk2nd/device/dts/msm8916/msm8929-samsung.dts
+++ b/lk2nd/device/dts/msm8916/msm8929-samsung.dts
@@ -90,9 +90,6 @@
 		panel {
 			compatible = "samsung,gprime-panel", "lk2nd,panel";
 
-			qcom,mdss_dsi_hx8389c_qhd_video {
-				compatible = "samsung,hx8389c-gh9607501a";
-			};
 			ss_dsi_panel_HX8389C_GH9607501A_QHD {
 				compatible = "samsung,hx8389c-gh9607501a";
 			};


### PR DESCRIPTION
fortunaltezt uses hx8389c without PWM, which is not used on most of the variants.