### PR TITLE
dts: xiaomi-vince: set back rmi4 as default touchscreen

### DIFF
--- a/lk2nd/device/dts/msm8953/msm8953-xiaomi-vince.dts
+++ b/lk2nd/device/dts/msm8953/msm8953-xiaomi-vince.dts
@@ -22,23 +22,28 @@
 
 			qcom,mdss_dsi_td4310_fhdplus_video_e7 {
 				compatible = "xiaomi,td4310-fhdplus-e7";
-				touchscreen-compatible = "novatek,nt36525-i2c";
+				touchscreen-compatible = "syna,rmi4-i2c";
+				// touchscreen-compatible = "novatek,nt36525-i2c";
 			};
 			qcom,mdss_dsi_td4310_fhdplus_video_e7_g55 {
 				compatible = "xiaomi,td4310-fhdplus-e7-g55";
-				touchscreen-compatible = "novatek,nt36525-i2c";
+				touchscreen-compatible = "syna,rmi4-i2c";
+				// touchscreen-compatible = "novatek,nt36525-i2c";
 			};
 			qcom,mdss_dsi_td4310_ebbg_fhdplus_video_e7 {
 				compatible = "xiaomi,td4310-ebbg-fhdplus-e7";
-				touchscreen-compatible = "novatek,nt36525-i2c";
+				touchscreen-compatible = "syna,rmi4-i2c";
+				// touchscreen-compatible = "novatek,nt36525-i2c";
 			};
 			qcom,mdss_dsi_nt36672_tianma_fhdplus_video_e7 {
 				compatible = "xiaomi,nt36672-tianma-fhdplus-e7";
-				touchscreen-compatible = "novatek,nt36525-i2c";
+				touchscreen-compatible = "syna,rmi4-i2c";
+				// touchscreen-compatible = "novatek,nt36525-i2c";
 			};
 			qcom,mdss_dsi_nt36672_csot_fhdplus_video_e7 {
 				compatible = "xiaomi,nt36672-csot-fhdplus-e7";
-				touchscreen-compatible = "novatek,nt36525-i2c";
+				touchscreen-compatible = "syna,rmi4-i2c";
+				// touchscreen-compatible = "novatek,nt36525-i2c";
 			};
 		};
 	};


### PR DESCRIPTION
Set back touchscreen-compatible to syna,rmi4-i2c because this is the primarily supported.

I would keep novatek compatible as a comment let users to switch it if they needed it.