### PR TITLE
dts: msm8952: Add Motorola Moto G5 (cedric)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -69,6 +69,7 @@
 
 ### lk2nd-msm8952
 
+- Motorola Moto G5 (cedric) (quirky - see comment in `dts/msm8952/msm8937-motorola-cedric.dts`)
 - Wileyfox Swift 2
 - Redmi Note 3 Pro (kenzo)
 - Sony Xperia X Compact

--- a/lk2nd/device/dts/msm8952/msm8937-motorola-cedric.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-motorola-cedric.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * To build for motorola-cedric, add LK2ND_DTBS="msm8937-motorola-cedric.dtb"
+ * to your make cmdline.
+ * cedric does not work with all dtbs enabled; the bootloader gets upset and
+ * goes into bootloop.
+ */
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8937 0x00>;
+	qcom,board-id = <0x41 0x8100>,
+			<0x41 0x8200>,
+			<0x41 0x8300>,
+			<0x42 0x8400>,
+			<0x42 0x8500>;
+};
+
+&lk2nd {
+	cedric {
+		model = "Motorola Moto G5 (cedric)";
+		compatible = "motorola,cedric";
+		lk2nd,match-device = "cedric";
+
+		lk2nd,dtb-files = "msm8937-motorola-cedric";
+	};
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -5,3 +5,6 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \
 	$(LOCAL_DIR)/msm8956-mtp.dtb \
 	$(LOCAL_DIR)/msm8976-qrd.dtb \
+
+QCDTBS += \
+	$(LOCAL_DIR)/msm8937-motorola-cedric.dtb \


### PR DESCRIPTION
For some reason lk2nd fails to boot if `$(LOCAL_DIR)/msm8937-mtp.dtb` is included in `rules.mk`.