### PR TITLE
dts: msm8974-lge-hammerhead: drop msm-id overrides

### DIFF
--- a/lk2nd/device/dts/msm8974/msm8974-lge-hammerhead.dts
+++ b/lk2nd/device/dts/msm8974/msm8974-lge-hammerhead.dts
@@ -4,39 +4,14 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <QCOM_ID_MSM8974 0x96 0x20002 0x2b>;
+	qcom,msm-id = <QCOM_ID_MSM8974 0x96 0x20002 0xb>;
 };
 
 &lk2nd {
-	hammerhead-d820 {
-		model = "LG Google Nexus 5 D820";
+	hammerhead {
+		model = "LG Google Nexus 5";
 		compatible = "lge,hammerhead";
-		lk2nd,match-cmdline = "* androidboot.hardware.sku=D820 *";
-
-		lk2nd,dtb-files = "msm8974-lge-nexus5-hammerhead";
-
-		gpio-keys {
-			compatible = "gpio-keys";
-			down {
-				lk2nd,code = <KEY_VOLUMEDOWN>;
-				gpios = <&pmic 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-			};
-
-			up {
-				lk2nd,code = <KEY_VOLUMEUP>;
-				gpios = <&pmic 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-			};
-		};
-	};
-
-	hammerhead-d821 {
-		model = "LG Google Nexus 5 D821";
-		compatible = "lge,hammerhead";
-		lk2nd,match-cmdline = "* androidboot.hardware.sku=D821 *";
-
-		// Currently unable to use a dedicated device tree because it won't
-		// load D821 after D820 loaded.
-		qcom,msm-id = <QCOM_ID_MSM8974 0x96 0x20002 0x0b>;
+		lk2nd,match-bootloader = "HHZ*";
 
 		lk2nd,dtb-files = "msm8974-lge-nexus5-hammerhead";
 

--- a/lk2nd/device/dts/msm8974/rules.mk
+++ b/lk2nd/device/dts/msm8974/rules.mk
@@ -6,8 +6,9 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8974pro-ab-pm8941-mtp.dtb \
 	$(LOCAL_DIR)/msm8974pro-ac-pm8941-mtp.dtb \
 	$(LOCAL_DIR)/msm8974-htc-m8.dtb \
-	$(LOCAL_DIR)/msm8974-lge-hammerhead.dtb \
 	$(LOCAL_DIR)/msm8974-lge-d855.dtb \
+	$(LOCAL_DIR)/msm8974-lge-hammerhead.dtb \
 
 ADTBS += \
+	$(LOCAL_DIR)/msm8974-lge-hammerhead.dtb \
 	$(LOCAL_DIR)/victara.dtb \


### PR DESCRIPTION
Assuming qcom,msm-id = <QCOM_ID_MSM8974 0x96 0x20002 0xb> is correct and
compatible with both D820 and D821, overrides are no longer required.
Drop the overrides, use lk2nd,match-bootloader = "HHZ*" instead of
lk2nd,match-cmdline and simplify the device tree.

To fix "dtb not found" error when doing `fastboot boot` with downstream
`boot.img` or `lk2nd-msm8974.img` when lk2nd expects appended DTBs
(ADTBs), and model "Unknown (FIXME!)" when ADTBs are load, add the dtb to
ADTBs rules. Fixes https://github.com/msm8916-mainline/lk2nd/issues/371.