### PR TITLE
lk2nd: fastboot: Add "fastboot oem dtb" to dump dtb passed by bootloader

### DIFF
--- a/Documentation/fastboot.md
+++ b/Documentation/fastboot.md
@@ -7,6 +7,7 @@ commands for debugging and development.
 > Not all fastboot commands may be enabled on a given build of lk2nd.
 > Use `fastboot oem help` to find which commands are available.
 
+- `oem dtb` - Stage dtb.
 - `oem hash` - Hash staged data using hardware crypto.
 - `oem log` - Stage lk log.
 - `oem reboot-edl` - Reboot into EDL mode.

--- a/lk2nd/device/device.c
+++ b/lk2nd/device/device.c
@@ -155,6 +155,7 @@ static void lk2nd_device_init(void)
 		return;
 	}
 
+	lk2nd_dev.dtb = dtb;
 	parse_dtb(dtb);
 }
 LK2ND_INIT(lk2nd_device_init);

--- a/lk2nd/device/device.h
+++ b/lk2nd/device/device.h
@@ -16,6 +16,8 @@ struct lk2nd_panel {
 };
 
 struct lk2nd_device {
+	const void *dtb;
+
 	const char *compatible;
 	const char *model;
 	const char *battery;

--- a/lk2nd/fastboot/dtb.c
+++ b/lk2nd/fastboot/dtb.c
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright (c) 2021-2022, Stephan Gerhold <stephan@gerhold.net> */
+
+#include <fastboot.h>
+#include <libfdt.h>
+
+#include "../device/device.h"
+
+static void cmd_oem_dtb(const char *arg, void *data, unsigned sz)
+{
+	fastboot_stage(lk2nd_dev.dtb, fdt_totalsize(lk2nd_dev.dtb));
+}
+FASTBOOT_REGISTER("oem dtb", cmd_oem_dtb);

--- a/lk2nd/fastboot/rules.mk
+++ b/lk2nd/fastboot/rules.mk
@@ -11,3 +11,15 @@ OBJS += \
 	$(LOCAL_DIR)/screenshot.o \
 	$(LOCAL_DIR)/screenshot-neon.o
 endif
+
+ifeq ($(LK2ND_PROJECT), lk2nd)
+OBJS += \
+	$(LOCAL_DIR)/dtb.o
+endif
+
+ifeq ($(LK2ND_PROJECT), lk1st)
+ifneq ($(LK2ND_BUNDLE_DTB),)
+OBJS += \
+	$(LOCAL_DIR)/dtb.o
+endif
+endif


### PR DESCRIPTION
This allows inspecting the changes to the dtb made by the bootloader.

Usage: "fastboot oem dtb && fastboot get_staged output.dtb"

Fixes #372