### PR TITLE
dts: msm8953: Add Lenovo ThinkSmart View (CD-18781Y)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -83,6 +83,7 @@
 - Fairphone 3
 - Huawei Maimang 5 / Nova (Plus) / G9 (Plus)
 - Lenovo P2 (kuntao)
+- Lenovo ThinkSmart View (cd-18781y) (quirky - see comments in `lk2nd/device/dts/msm8953/apq8053-lenovo-cd-18781y.dts`)
 - Meizu M6 Note (m1721)
 - Motorola Moto G5 Plus (potter)
 - Motorola Moto G7 Power (ocean)

--- a/lk2nd/device/dts/msm8953/apq8053-lenovo-cd-18781y.dts
+++ b/lk2nd/device/dts/msm8953/apq8053-lenovo-cd-18781y.dts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * While the bootloader can be unlocked using `fastboot oem-unlock` the
+ * device's lk bootloader will crash as long as the bootloader remains
+ * unlocked. Therefor:
+ * - Secure Boot can not be disabled
+ *   However, the device will happily boot any AVB1 signed image. Tools
+ *   such as magiskboot can be used to sign lk2nd.img and make it bootable.
+ * - lk2nd cannot be flashed in fastboot mode
+ *   Instead, use EDL to write the signed lk2nd.img to the boot partition.
+ */
+
+/ {
+	qcom,msm-id = <QCOM_ID_APQ8053 0>;
+	qcom,board-id= <0x1010520 0>;
+};
+
+&lk2nd {
+	model = "Lenovo ThinkSmart View";
+	compatible = "lenovo,cd-18781y";
+
+	lk2nd,dtb-files = "apq8053-lenovo-cd-18781y";
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		/* HACK: map KEY_VOLUMEUP to non-existent button so the actual
+		 * Volume Up button will successfully re-map to KEY_POWER below.
+		 */
+		volume-up-unmap {
+			lk2nd,code = <KEY_VOLUMEUP>;
+			gpios = <&pmic_pon 0 0>;
+		};
+
+		/*
+		 * Remap Volume Up to KEY_POWER to allow selecting menu items as
+		 * there is no power button present on the device.
+		 * Use Volume Down to navigate the menu and Volume Up to select.
+		 */
+		volume-up {
+			lk2nd,code = <KEY_POWER>;
+			gpios = <&tlmm 85 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+	};
+
+	panel {
+		compatible = "lenovo,cd-18781y-panel", "lk2nd,panel";
+
+		qcom,mdss_dsi_boyift8201_800p_video {
+			compatible = "lenovo,cd-18781y-ft8201";
+			touchscreen-compatible = "edt,edt-ft8201";
+		};
+		qcom,mdss_dsi_hx83100a_800p_video {
+			compatible = "lenovo,cd-18781y-hx83100a";
+			touchscreen-compatible = "himax,hx83100a";
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8953/rules.mk
+++ b/lk2nd/device/dts/msm8953/rules.mk
@@ -2,6 +2,7 @@
 LOCAL_DIR := $(GET_LOCAL_DIR)
 
 ADTBS += \
+	$(LOCAL_DIR)/apq8053-lenovo-cd-18781y.dtb \
 	$(LOCAL_DIR)/msm8953-huawei-milan.dtb  \
 	$(LOCAL_DIR)/msm8953-lenovo-kuntao.dtb  \
 	$(LOCAL_DIR)/msm8953-motorola-deen.dtb  \


### PR DESCRIPTION
Menu navigation is currently not possible as the only two buttons available on this device are Volume Up and Volume Down. Menu items can be browsed but not selected as there is no button mapped to KEY_HOME.

Note that bootloader unlock is not functional on the ThinkSmart View. But the device will boot any image as long as it is AVB1 signed. For simple and quick signing `magiskboot sign` can be used on `lk2nd.img`.