### PR TITLE
on7lte-chn fixes

### DIFF
--- a/lk2nd/device/dts/msm8916/msm8916-samsung.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-samsung.dts
@@ -398,7 +398,7 @@
 	on7lte-chn {
 		model = "Samsung Galaxy On7 2015 (SM-G6000)";
 		compatible = "samsung,on7lte-chn", "samsung,on7";
-		lk2nd,match-bootloader = "G600S*";
+		lk2nd,match-bootloader = "G6000*";
 
 		lk2nd,dtb-files = "msm8916-samsung-on7";
 

--- a/lk2nd/device/dts/msm8916/msm8929-samsung.dts
+++ b/lk2nd/device/dts/msm8916/msm8929-samsung.dts
@@ -52,24 +52,6 @@
 		};
 	};
 
-	on7lte-chn {
-		model = "Samsung Galaxy On7 2015 (SM-G6000)";
-		compatible = "samsung,on7lte-chn", "samsung,on7";
-		lk2nd,match-bootloader = "G600S*";
-
-		lk2nd,dtb-files = "msm8916-samsung-on7";
-
-		qcom,msm-id = <QCOM_ID_MSM8916 0>;
-		qcom,board-id = <0xCE08FF01 3>;
-
-		muic-reset {
-			compatible = "samsung,muic-reset";
-			i2c-reg = <0x25>;
-			i2c-sda-gpios = <&tlmm 105 I2C_GPIO_FLAGS>;
-			i2c-scl-gpios = <&tlmm 106 I2C_GPIO_FLAGS>;
-		};
-	};
-
 	fortuna3g {
 		model = "Samsung Galaxy Grand Prime (SM-G530H)";
 		compatible = "samsung,fortuna3g";


### PR DESCRIPTION
In the transfer from the old way of working to the new one, the match-bootloader line for on7lte-chn got mangled.

Retested a bit with removing the line from msm8929 and now it seems to work weirdly enough. Don't know what happened there when I got lk2nd working....