### PR TITLE
dts: msm8953: Add Asus Zenfone 3 ZE520KL/ZE552KL (zenfone3)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -80,6 +80,7 @@
 
 ### lk2nd-msm8953
 
+- Asus Zenfone 3 ZE520KL/ZE552KL (zenfone3)
 - Fairphone 3
 - Huawei Maimang 5 / Nova (Plus) / G9 (Plus)
 - Lenovo P2 (kuntao)

--- a/lk2nd/device/dts/msm8953/msm8953-asus-zenfone3.dts
+++ b/lk2nd/device/dts/msm8953/msm8953-asus-zenfone3.dts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8953 0>;
+	qcom,board-id = <21 0>;
+};
+
+&lk2nd {
+	model = "Asus Zenfone 3";
+	compatible = "asus,zenfone3";
+	lk2nd,dtb-files = "msm8953-asus-zenfone3", "ze552kl-sr1_msm8953-mtp";
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		volume-down {
+			lk2nd,code = <KEY_VOLUMEDOWN>;
+			gpios = <&tlmm 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8953/msm8953-asus-zenfone3.dts
+++ b/lk2nd/device/dts/msm8953/msm8953-asus-zenfone3.dts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: BSD-3-Clause
 
 /dts-v1/;
 
@@ -13,7 +13,7 @@
 &lk2nd {
 	model = "Asus Zenfone 3";
 	compatible = "asus,zenfone3";
-	lk2nd,dtb-files = "msm8953-asus-zenfone3", "ze552kl-sr1_msm8953-mtp";
+	lk2nd,dtb-files = "msm8953-asus-zenfone3";
 
 	gpio-keys {
 		compatible = "gpio-keys";

--- a/lk2nd/device/dts/msm8953/rules.mk
+++ b/lk2nd/device/dts/msm8953/rules.mk
@@ -3,6 +3,7 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 
 ADTBS += \
 	$(LOCAL_DIR)/apq8053-lenovo-cd-18781y.dtb \
+	$(LOCAL_DIR)/msm8953-asus-zenfone3.dtb \
 	$(LOCAL_DIR)/msm8953-huawei-milan.dtb  \
 	$(LOCAL_DIR)/msm8953-lenovo-kuntao.dtb  \
 	$(LOCAL_DIR)/msm8953-motorola-deen.dtb  \


### PR DESCRIPTION
both ZE520KL and ZE552KL are using the same device tree on the downstream kernel, at least that's when I'm looking at the kernel source at the LineageOS.

---

btw, I have a question about `lk2nd.dtb-files`

```
lk2nd,dtb-files = "msm8953-asus-zenfone3", "ze552kl-sr1_msm8953-mtp";
```

the first one I followed the mainline kernel convention, while the second one is from the downstream kernel. Wdyt? Without these, the lk2nd still boots normally, though.