### PR TITLE
dts: msm8952: Add support for HMD Global Nokia 6

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -71,6 +71,7 @@
 ### lk2nd-msm8952
 
 - BQ X5 Plus (Longcheer L9360)
+- HMD Global Nokia 6 (ple)
 - Leeco s2
 - Motorola Moto G5 (cedric) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-motorola-cedric.dts`)
 - Redmi Note 3 Pro (kenzo)

--- a/lk2nd/device/dts/msm8952/msm8937-nokia-ple.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-nokia-ple.dts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8937 0x2000>,
+		      <QCOM_ID_MSM8937 0x3000>;
+	qcom,board-id = <0x9B 0>;
+};
+
+&lk2nd {
+	ple {
+		model = "HMD Global Nokia 6 (ple)";
+		compatible = "nokia,ple";
+		lk2nd,match-device = "PLE";
+
+		lk2nd,dtb-files = "msm8937-nokia-ple";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&tlmm 91 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -3,6 +3,7 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 
 ADTBS += \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \
+	$(LOCAL_DIR)/msm8937-nokia-ple.dtb \
 	$(LOCAL_DIR)/msm8956-mtp.dtb \
 	$(LOCAL_DIR)/msm8976-qrd.dtb \
 


### PR DESCRIPTION
Adds <i>some</i> support for the HMD Global Nokia 6 (ple).
The only weird thing I've noticed is that the volume keys are swapped around.

<i>The IDs seem to be correct, but still can't boot the downstream.</i>
Tried both, ADTB and QCDTB, but the result seems to be the same.

<img src="https://github.com/user-attachments/assets/72252bbc-5489-4d49-ba4f-5cb41bdaf980" width="40%" />

[lk2nd.log](https://github.com/user-attachments/files/16437903/lk2nd.log)

