### PR TITLE
dts: msm8952: Add support for Huawei Honor 7C

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -72,6 +72,7 @@
 
 - BQ X5 Plus (Longcheer L9360)
 - HMD Global Nokia 6 (ple)
+- Huawei Honor 7C (aum-l41) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-huawei-aum.dts`)
 - Leeco s2
 - Motorola Moto G5 (cedric) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-motorola-cedric.dts`)
 - Redmi Note 3 Pro (kenzo)

--- a/lk2nd/device/dts/msm8952/msm8937-huawei-aum.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-huawei-aum.dts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * To flash lk2nd onto the device, you need to flash lk2nd as the
+ * kernel and flash an empty image in place of the ramdisk.
+ * To create an empty image use the following command:
+ * mkbootimg --kernel /dev/null --ramdisk /dev/null --base 0x80000000 --kernel_offset 0x00008000 --ramdisk_offset 0x02000000 --second_offset 0x00f00000 --tags_offset 0x00000100 --pagesize 2048 --header_version 0 -o ramdisk.img"
+ *
+ * As this device has no boot partition, you'll have to create
+ * one yourself.
+ * To create the partition follow these steps:
+ * ./parted /dev/block/mmcblk0
+ * unit kB
+ * resizepart 55 31209799kB
+ * mkpart boot ext2 31209799kB 100%
+ * quit
+ * dd if=/dev/block/mmcblk0p41 of=/dev/block/mmcblk0p56 bs=1 seek=446 count=64
+ */
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8937 0x8192>;
+	qcom,board-id = <8331 0>;
+};
+
+&lk2nd {
+	aum {
+		model = "Huawei Honor 7C (aum-l41)";
+		compatible = "huawei,aum";
+		lk2nd,match-panel;
+
+		lk2nd,dtb-files = "msm8937-huawei-aum";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&tlmm 91 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+
+		panel {
+			compatible = "huawei,aum-panel", "lk2nd,panel";
+
+			lcdkit_aum_l41_va_djn_cpt_ili9881c_5p7_hd_video {
+				compatible = "huawei,aum-ili9881c";
+			};
+			lcdkit_aum_l41_va_djn_inx_ili9881c_5p7_hd_video {
+				compatible = "huawei,aum-ili9881c";
+			};
+			lcdkit_aum_l41_va_ofilm_inx_ili9881c_5p7_hd_video {
+				compatible = "huawei,aum-ili9881c";
+			};
+			lcdkit_aum_l41_va_tcl_csot_ft8613_5p7_hd_video {
+				compatible = "huawei,aum-ft8613";
+			};
+			lcdkit_aum_l41_va_txd_hsd_hx8394f_5p7_hd_video {
+				compatible = "huawei,aum-hx8394f";
+			};
+			lcdkit_aum_l41_va_txd_inx_hx8394f_5p7_hd_video {
+				compatible = "huawei,aum-hx8394f";
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -2,6 +2,7 @@
 LOCAL_DIR := $(GET_LOCAL_DIR)
 
 ADTBS += \
+	$(LOCAL_DIR)/msm8937-huawei-aum.dtb \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \
 	$(LOCAL_DIR)/msm8937-nokia-ple.dtb \
 	$(LOCAL_DIR)/msm8956-mtp.dtb \


### PR DESCRIPTION
Adds <i>some initial</i> support for the Huawei Honor 7C (aum-l41).
The main issue is that it has separate ramdisk and kernel partitions in place of a normal boot partition. And so, there's a need for some more shenanigans to make it work correctly.

<s><i>Haven't tested if it actually boots anything yet.</i></s>
<s>Trying to boot the downstream results in a freeze, whether it's flashed onto a new boot partition or booted without flashing.</s>

<img src="https://github.com/user-attachments/assets/e7f0d244-979a-47aa-9114-30ea0ebf0874" width="40%" />

[lk2nd.log](https://github.com/user-attachments/files/16431450/lk2ndaum.log)
