### PR TITLE
dts: apq8053-lenovo-cd-18781y: change touchscreen-compatible for FT8201

### DIFF
--- a/lk2nd/device/dts/msm8953/apq8053-lenovo-cd-18781y.dts
+++ b/lk2nd/device/dts/msm8953/apq8053-lenovo-cd-18781y.dts
@@ -62,7 +62,7 @@
 
 		qcom,mdss_dsi_boyift8201_800p_video {
 			compatible = "lenovo,cd-18781y-ft8201";
-			touchscreen-compatible = "edt,edt-ft8201";
+			touchscreen-compatible = "focaltech,ft8201";
 		};
 		qcom,mdss_dsi_hx83100a_800p_video {
 			compatible = "lenovo,cd-18781y-hx83100a";


### PR DESCRIPTION
Mainline settled on using the focaltech,ft8201 format instead of the edt prefix for LCMs that aren't actually made by EDT.

Link: https://lore.kernel.org/linux-input/20240804031310.331871-1-felix@kaechele.ca/T/