### PR TITLE
Add support for OPPO MSM8937 devices

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -75,6 +75,7 @@
 - Huawei Honor 7C (aum-l41) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-huawei-aum.dts`)
 - Leeco s2
 - Motorola Moto G5 (cedric) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-motorola-cedric.dts`)
+- OPPO A57 (A57) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8940-oppo-a57.dts`)
 - Redmi Note 3 Pro (kenzo)
 - Sony Xperia X
 - Sony Xperia X Compact

--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -92,6 +92,7 @@
 - Motorola Moto G5 Plus (potter)
 - Motorola Moto G7 Power (ocean)
 - Motorola One (deen)
+- OPPO R9s/R9sk (R9s/R9sk) (quirky - see comments in `lk2nd/device/dts/msm8953/msm8953-oppo-r9s.dts`)
 - Samsung Galaxy A6+
 - Samsung Galaxy J8 LTE
 - Samsung Tab A2 XL WIFI

--- a/lk2nd/device/dts/msm8952/msm8940-oppo-a57.dts
+++ b/lk2nd/device/dts/msm8952/msm8940-oppo-a57.dts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * OPPO A57 has a few quirks to be aware of before working with lk2nd:
+ *
+ * - Custom board id is required by the bootloader
+ *   The bootloader will attempt to load the first dtb with
+ *   matching msm id, which fails as the board id does not match.
+ *   Add LK2ND_DTBS="msm8940-oppo-a57.dtb" to your make cmdline.
+ *
+ * - Not unlockable bootloaders
+ *   However, downgrading to earlier bootloader versions allow for
+ *   the exploitation of an unvalidated AVB signature vulnerability.
+ *   You will have to insert OPPO AVB signature found at the end of
+ *   stock boot images before the `SEANDROIDENFORCE` string.
+ *   Generic AVB signatures via SIGN_BOOTIMG do not work!
+ *
+ * - lk2nd cannot be flashed in fastboot mode
+ *   Instead, use EDL (https://github.com/bkerler/edl) to write the signed
+ *   lk2nd.img to the boot partition.
+ *   For example:
+ *
+ *     edl w boot build-lk2nd-msm8952/lk2nd.img
+ */
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8940 0x00>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0x00 16061>;
+};
+
+&lk2nd {
+	oppo-a57 {
+		model = "OPPO A57 (16061)";
+		compatible = "oppo,a57";
+		lk2nd,match-cmdline = "*oppo16061*";
+
+		// FIXME: lk2nd,dtb-files = "...";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&tlmm 128 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&tlmm 127 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -5,6 +5,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8937-huawei-aum.dtb \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \
 	$(LOCAL_DIR)/msm8937-nokia-ple.dtb \
+	$(LOCAL_DIR)/msm8940-oppo-a57.dtb \
 	$(LOCAL_DIR)/msm8956-mtp.dtb \
 	$(LOCAL_DIR)/msm8976-qrd.dtb \
 

--- a/lk2nd/device/dts/msm8953/msm8953-oppo-r9s.dts
+++ b/lk2nd/device/dts/msm8953/msm8953-oppo-r9s.dts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * OPPO R9s/k has a few quirks to be aware of before working with lk2nd:
+ *
+ * - Custom board id is required by the bootloader
+ *   The bootloader will attempt to load the first dtb with
+ *   matching msm id, which fails as the board id does not match.
+ *   Add LK2ND_DTBS="msm8953-oppo-r9s.dtb" to your make cmdline.
+ *
+ * - Not unlockable bootloaders
+ *   However, downgrading to earlier bootloader versions allow for
+ *   the exploitation of an unvalidated AVB signature vulnerability.
+ *   You will have to insert OPPO AVB signature found at the end of
+ *   stock boot images before the `SEANDROIDENFORCE` string.
+ *   Generic AVB signatures via SIGN_BOOTIMG do not work!
+ *
+ * - lk2nd cannot be flashed in fastboot mode
+ *   Instead, use EDL (https://github.com/bkerler/edl) to write the signed
+ *   lk2nd.img to the boot partition.
+ *   For example:
+ *
+ *     edl w boot build-lk2nd-msm8952/lk2nd.img
+ */
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8953 0>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0 16017>,
+					<QCOM_BOARD_ID_MTP 0 16027>;
+};
+
+&lk2nd {
+	oppo-r9s {
+		model = "OPPO R9s (16017)";
+		compatible = "oppo,r9s";
+		lk2nd,match-cmdline = "*oppo16017*";
+
+		// FIXME: lk2nd,dtb-files = "...";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&tlmm 86 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
+
+	oppo-r9sk {
+		model = "OPPO R9sk (16027)";
+		compatible = "oppo,r9sk";
+		lk2nd,match-cmdline = "*oppo16027*";
+
+		// FIXME: lk2nd,dtb-files = "...";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&tlmm 86 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8953/rules.mk
+++ b/lk2nd/device/dts/msm8953/rules.mk
@@ -9,6 +9,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8953-motorola-deen.dtb  \
 	$(LOCAL_DIR)/msm8953-motorola-potter.dtb  \
 	$(LOCAL_DIR)/msm8953-mtp.dtb  \
+	$(LOCAL_DIR)/msm8953-oppo-r9s.dtb  \
 	$(LOCAL_DIR)/msm8953-qrd.dtb  \
 	$(LOCAL_DIR)/msm8953-xiaomi-common.dtb  \
 	$(LOCAL_DIR)/msm8953-xiaomi-daisy.dtb  \


### PR DESCRIPTION
These devices were released during which the official notice from CCP regarding locking down bootloader unlock access was released, so earlier versions of their bootloaders weren't impossible to crack, but requires some hacks to work. Please check the individual dts files. Thanks.