### PR TITLE
dts: msm8953: Add support for Xiaomi Redmi 5 (rosy)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -99,6 +99,7 @@
 - Xiaomi Mi A1 (tissot)
 - Xiaomi Mi A2 Lite (daisy)
 - Xiaomi Redmi 4 Prime (markw)
+- Xiaomi Redmi 5 (rosy)
 - Xiaomi Redmi 5 Plus (vince)
 - Xiaomi Redmi 6 Pro (sakura)
 - Xiaomi Redmi 7 (onclite)

--- a/lk2nd/device/dts/msm8953/rules.mk
+++ b/lk2nd/device/dts/msm8953/rules.mk
@@ -17,6 +17,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8953-xiaomi-vince.dtb  \
 	$(LOCAL_DIR)/sdm450-samsung-r04.dtb  \
 	$(LOCAL_DIR)/sdm450-samsung-r05.dtb  \
+	$(LOCAL_DIR)/sdm450-xiaomi-rosy.dtb  \
 	$(LOCAL_DIR)/sdm632-fairphone-fp3.dtb  \
 	$(LOCAL_DIR)/sdm632-motorola-ocean.dtb  \
 	$(LOCAL_DIR)/sdm632-mtp.dtb  \

--- a/lk2nd/device/dts/msm8953/sdm450-xiaomi-rosy.dts
+++ b/lk2nd/device/dts/msm8953/sdm450-xiaomi-rosy.dts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: BSD-3-Clause
 
 /dts-v1/;
 

--- a/lk2nd/device/dts/msm8953/sdm450-xiaomi-rosy.dts
+++ b/lk2nd/device/dts/msm8953/sdm450-xiaomi-rosy.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_SDM450 0>;
+	qcom,board-id = <QCOM_BOARD_ID(QRD, 1, 0) 1>;
+};
+
+&lk2nd {
+	model = "Xiaomi Redmi 5";
+	compatible = "xiaomi,rosy";
+
+	lk2nd,dtb-files = "sdm450-xiaomi-rosy";
+};


### PR DESCRIPTION
This PR adds support for the Xiaomi Redmi 5 (rosy) which is an SDM450 (MSM8953) device. Unfortunately, I don't have a screen on this phone, so I can't add/test panel support.

<details>
<summary>lk2nd.log</summary>

```text
[0] welcome to lk

[10] platform_init()
[10] target_init()
[20] MMC card: <removed> (0.3, 05 1998), manufacturer: 15, OEM: 100, capacity: <removed> bytes
[30] SDHC Running in HS400 mode
[40] Done initialization of the card
[40] Waiting for the RPM to populate smd channel table
[40] lk2nd_init()
[50] Booted @ 0x80008000, r0=0x0, r1=0x0, r2=0x83400000
[50] Found valid DTB with 732 bytes total
[50] Command line from previous bootloader: lk2nd androidboot.emmc=true androidboot.verifiedbootstate=orange androidboot.veritymode=enforcing androidboot.keymaster=1 androidboot.serialno=<removed> androidboot.baseband=msm board_id=<removed>:board_vol=<removed>
[80] Detected device: Xiaomi Redmi 5 (compatible: xiaomi,rosy)
[80] Unexpected DTB selected by bootloader, need to override
[100] No continuous splash: MDP GDSC is not enabled
[100] Registering wrapper bio devices...
[110] Registering mmc_sdhci bio devices...
[130] Error: Command timeout error
[130] Failure getting OCR response from MMC Card
[130] MMC card failed to respond, try for SD card
[140] Error: Command timeout error
[140] The response for CMD8 does not match the supplied value
[140] Failed to initialize SD card
[150] Failed detecting MMC/SDC @ slot2
[150] SD card MMC is unavailable.
[150] block devices:
[160]  | dev        | label           | size       | Leaf |
[160]  | wrp0p49    | lk2nd           |    512 KiB | Yes  |
[170]  | wrp0p48p1  |                 |    268 MiB | Yes  |
[170]  | wrp0p48p0  |                 |    243 MiB | Yes  |
[180]  | wrp0p48    | userdata        |   9853 MiB |      |
[180]  | wrp0p47    | cust            |    512 MiB | Yes  |
[190]  | wrp0p46    | dpo             |      8 KiB | Yes  |
[190]  | wrp0p45    | msadp           |    256 KiB | Yes  |
[200]  | wrp0p44    | apdp            |    256 KiB | Yes  |
[200]  | wrp0p43    | keymasterbak    |    256 KiB | Yes  |
[210]  | wrp0p42    | keymaster       |    256 KiB | Yes  |
[210]  | wrp0p41    | cmnlib64bak     |    256 KiB | Yes  |
[220]  | wrp0p40    | cmnlib64        |    256 KiB | Yes  |
[230]  | wrp0p39    | cmnlibbak       |    256 KiB | Yes  |
[230]  | wrp0p38    | cmnlib          |    256 KiB | Yes  |
[240]  | wrp0p37    | lksecappbak     |    128 KiB | Yes  |
[240]  | wrp0p36    | lksecapp        |    128 KiB | Yes  |
[250]  | wrp0p35    | mcfg            |      4 MiB | Yes  |
[250]  | wrp0p34    | syscfg          |    512 KiB | Yes  |
[260]  | wrp0p33    | mdtp            |     32 MiB | Yes  |
[260]  | wrp0p32    | dip             |   1024 KiB | Yes  |
[270]  | wrp0p31    | mota            |    512 KiB | Yes  |
[270]  | wrp0p30    | limits          |     32 KiB | Yes  |
[280]  | wrp0p29    | oem             |     64 MiB | Yes  |
[280]  | wrp0p28    | config          |     32 KiB | Yes  |
[290]  | wrp0p27    | keystore        |    512 KiB | Yes  |
[290]  | wrp0p26    | misc            |   1024 KiB | Yes  |
[300]  | wrp0p25    | persist         |     32 MiB | Yes  |
[300]  | wrp0p24    | cache           |    512 MiB | Yes  |
[310]  | wrp0p23p1  |                 |    276 MiB | Yes  |
[320]  | wrp0p23p0  |                 |    243 MiB | Yes  |
[320]  | wrp0p23    | system          |   3072 MiB |      |
[330]  | wrp0p22    | devinfo         |   1024 KiB | Yes  |
[330]  | wrp0p21    | recovery        |     64 MiB | Yes  |
[340]  | wrp0p20    | boot            |     63 MiB | Yes  |
[340]  | wrp0p19    | abootbak        |   1024 KiB | Yes  |
[350]  | wrp0p18    | aboot           |   1024 KiB | Yes  |
[350]  | wrp0p17    | splash          |     20 MiB | Yes  |
[360]  | wrp0p16    | sec             |     16 KiB | Yes  |
[360]  | wrp0p15    | fsg             |      4 MiB | Yes  |
[370]  | wrp0p14    | DDR             |     32 KiB | Yes  |
[370]  | wrp0p13    | modemst2        |      4 MiB | Yes  |
[380]  | wrp0p12    | modemst1        |      4 MiB | Yes  |
[380]  | wrp0p11    | dsp             |     16 MiB | Yes  |
[390]  | wrp0p10    | devcfgbak       |    256 KiB | Yes  |
[390]  | wrp0p9     | devcfg          |    256 KiB | Yes  |
[400]  | wrp0p8     | tzbak           |      2 MiB | Yes  |
[410]  | wrp0p7     | tz              |      2 MiB | Yes  |
[410]  | wrp0p6     | rpmbak          |    512 KiB | Yes  |
[420]  | wrp0p5     | rpm             |    512 KiB | Yes  |
[420]  | wrp0p4     | sbl1bak         |    512 KiB | Yes  |
[430]  | wrp0p3     | sbl1            |    512 KiB | Yes  |
[430]  | wrp0p2     | ssd             |      8 KiB | Yes  |
[440]  | wrp0p1     | fsc             |      1 KiB | Yes  |
[440]  | wrp0p0     | modem           |     84 MiB | Yes  |
[450]  | wrp0       |                 |  14910 MiB |      |
[450] boot: Trying to boot from the file system...
[460] ERROR: Invalid boot image header
[460] ERROR: Could not do normal boot. Reverting to fastboot mode.
[470] fastboot_init()
[940] fastboot: processing commands
[5160] fastboot: oem log
```

*Note: potential phone identifiers have been replaced.*
</details>