### PR TITLE
dts: msm8953: Add support for Motorola Moto G6

### DIFF
--- a/lk2nd/device/dts/lk2nd.dtsi
+++ b/lk2nd/device/dts/lk2nd.dtsi
@@ -2,8 +2,19 @@
 #include <dt-bindings/arm/qcom,ids.h>
 #include <dt-bindings/lk2nd/gpio.h>
 #include <dt-bindings/lk2nd/key-codes.h>
+#include <config.h>
 
 / {
+	/*
+	 * Some bootloaders device tree selection logic requires the model property
+	 * to be present in every device tree included in the boot image.
+	 * This is a hack to include the model property in all device trees
+	 * of affected platforms.
+	 */
+#ifdef TARGET_MSM8953
+	model = "";
+#endif
+
 	lk2nd: lk2nd { };
 
 	lk2nd-hw {

--- a/lk2nd/device/dts/msm8953/rules.mk
+++ b/lk2nd/device/dts/msm8953/rules.mk
@@ -15,6 +15,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8953-xiaomi-daisy.dtb  \
 	$(LOCAL_DIR)/msm8953-xiaomi-markw.dtb  \
 	$(LOCAL_DIR)/msm8953-xiaomi-vince.dtb  \
+	$(LOCAL_DIR)/sdm450-motorola-ali.dtb  \
 	$(LOCAL_DIR)/sdm450-samsung-r04.dtb  \
 	$(LOCAL_DIR)/sdm450-samsung-r05.dtb  \
 	$(LOCAL_DIR)/sdm450-xiaomi-rosy.dtb  \

--- a/lk2nd/device/dts/msm8953/sdm450-motorola-ali.dts
+++ b/lk2nd/device/dts/msm8953/sdm450-motorola-ali.dts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+#include <motorola-carrier-channel-ids.dtsi>
+
+/ {
+	/* 
+	 * model is required by bootloader to pick dtb.
+	 * The bootloader also crashes if model isn't present in every dtb. (see lk2nd.dtsi for more info)
+	 */
+	model = "ali"; 
+	qcom,msm-id = <QCOM_ID_SDM450 0>;
+	qcom,board-id = <0x41 0xb1a0>,
+			<0x42 0xb1a0>,
+			<0x42 0xb1b0>,
+			<0x42 0xb200>,
+			<0x43 0xb200>,
+			<0x43 0xc100>,
+			<0x43 0xc200>,
+			<0x44 0xc200>;
+};
+
+&lk2nd {
+	model = "Motorola Moto G6 (ali)";
+	compatible = "motorola,ali";
+
+	lk2nd,dtb-files = "sdm450-motorola-ali";
+
+	unit-info {
+		compatible = "motorola,unit-info";
+	};
+
+	panel {
+		compatible = "motorola,ali-panel", "lk2nd,panel";
+
+		qcom,mdss_dsi_mot_auo_565_1080p_vid_v0 {
+			compatible = "motorola,ali-panel-auo";
+		};
+
+		qcom,mdss_dsi_mot_boe_565_1080p_vid_v0 {
+			compatible = "motorola,ali-panel-boe";
+		};
+
+		qcom,mdss_dsi_mot_tianma_565_1080p_vid_v0 {
+			compatible = "motorola,ali-panel-tianma";
+		};
+	};
+
+};

--- a/lk2nd/device/dts/rules.mk
+++ b/lk2nd/device/dts/rules.mk
@@ -2,7 +2,7 @@
 LOCAL_DIR := $(GET_LOCAL_DIR)
 
 INCLUDES += -I$(LOCAL_DIR)/include
-DT_INCLUDES := -I$(LOCAL_DIR) -I$(LOCAL_DIR)/include
+DT_INCLUDES := -I$(LOCAL_DIR) -I$(LOCAL_DIR)/include -I$(BUILDDIR)
 
 -include $(LOCAL_DIR)/$(TARGET)/rules.mk
 


### PR DESCRIPTION
Adds a device tree for the Motorola Moto G6.
The bootloader requires every appended device tree has the `model` property, otherwise it will crash trying to select a device tree. 
We could add proper model props to every device tree under msm8953, or just add an empty string model to `skeleton64.dtsi`?
`msm8952`'s `cedric` is also affected by this quirk.