### PR TITLE
dts: msm8952: Add support for Motorola Moto G6 Play (jeter)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -76,6 +76,7 @@
 - Leeco s2
 - Motorola Moto G5 (cedric)
 - Motorola Moto G5S (montana)
+- Motorola Moto G6 Play (jeter)
 - OPPO A57 (A57) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8940-oppo-a57.dts`)
 - Redmi 3S (land) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-xiaomi-land.dts`)
 - Redmi 4X (santoni)

--- a/lk2nd/device/dts/msm8952/msm8937-motorola-jeter.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-motorola-jeter.dts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8937 0x00>;
+	qcom,board-id = <0x4A 0x8100>,
+			<0x4A 0x8000>;
+
+	/* 
+	 * model is required by bootloader to pick dtb.
+	 * The bootloader also crashes if model isn't present in every dtb. (see lk2nd.dtsi for more info)
+	 */
+	
+	model = "jeter";
+};
+
+&lk2nd {
+	model = "Motorola Moto G6 Play (jeter)";
+	compatible = "motorola,jeter";
+	lk2nd,match-device = "jeter";
+
+	lk2nd,dtb-files = "msm8937-motorola-jeter";
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -4,6 +4,7 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 ADTBS += \
 	$(LOCAL_DIR)/msm8917-xiaomi-riva.dtb \
 	$(LOCAL_DIR)/msm8937-huawei-aum.dtb \
+	$(LOCAL_DIR)/msm8937-motorola-jeter.dtb \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \
 	$(LOCAL_DIR)/msm8937-nokia-ple.dtb \
 	$(LOCAL_DIR)/msm8937-xiaomi-land.dtb \


### PR DESCRIPTION
Add device tree for the Motorola Moto G6 Play (jeter).

![scr](https://github.com/user-attachments/assets/27240ff3-ae1d-4003-b172-46e3302997ac)
