### PR TITLE
Add support for Redmi Note 5 and Note 5 Prime

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -82,6 +82,7 @@
 - Redmi 4X (santoni)
 - Redmi 5A (riva)
 - Redmi Note 3 Pro (kenzo)
+- Redmi Note 5A (ugglite)
 - Sony Xperia X
 - Sony Xperia X Compact
 - Wileyfox Swift 2

--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -83,6 +83,7 @@
 - Redmi 5A (riva)
 - Redmi Note 3 Pro (kenzo)
 - Redmi Note 5A (ugglite)
+- Redmi Note 5A Prime (ugg)
 - Sony Xperia X
 - Sony Xperia X Compact
 - Wileyfox Swift 2

--- a/lk2nd/device/dts/msm8952/msm8917-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-mtp.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8917 0>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0>;
+};
+
+&lk2nd {
+	xiaomi-ugglite {
+		model = "Xiaomi Redmi Note 5A (ugglite)";
+		compatible = "xiaomi,ugglite";
+
+		lk2nd,dtb-files = "msm8917-xiaomi-ugglite";
+
+		lk2nd,match-panel;
+		panel {
+			compatible = "xiaomi,ugglite-panel", "lk2nd,panel";
+
+			qcom,mdss_dsi_tm_otm1901a_720p_video {
+				compatible = "xiaomi,ugglite-otm1901a-tm";
+			};
+			qcom,mdss_dsi_sc_ili9881c_720p_video {
+				compatible = "xiaomi,ugglite-ili9881c-sc";
+			};
+			qcom,mdss_dsi_hx_otm1901a_720p_video {
+				compatible = "xiaomi,ugglite-otm1901a-hx";
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/msm8917-xiaomi-riva.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-xiaomi-riva.dts
@@ -6,7 +6,7 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <QCOM_ID_MSM8917 0>, <308 0>, <309 0>;
+	qcom,msm-id = <QCOM_ID_MSM8917 0>;
 	qcom,board-id = <0x1000b 2>, <0x2000b 2>;
 };
 

--- a/lk2nd/device/dts/msm8952/msm8940-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8940-mtp.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8940 0>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0>;
+};
+
+&lk2nd {
+	xiaomi-ugg {
+		model = "Xiaomi Redmi Note 5A Prime (ugg)";
+		compatible = "xiaomi,ugg";
+
+		lk2nd,dtb-files = "msm8940-xiaomi-ugg";
+
+		lk2nd,match-panel;
+		panel {
+			compatible = "xiaomi,ugg-panel", "lk2nd,panel";
+
+			qcom,mdss_dsi_tm_otm1901a_720p_video {
+				compatible = "xiaomi,ugglite-otm1901a-tm";
+			};
+			qcom,mdss_dsi_sc_ili9881c_720p_video {
+				compatible = "xiaomi,ugglite-ili9881c-sc";
+			};
+			qcom,mdss_dsi_hx_otm1901a_720p_video {
+				compatible = "xiaomi,ugglite-otm1901a-hx";
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -9,6 +9,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \
 	$(LOCAL_DIR)/msm8937-nokia-ple.dtb \
 	$(LOCAL_DIR)/msm8937-xiaomi-land.dtb \
+	$(LOCAL_DIR)/msm8940-mtp.dtb \
 	$(LOCAL_DIR)/msm8940-oppo-a57.dtb \
 	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb \
 	$(LOCAL_DIR)/msm8956-mtp.dtb \

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -2,6 +2,7 @@
 LOCAL_DIR := $(GET_LOCAL_DIR)
 
 ADTBS += \
+	$(LOCAL_DIR)/msm8917-mtp.dtb \
 	$(LOCAL_DIR)/msm8917-xiaomi-riva.dtb \
 	$(LOCAL_DIR)/msm8937-huawei-aum.dtb \
 	$(LOCAL_DIR)/msm8937-motorola-jeter.dtb \


### PR DESCRIPTION
- Update xiaomi-riva's msm-id to use predefined id macros.
- Add xiaomi-ugglite (msm8917) and ugg (msm8940).