### PR TITLE
doc/dts: msm8974: Remove hammerhead from qcdtbs and document the quirks

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -121,7 +121,7 @@
 - Fairphone 2 - FP2
 - HTC One M8 - m8
 - LG G3 - D855
-- LG Google Nexus 5 - hammerhead D820, D821
+- LG Google Nexus 5 - hammerhead D820, D821 (quirky - see comment in `lk2nd/device/dts/msm8974/msm8974-lge-hammerhead.dts`)
 - Motorola Moto X 2014 - victara
 - OnePlus One - bacon <!--(use `lk2nd-msm8974-appended-dtb.img`)-->
 - Samsung Galaxy Note 3 - SM-N9005

--- a/lk2nd/device/dts/msm8974/msm8974-lge-hammerhead.dts
+++ b/lk2nd/device/dts/msm8974/msm8974-lge-hammerhead.dts
@@ -3,6 +3,11 @@
 #include <skeleton64.dtsi>
 #include <lk2nd.dtsi>
 
+/*
+ * To build for hammerhead, add LK2ND_QCDTBS="" to your make cmdline
+ * hammerhead does not work with qcdtbs enabled.
+ */
+
 / {
 	qcom,msm-id = <QCOM_ID_MSM8974 0x96 0x20002 0xb>;
 };

--- a/lk2nd/device/dts/msm8974/rules.mk
+++ b/lk2nd/device/dts/msm8974/rules.mk
@@ -7,7 +7,6 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8974pro-ac-pm8941-mtp.dtb \
 	$(LOCAL_DIR)/msm8974-htc-m8.dtb \
 	$(LOCAL_DIR)/msm8974-lge-d855.dtb \
-	$(LOCAL_DIR)/msm8974-lge-hammerhead.dtb \
 
 ADTBS += \
 	$(LOCAL_DIR)/msm8974-lge-hammerhead.dtb \


### PR DESCRIPTION
LG Nexus 5 (hammerhead) should not be added for QCDTBS list it breaks other devices. It works with ADTBS and QCDTBS list should be empty.

@z3ntu @minlexx 