### PR TITLE
Fix xiaomi daisy dts

### DIFF
--- a/lk2nd/device/dts/msm8953/msm8953-xiaomi-daisy.dts
+++ b/lk2nd/device/dts/msm8953/msm8953-xiaomi-daisy.dts
@@ -7,7 +7,7 @@
 
 / {
 	qcom,msm-id = <QCOM_ID_MSM8953 0>;
-	qcom,board-id = <QCOM_BOARD_ID(MTP, 1, 0) 0x09>;
+	qcom,board-id = <QCOM_BOARD_ID(QRD, 1, 0) 9>;
 };
 
 &lk2nd {


### PR DESCRIPTION
This PR fixes the xiaomi-daisy DTS which is misconfigured as `QCOM_BOARD_ID(MTP` instead of QCOM_BOARD_ID(QRD`.

Reference: https://github.com/msm8953-mainline/lk2nd/blob/main/dts/msm8953-xiaomi-daisy.dts#L10