### PR TITLE
Add long-press navigation mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ target/*/tools/mkheader
 cscope.*
 ncscope.*
 
+# clangd
+.cache
+compile_commands.json

--- a/Documentation/dt-bindings.md
+++ b/Documentation/dt-bindings.md
@@ -151,6 +151,16 @@ them in the device node and lk2nd will use them instead of autodetecting.
 	qcom,board-id = <0xCE08FF01 1>;
 ```
 
+### Single-key navigation
+
+On some devices, such as smartwatches, there is only one key available for
+navigation. In this case `lk2nd,single-key-navigation` property can be
+used to switch the navigation scheme to short/long press of a single key.
+
+```
+	lk2nd,single-key-navigation;
+```
+
 ## Additional drivers
 
 lk2nd provides a set of optional nodes, following a simple driver

--- a/lk2nd/device/device.c
+++ b/lk2nd/device/device.c
@@ -122,6 +122,10 @@ static void parse_dtb(const void *dtb)
 	if (len < 0)
 		dprintf(CRITICAL, "Failed to read 'lk2nd,dtb-files': %d\n", len);
 
+	val = fdt_getprop(dtb, node, "lk2nd,single-key-navigation", &len);
+	if (len >= 0)
+		lk2nd_dev.single_key = true;
+
 	dprintf(INFO, "Detected device: %s (compatible: %s)\n",
 		lk2nd_dev.model, lk2nd_dev.compatible);
 

--- a/lk2nd/device/device.h
+++ b/lk2nd/device/device.h
@@ -2,6 +2,8 @@
 #ifndef LK2ND_DEVICE_DEVICE_H
 #define LK2ND_DEVICE_DEVICE_H
 
+#include <stdbool.h>
+
 struct lk2nd_panel {
 	const char *name;
 	const char *old_compatible;
@@ -23,6 +25,7 @@ struct lk2nd_device {
 	const char *battery;
 
 	const char *const *dtbfiles;
+	bool single_key;
 
 	struct lk2nd_panel panel;
 

--- a/lk2nd/device/dts/msm8226/apq8026-asus-sparrow.dts
+++ b/lk2nd/device/dts/msm8226/apq8026-asus-sparrow.dts
@@ -12,5 +12,6 @@
 	model = "ASUS ZenWatch 2";
 	compatible = "asus,sparrow";
 
+	lk2nd,single-key-navigation;
 	lk2nd,dtb-files = "apq8026-asus-sparrow";
 };

--- a/lk2nd/device/dts/msm8226/apq8026-huawei-sturgeon.dts
+++ b/lk2nd/device/dts/msm8226/apq8026-huawei-sturgeon.dts
@@ -12,6 +12,7 @@
 	model = "Huawei Watch";
 	compatible = "huawei,sturgeon";
 
+	lk2nd,single-key-navigation;
 	lk2nd,dtb-files = "apq8026-huawei-sturgeon";
 
 	gpio-keys {

--- a/lk2nd/device/dts/msm8226/apq8026-lg-lenok.dts
+++ b/lk2nd/device/dts/msm8226/apq8026-lg-lenok.dts
@@ -15,6 +15,7 @@
 	model = "LG G Watch R";
 	compatible = "lg,lenok";
 
+	lk2nd,single-key-navigation;
 	lk2nd,dtb-files = "apq8026-lg-lenok";
 };
 


### PR DESCRIPTION
Implement optional single-key navigation scheme: short keypress navigates menu items down, and a long press (>1s) selects the item.

fixes #432

@z3ntu would you mind checking that I've picked the correct smartwatches to use single-key? not sure if one of those has multiple keys...