### PR TITLE
msm8953: set more lk2nd,dtb-files

### DIFF
--- a/lk2nd/device/dts/msm8953/msm8953-huawei-milan.dts
+++ b/lk2nd/device/dts/msm8953/msm8953-huawei-milan.dts
@@ -19,7 +19,7 @@
 	model = "Huawei Maimang 5 / Nova (Plus) / G9 (Plus)";
 	compatible = "huawei,milan";
 
-	// FIXME: lk2nd,dtb-files = "msm8953-huawei-milan";
+	lk2nd,dtb-files = "msm8953-huawei-milan";
 
 	panel {
 		compatible = "huawei,milan-panel", "lk2nd,panel";

--- a/lk2nd/device/dts/msm8953/msm8953-lenovo-kuntao.dts
+++ b/lk2nd/device/dts/msm8953/msm8953-lenovo-kuntao.dts
@@ -14,5 +14,5 @@
 	model = "Lenovo P2 (kuntao)";
 	compatible = "lenovo,kuntao";
 	
-	// FIXME: lk2nd,dtb-files = "msm8953-lenovo-kuntao";
+	lk2nd,dtb-files = "msm8953-lenovo-kuntao";
 };


### PR DESCRIPTION
Set lk2nd,dtb-files for lenovo-kuntao and huawei-milan.