### PR TITLE
dts: msm8216-samsung: add e53g

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -35,7 +35,7 @@
 - Samsung Galaxy Ace 4 - SM-G357FZ (quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-samsung.dts`)
 - Samsung Galaxy Core Max - SM-G5108Q (quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-samsung.dts`)
 - Samsung Galaxy Core Prime LTE - SM-G360F, SM-G360G, SM-G360T (rossaltezt is quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-samsung.dts`)
-- Samsung Galaxy E5 - SM-E500F
+- Samsung Galaxy E5 - SM-E500F, SM-E500H
 - Samsung Galaxy E7 - SM-E7000
 - Samsung Galaxy Grand Max - SM-G720AX
 - Samsung Galaxy Grand Prime - SM-G530FZ, SM-G530H, SM-G530R4, SM-G530W, SM-G530Y (G530Y is quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-samsung.dts`)

--- a/lk2nd/device/dts/msm8916/msm8216-samsung.dts
+++ b/lk2nd/device/dts/msm8916/msm8216-samsung.dts
@@ -9,7 +9,8 @@
 	qcom,msm-id = <QCOM_ID_MSM8216 0>;
 	qcom,board-id = <0xF808FF01 5>,
 			<0xF808FF01 7>,
-			<0xF808FF01 8>;
+			<0xF808FF01 8>,
+			<0xF808FF01 10>;
 };
 
 &lk2nd {
@@ -95,5 +96,17 @@
 		qcom,board-id = <0xF808FF01 8>;
 	};
 
+	/* rev 10 */
+
+	e53g {
+		model = "Samsung Galaxy E5 (SM-E500H)";
+		compatible = "samsung,e35g", "samsung,e5";
+		lk2nd,match-bootloader = "E500H*";
+
+		lk2nd,dtb-files = "msm8916-samsung-e5";
+
+		qcom,msm-id = <QCOM_ID_MSM8216 0>;
+		qcom,board-id = <0xF808FF01 10>;
+	};
 };
 


### PR DESCRIPTION
This commit adds E5 Duos (E500H) model node to the msm8216-samsung dts. Also lists the device under Documentation/devices.md.
Can't test if the panel works but another user reports that there's display already.

```
$ fastboot getvar all
....
(bootloader) lk2nd:model:Samsung Galaxy E5 (SM-E500H)
(bootloader) lk2nd:compatible:samsung,e35g

```