### PR TITLE
msm8909: add support for ZTE N818s (codename: sapphire)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -69,6 +69,7 @@
 - Nokia 6300 4G
 - Nokia 8000 4G
 - Nokia 8110 4G
+- ZTE N818S (sapphire)
 
 ### lk2nd-msm8952
 

--- a/lk2nd/device/dts/msm8909/msm8909-zte-sapphire.dts
+++ b/lk2nd/device/dts/msm8909/msm8909-zte-sapphire.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton32.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8909 0>;
+	qcom,board-id = <QCOM_BOARD_ID(QRD, 1, 0) 0x6e>,
+			<QCOM_BOARD_ID(QRD, 1, 4) 0x6e>;
+	compatible = "qcom,msm8909-qrd", "qcom,msm8909", "qcom,qrd";
+};
+
+&lk2nd {
+	zte-sapphire {
+		model = "ZTE N818S (sapphire)";
+		compatible = "zte,sapphire";
+		lk2nd,match-panel;
+		lk2nd,dtb-files = "msm8909-zte-sapphire";
+
+		panel {
+			compatible = "zte,sapphire-panel", "lk2nd,panel";
+
+			qcom,mdss_dsi_hlt_jd9161_hsd_4p_fwvga_video {
+				compatible = "zte,helitai-jd9161-hsd";
+			};
+
+			// possible other variant
+			qcom,zte-lianchuang-ili9806e-hsd-4p0-fwvga-video {
+				compatible = "zte,lianchuang-ili9806e-hsd";
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8909/rules.mk
+++ b/lk2nd/device/dts/msm8909/rules.mk
@@ -7,6 +7,7 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8909-1gb-qrd-skuc.dtb \
 	$(LOCAL_DIR)/msm8909-mtp.dtb \
 	$(LOCAL_DIR)/msm8909-qrd-skue.dtb \
+	$(LOCAL_DIR)/msm8909-zte-sapphire.dtb \
 
 ADTBS += \
         $(LOCAL_DIR)/apq8009w-wtp.dtb \


### PR DESCRIPTION
I have created a basic device tree to get lk2nd booting on my zte sapphire.

Quirks: the system partition is read-only from linux.  Installing to the userdata partition worked fine