### PR TITLE
dts: msm8226: msm8226-samsung: millet3g: new device

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -148,7 +148,7 @@
 - Motorola Moto G 2014 LTE - thea
 - Samsung Galaxy Grand 2 - SM-G7102
 - Samsung Galaxy Tab 4 10.1 (2014) - SM-T530, SM-T535
-- Samsung Galaxy Tab 4 8.0 (2014) - SM-T330, SM-T330NU
+- Samsung Galaxy Tab 4 8.0 (2014) - SM-T330, SM-T330NU, SM-T331
 
 ### lk2nd-msm8994
 

--- a/lk2nd/device/dts/msm8226/msm8226-samsung.dts
+++ b/lk2nd/device/dts/msm8226/msm8226-samsung.dts
@@ -30,5 +30,29 @@
 			};
 		};
 	};
+
+	millet3g {
+		model = "Samsung Galaxy Tab 4 8.0 3G (SM-T331)";
+		compatible = "samsung,millet3g", "samsung,millet";
+		lk2nd,match-bootloader = "T331*";
+
+		lk2nd,dtb-files = "msm8226-samsung-millet3g", "msm8226-samsung-milletwifi";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			home {
+				lk2nd,code = <KEY_HOME>;
+				gpios = <&tlmm 108 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&tlmm 107 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&tlmm 106 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
 };
 


### PR DESCRIPTION
Add 3g variant of samsung-millet.
It based on msm8226 instead of apq8026 which used in milletwifi (SM-T330)

<details>
  <summary>Pictures</summary>
  Tablet running lk2nd photo

  ![Tablet running lk2nd](https://github.com/user-attachments/assets/c28f1b5d-fd2a-41a8-9131-31fef1b6bbcd)

</details>

