### PR TITLE
Add lk1st support for Huawei Mediapad T1-A21W

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -4051,7 +4051,6 @@ normal_boot:
 		if (target_is_emmc_boot())
 		{
 			if (!boot_into_recovery) {
-				/* Try to boot from first fs we can find */
 				ssize_t loaded_file = fsboot_boot_first(target_get_scratch_address(), target_get_max_flash_size());
 
 				if (loaded_file > 0)
@@ -4114,6 +4113,7 @@ normal_boot:
 #if FBCON_DISPLAY_MSG
 	display_fastboot_menu();
 #endif
+	
 }
 
 uint32_t get_page_size()

--- a/dts/msm8916/msm8916-huawei-hwt1a21w.dts
+++ b/dts/msm8916/msm8916-huawei-hwt1a21w.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton.dtsi>
+
+
+/ {
+	qcom,msm-id = <206 0>;
+	qcom,board-id = <8017 4>;
+	model = "Huawei Mediapad T1-A21W";
+	compatible = "huawei,hwt1a21w","qcom,msm8916", "lk2nd,device";
+
+	
+	panel {
+		compatible = "huawei,hwt1a21w-panel";
+		qcom,mdss_dsi_boe_nt51017_10_800p_video {
+			compatible = "huawei,boe-nt51017";
+		};
+	};
+};
+
+

--- a/dts/msm8916/rules.mk
+++ b/dts/msm8916/rules.mk
@@ -13,6 +13,7 @@ DTBS += \
         $(LOCAL_DIR)/msm8916-asus-z00e.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-g7-l01.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-hwt1a21l.dtb \
+	$(LOCAL_DIR)/msm8916-huawei-hwt1a21w.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-y635-l01.dtb \
 	$(LOCAL_DIR)/msm8916-lg.dtb \
 	$(LOCAL_DIR)/msm8916-motorola-harpia-p1b-4d.dtb \

--- a/lk2nd/panel/generated/lk_panel_boe_nt51017_10_800p_video.h
+++ b/lk2nd/panel/generated/lk_panel_boe_nt51017_10_800p_video.h
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2024 FIXME
+// Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
+//   Copyright (c) 2014, The Linux Foundation. All rights reserved. (FIXME)
+
+#ifndef _PANEL_BOE_NT51017_10_800P_VIDEO_H_
+#define _PANEL_BOE_NT51017_10_800P_VIDEO_H_
+
+#include <mipi_dsi.h>
+#include <panel_display.h>
+#include <panel.h>
+#include <string.h>
+
+static struct panel_config boe_nt51017_10_800p_video_panel_data = {
+	.panel_node_id = "qcom,mdss_dsi_boe_nt51017_10_800p_video",
+	.panel_controller = "dsi:0:",
+	.panel_compatible = "qcom,mdss-dsi-panel",
+	.panel_type = 0,
+	.panel_destination = "DISPLAY_1",
+	/* .panel_orientation not supported yet */
+	.panel_framerate = 60,
+	.panel_lp11_init = 1,
+	.panel_init_delay = 0,
+};
+
+static struct panel_resolution boe_nt51017_10_800p_video_panel_res = {
+	.panel_width = 800,
+	.panel_height = 1280,
+	.hfront_porch = 164,
+	.hback_porch = 136,
+	.hpulse_width = 8,
+	.hsync_skew = 0,
+	.vfront_porch = 56,
+	.vback_porch = 42,
+	.vpulse_width = 4,
+	/* Borders not supported yet */
+};
+
+static struct color_info boe_nt51017_10_800p_video_color = {
+	.color_format = 24,
+	.color_order = DSI_RGB_SWAP_RGB,
+	.underflow_color = 0xff,
+	/* Borders and pixel packing not supported yet */
+};
+
+static char boe_nt51017_10_800p_video_on_cmd_0[] = {
+	0x83, 0x96, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_1[] = {
+	0x84, 0x69, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_2[] = {
+	0x95, 0x00, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_3[] = {
+	0x91, 0xc0, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_4[] = {
+	0x92, 0x57, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_5[] = {
+	0x93, 0x20, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_6[] = {
+	0xa9, 0xff, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_7[] = {
+	0xaa, 0xfa, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_8[] = {
+	0xab, 0xf3, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_9[] = {
+	0xac, 0xed, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_10[] = {
+	0xad, 0xe7, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_11[] = {
+	0xae, 0xe2, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_12[] = {
+	0xaf, 0xdc, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_13[] = {
+	0xb0, 0xd7, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_14[] = {
+	0xb1, 0xd1, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_15[] = {
+	0xb2, 0xcc, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_16[] = {
+	0x99, 0x00, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_17[] = {
+	0x83, 0x00, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_18[] = {
+	0x84, 0x00, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_19[] = {
+	0xf5, 0x00, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_20[] = {
+	0x96, 0x40, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_21[] = {
+	0x51, 0xff, 0x15, 0x80
+};
+
+static struct mipi_dsi_cmd boe_nt51017_10_800p_video_on_command[] = {
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_0), boe_nt51017_10_800p_video_on_cmd_0, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_1), boe_nt51017_10_800p_video_on_cmd_1, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_2), boe_nt51017_10_800p_video_on_cmd_2, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_3), boe_nt51017_10_800p_video_on_cmd_3, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_4), boe_nt51017_10_800p_video_on_cmd_4, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_5), boe_nt51017_10_800p_video_on_cmd_5, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_6), boe_nt51017_10_800p_video_on_cmd_6, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_7), boe_nt51017_10_800p_video_on_cmd_7, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_8), boe_nt51017_10_800p_video_on_cmd_8, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_9), boe_nt51017_10_800p_video_on_cmd_9, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_10), boe_nt51017_10_800p_video_on_cmd_10, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_11), boe_nt51017_10_800p_video_on_cmd_11, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_12), boe_nt51017_10_800p_video_on_cmd_12, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_13), boe_nt51017_10_800p_video_on_cmd_13, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_14), boe_nt51017_10_800p_video_on_cmd_14, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_15), boe_nt51017_10_800p_video_on_cmd_15, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_16), boe_nt51017_10_800p_video_on_cmd_16, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_17), boe_nt51017_10_800p_video_on_cmd_17, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_18), boe_nt51017_10_800p_video_on_cmd_18, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_19), boe_nt51017_10_800p_video_on_cmd_19, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_20), boe_nt51017_10_800p_video_on_cmd_20, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_21), boe_nt51017_10_800p_video_on_cmd_21, 0 },
+};
+
+
+static struct mipi_dsi_cmd boe_nt51017_10_800p_video_off_command[] = {
+};
+
+static struct command_state boe_nt51017_10_800p_video_state = {
+	.oncommand_state = 0,
+	.offcommand_state = 0,
+};
+
+static struct commandpanel_info boe_nt51017_10_800p_video_command_panel = {
+	/* Unused, this is a video mode panel */
+};
+
+static struct videopanel_info boe_nt51017_10_800p_video_video_panel = {
+	.hsync_pulse = 1,
+	.hfp_power_mode = 0,
+	.hbp_power_mode = 0,
+	.hsa_power_mode = 0,
+	.bllp_eof_power_mode = 1,
+	.bllp_power_mode = 1,
+	.traffic_mode = 2,
+	/* This is bllp_eof_power_mode and bllp_power_mode combined */
+	.bllp_eof_power = 1 << 3 | 1 << 0,
+};
+
+static struct lane_configuration boe_nt51017_10_800p_video_lane_config = {
+	.dsi_lanes = 4,
+	.dsi_lanemap = 0,
+	.lane0_state = 1,
+	.lane1_state = 1,
+	.lane2_state = 1,
+	.lane3_state = 1,
+	.force_clk_lane_hs = 0,
+};
+
+static const uint32_t boe_nt51017_10_800p_video_timings[] = {
+	0x98, 0x22, 0x16, 0x00, 0x4a, 0x4c, 0x1c, 0x26, 0x1a, 0x03, 0x04, 0x00
+};
+
+static struct panel_timing boe_nt51017_10_800p_video_timing_info = {
+	.tclk_post = 0x04,
+	.tclk_pre = 0x1b,
+};
+
+static struct panel_reset_sequence boe_nt51017_10_800p_video_reset_seq = {
+	.pin_state = { 1, 0, 1 },
+	.sleep = { 1, 20, 120 },
+	.pin_direction = 2,
+};
+
+static struct backlight boe_nt51017_10_800p_video_backlight = {
+	.bl_interface_type = BL_DCS,
+	.bl_min_level = 1,
+	.bl_max_level = 255,
+};
+
+static inline void panel_boe_nt51017_10_800p_video_select(struct panel_struct *panel,
+							  struct msm_panel_info *pinfo,
+							  struct mdss_dsi_phy_ctrl *phy_db)
+{
+	panel->paneldata = &boe_nt51017_10_800p_video_panel_data;
+	panel->panelres = &boe_nt51017_10_800p_video_panel_res;
+	panel->color = &boe_nt51017_10_800p_video_color;
+	panel->videopanel = &boe_nt51017_10_800p_video_video_panel;
+	panel->commandpanel = &boe_nt51017_10_800p_video_command_panel;
+	panel->state = &boe_nt51017_10_800p_video_state;
+	panel->laneconfig = &boe_nt51017_10_800p_video_lane_config;
+	panel->paneltiminginfo = &boe_nt51017_10_800p_video_timing_info;
+	panel->panelresetseq = &boe_nt51017_10_800p_video_reset_seq;
+	panel->backlightinfo = &boe_nt51017_10_800p_video_backlight;
+	pinfo->mipi.panel_cmds = boe_nt51017_10_800p_video_on_command;
+	pinfo->mipi.num_of_panel_cmds = ARRAY_SIZE(boe_nt51017_10_800p_video_on_command);
+	memcpy(phy_db->timing, boe_nt51017_10_800p_video_timings, TIMING_SIZE);
+	phy_db->regulator_mode = DSI_PHY_REGULATOR_LDO_MODE;
+}
+
+#endif /* _PANEL_BOE_NT51017_10_800P_VIDEO_H_ */

--- a/lk2nd/panel/generated/lk_panel_boe_nt51017_10_800p_video.h
+++ b/lk2nd/panel/generated/lk_panel_boe_nt51017_10_800p_video.h
@@ -107,7 +107,16 @@ static char boe_nt51017_10_800p_video_on_cmd_20[] = {
 	0x96, 0x40, 0x15, 0x80
 };
 static char boe_nt51017_10_800p_video_on_cmd_21[] = {
-	0x51, 0xff, 0x15, 0x80
+	0x83, 0x00, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_22[] = {
+	0x84, 0x00, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_23[] = {
+	0x96, 0x00, 0x15, 0x80
+};
+static char boe_nt51017_10_800p_video_on_cmd_24[] = {
+	0xf5, 0xfa, 0x15, 0x80
 };
 
 static struct mipi_dsi_cmd boe_nt51017_10_800p_video_on_command[] = {
@@ -133,6 +142,9 @@ static struct mipi_dsi_cmd boe_nt51017_10_800p_video_on_command[] = {
 	{ sizeof(boe_nt51017_10_800p_video_on_cmd_19), boe_nt51017_10_800p_video_on_cmd_19, 0 },
 	{ sizeof(boe_nt51017_10_800p_video_on_cmd_20), boe_nt51017_10_800p_video_on_cmd_20, 0 },
 	{ sizeof(boe_nt51017_10_800p_video_on_cmd_21), boe_nt51017_10_800p_video_on_cmd_21, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_22), boe_nt51017_10_800p_video_on_cmd_22, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_23), boe_nt51017_10_800p_video_on_cmd_23, 0 },
+	{ sizeof(boe_nt51017_10_800p_video_on_cmd_24), boe_nt51017_10_800p_video_on_cmd_24, 0 },
 };
 
 
@@ -167,7 +179,7 @@ static struct lane_configuration boe_nt51017_10_800p_video_lane_config = {
 	.lane1_state = 1,
 	.lane2_state = 1,
 	.lane3_state = 1,
-	.force_clk_lane_hs = 0,
+	.force_clk_lane_hs = 1,
 };
 
 static const uint32_t boe_nt51017_10_800p_video_timings[] = {

--- a/lk2nd/panel/generated/panels.h
+++ b/lk2nd/panel/generated/panels.h
@@ -4,6 +4,7 @@
 #define _LK2ND_GENERATED_PANELS_H_
 
 #include "lk_panel_boe_otm8019a_5p0_fwvga_video.h"
+#include "lk_panel_boe_nt51017_10_800p_video.h"
 #include "lk_panel_booyi_otm1287_720p_video.h"
 #include "lk_panel_cmi_nt35532_5p5_1080pxa_video.h"
 #include "lk_panel_hx8394d_720p_video.h"

--- a/lk2nd/panel/oem_panel.c
+++ b/lk2nd/panel/oem_panel.c
@@ -16,7 +16,7 @@
 
 #if TARGET_MSM8916
 uint32_t panel_regulator_settings[] = {
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+	0x00, 0x01, 0x01, 0x00, 0x20, 0x07, 0x00
 };
 #endif
 
@@ -70,7 +70,7 @@ static int target_tps65132_ctrl(uint8_t enable)
 int target_ldo_ctrl(uint8_t enable, struct msm_panel_info *pinfo)
 {
 	if (panel_select(LK1ST_PANEL) == panel_tianma_nt35521_5p5_720p_video_select ||
-	    panel_select(LK1ST_PANEL) == panel_cmi_nt35532_5p5_1080pxa_video_select)
+	    panel_select(LK1ST_PANEL) == panel_cmi_nt35532_5p5_1080pxa_video_select||panel_select(LK1ST_PANEL)==panel_boe_nt51017_10_800p_video_select)
 		return target_tps65132_ctrl(enable);
 
 	return NO_ERROR;

--- a/lk2nd/panel/oem_panel.c
+++ b/lk2nd/panel/oem_panel.c
@@ -16,7 +16,7 @@
 
 #if TARGET_MSM8916
 uint32_t panel_regulator_settings[] = {
-	0x00, 0x01, 0x01, 0x00, 0x20, 0x07, 0x00
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 #endif
 
@@ -47,19 +47,20 @@ uint32_t oem_panel_max_auto_detect_panels()
 static int target_tps65132_ctrl(uint8_t enable)
 {
 	if (enable) {
+		gpio_tlmm_config(enn_gpio.pin_id, 0,
+			enn_gpio.pin_direction, 0,
+			enn_gpio.pin_strength,
+			enn_gpio.pin_state);
+		gpio_set_dir(enn_gpio.pin_id, 2);
 		/* for tps65132 ENP pin */
 		gpio_tlmm_config(enp_gpio.pin_id, 0,
-			enp_gpio.pin_direction, enp_gpio.pin_pull,
+			enp_gpio.pin_direction, 0,
 			enp_gpio.pin_strength,
 			enp_gpio.pin_state);
 		gpio_set_dir(enp_gpio.pin_id, 2);
 
 		/* for tps65132 ENN pin*/
-		gpio_tlmm_config(enn_gpio.pin_id, 0,
-			enn_gpio.pin_direction, enn_gpio.pin_pull,
-			enn_gpio.pin_strength,
-			enn_gpio.pin_state);
-		gpio_set_dir(enn_gpio.pin_id, 2);
+		
 	} else {
 		gpio_set_dir(enp_gpio.pin_id, 0); /* ENP */
 		gpio_set_dir(enn_gpio.pin_id, 0); /* ENN */

--- a/platform/msm_shared/display_menu.c
+++ b/platform/msm_shared/display_menu.c
@@ -345,7 +345,7 @@ void display_bootverify_option_menu_renew(struct select_msg_info *msg_info)
 		FBCON_COMMON_MSG, big_factor);
 	display_fbcon_menu_message("Press volume keys to navigate, and "\
 		"press power key to select\n\n", FBCON_COMMON_MSG, common_factor);
-
+	display_fbcon_menu_message("Welcome to HICODE002 BOOTLOADER!\n", FBCON_RED_MSG, common_factor);
 	for (i = 0; i < len; i++) {
 		fbcon_draw_line(FBCON_COMMON_MSG);
 		msg_info->info.option_start[i] = fbcon_get_current_line();
@@ -443,7 +443,7 @@ void display_fastboot_menu_renew(struct select_msg_info *fastboot_msg_info)
 	fbcon_draw_line(msg_type);
 	display_fbcon_menu_message("\n\nPress volume keys to navigate, and "\
 		"press power key to select\n\n", FBCON_COMMON_MSG, common_factor);
-
+	display_fbcon_menu_message("Welcome to HICODE002 BOOTLOADER!\n", FBCON_RED_MSG, common_factor);
 	display_fbcon_menu_message("FASTBOOT MODE\n", FBCON_RED_MSG, common_factor);
 
 #ifdef LK2ND_VERSION

--- a/target/msm8916/include/target/display.h
+++ b/target/msm8916/include/target/display.h
@@ -72,7 +72,7 @@ static struct gpio_pin enn_gpio_1 = {
 };
 
 static struct gpio_pin te_gpio = {
-  0, 0, 0, 0, 0, 0
+  "msmgpio", 24, 3, 1, 0, 1
 };
 
 static struct gpio_pin pwm_gpio = {

--- a/target/msm8916/init.c
+++ b/target/msm8916/init.c
@@ -65,7 +65,7 @@
 #define PMIC_ARB_CHANNEL_NUM    0
 #define PMIC_ARB_OWNER_ID       0
 #define TLMM_VOL_UP_BTN_GPIO    107
-#define TLMM_SBC_USR_LED1_GPIO  21
+#define TLMM_SBC_USR_LED1_GPIO  9
 
 #if PON_VIB_SUPPORT
 #define VIBRATE_TIME    250
@@ -299,6 +299,8 @@ void target_init(void)
         /*
          * Turn on Boot LED
          */
+ gpio_tlmm_config(TLMM_SBC_USR_LED1_GPIO, 0, GPIO_OUTPUT,
+                        GPIO_PULL_UP, GPIO_2MA, GPIO_ENABLE);
         if (board_hardware_id() == HW_PLATFORM_SBC)
                 gpio_tlmm_config(TLMM_SBC_USR_LED1_GPIO, 0, GPIO_OUTPUT,
                         GPIO_PULL_UP, GPIO_2MA, GPIO_ENABLE);

--- a/target/msm8916/target_display.c
+++ b/target/msm8916/target_display.c
@@ -360,7 +360,7 @@ int target_display_dsi2hdmi_config(struct msm_panel_info *pinfo)
 }
 
 static int target_panel_reset_skuh(uint8_t enable)
-{
+{	dprintf(CRITICAL, "Reset Panel\n");
 	int ret = NO_ERROR;
 	if (enable) {
 		/* for tps65132 ENP pin */
@@ -382,7 +382,7 @@ static int target_panel_reset_skuh(uint8_t enable)
 			dprintf(CRITICAL, "qup_blsp_i2c_init failed \n");
 			ASSERT(0);
 		}
-
+		dprintf(CRITICAL, "Reset Panel\n");
 		ret = qrd_lcd_i2c_write(QRD_LCD_VPOS_ADDRESS, 0x0E); /* 5.4V */
 		if (ret) {
 			dprintf(CRITICAL, "VPOS Register: I2C Write failure\n");
@@ -496,8 +496,10 @@ int target_panel_reset(uint8_t enable, struct panel_reset_sequence *resetseq,
 
 			gpio_set_dir(enable_gpio.pin_id, 2);
 		}
-
+		//target_panel_reset_skuh(enable);
+		//dprintf(CRITICAL, "Reset Panel\n");
 #ifndef WITH_LK2ND_PANEL
+		dprintf(CRITICAL, "Reset Panel1\n");
 		if (platform_is_msm8939() || platform_is_msm8929()) {
 			if ((hw_id == HW_PLATFORM_QRD) &&
 				 (hw_subtype == HW_PLATFORM_SUBTYPE_SKUK))


### PR DESCRIPTION
In fact, T1-A21W is the wifi-only version of T1-A21L.
This device does not use tps65132,but shared the same gpios with tps65132
GPIO 32 is used to enable the regulator of LCD
GPIO 97 is used to enable the regulator of the backlight
And huawei uses custom dcs commands to set brightness. 
```
0xf5, your brightness, 0x15, 0x80
```