### PR TITLE
Add support for Nokia 5 and Nokia 6 variants

### DIFF
--- a/lk2nd/device/dts/msm8952/msm8937-nokia-nd1.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-nokia-nd1.dts
@@ -4,37 +4,41 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <QCOM_ID_MSM8937 0x2000>;
+	qcom,msm-id = 	<QCOM_ID_MSM8937 0x0>,    // Variant: FIH_D1_EVB
+			<QCOM_ID_MSM8937 0x1000>, // Variant: FIH_D1_EVT
+			<QCOM_ID_MSM8937 0x2000>; // Variant: FIH_D1_DVT 
 	qcom,board-id = <0x94 0>;
 };
 
 &lk2nd {
-	model = "HMD Global Nokia 5 (nd1)";
-	compatible = "nokia,nd1";
-	lk2nd,match-device = "ND1";
-	lk2nd,dtb-files = "msm8937-nokia-nd1";
-	
+	nd1 {
+		model = "HMD Global Nokia 5 (nd1)";
+		compatible = "nokia,nd1";
+		lk2nd,match-device = "ND1";
+		lk2nd,dtb-files = "msm8937-nokia-nd1";
+		
 
-	gpio-keys {
-		compatible = "gpio-keys";
+		gpio-keys {
+			compatible = "gpio-keys";
 
-		down {
-			lk2nd,code = <KEY_VOLUMEDOWN>;
-			gpios = <&tlmm 91 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&tlmm 91 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+
+			up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&pmic_pon GPIO_PMIC_RESIN 0>;
+			};
 		};
 
-		up {
-			lk2nd,code = <KEY_VOLUMEUP>;
-			gpios = <&pmic_pon GPIO_PMIC_RESIN 0>;
-		};
-	};
+		
+		panel {
+			compatible = "nokia,nd1-panel", "lk2nd,panel";
 
-	
-	panel {
-		compatible = "nokia,nd1-panel", "lk2nd,panel";
-
-		qcom,mdss_dsi_nt35521s_720p_video {
-			compatible = "nokia,nd1-nt35521s";
+			qcom,mdss_dsi_nt35521s_720p_video {
+				compatible = "nokia,nd1-nt35521s";
+			};
 		};
 	};
 };

--- a/lk2nd/device/dts/msm8952/msm8937-nokia-ple.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-nokia-ple.dts
@@ -4,9 +4,11 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <QCOM_ID_MSM8937 0x2000>,
-		      <QCOM_ID_MSM8937 0x3000>;
-	qcom,board-id = <0x9B 0>;
+	qcom,msm-id = 	<QCOM_ID_MSM8937 0x0>,	  // Variant: FIH_PLE_EVT1 / FIH_D1C_EVT1
+			<QCOM_ID_MSM8937 0x2000>, // Variant: FIH_PLE_DVT1 / FIH_D1C_DVT1
+			<QCOM_ID_MSM8937 0x3000>; // Variant: FIH_PLE_PVT / FIH_D1C_PVT
+	qcom,board-id = <0x9B 0>, // PLE (Global version)
+			<0x91 0>; // D1C (China version)
 };
 
 &lk2nd {


### PR DESCRIPTION
These changes are based on downstream DTS files. I have tested the changes on my Nokia 5 with qcom,msm-id value <QCOM_ID_MSM8937 0x2000>. I do not personally own the other devices, so the changes for those variants have not been tested. I believe it is valid to provide support for these devices even though I cannot test them personally. Feedback or verification from someone with access to those devices would be very useful.