### PR TITLE
dts: msm8952: Add support for Motorola Moto G6 Play (XT1922-X, jeter)

### DIFF
--- a/lk2nd/device/dts/msm8952/msm8920-motorola-jeter.dts
+++ b/lk2nd/device/dts/msm8952/msm8920-motorola-jeter.dts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8920 0x00>;
+	qcom,board-id = <0x43 0x8000>,
+			<0x43 0x83a0>;
+
+	/* 
+	 * model is required by bootloader to pick dtb.
+	 * The bootloader also crashes if model isn't present in every dtb. (see lk2nd.dtsi for more info)
+	 */
+	
+	model = "jeter";
+};
+
+&lk2nd {
+	model = "Motorola Moto G6 Play (jeter) (MSM8920)";
+	compatible = "motorola,jeter";
+	lk2nd,match-device = "jeter";
+
+	lk2nd,dtb-files = "msm8920-motorola-jeter";
+};

--- a/lk2nd/device/dts/msm8952/msm8937-motorola-jeter.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-motorola-jeter.dts
@@ -6,7 +6,8 @@
 / {
 	qcom,msm-id = <QCOM_ID_MSM8937 0x00>;
 	qcom,board-id = <0x4A 0x8100>,
-			<0x4A 0x8000>;
+			<0x4A 0x8000>,
+			<0x4B 0x8000>;
 
 	/* 
 	 * model is required by bootloader to pick dtb.
@@ -17,7 +18,7 @@
 };
 
 &lk2nd {
-	model = "Motorola Moto G6 Play (jeter)";
+	model = "Motorola Moto G6 Play (jeter) (MSM8937)";
 	compatible = "motorola,jeter";
 	lk2nd,match-device = "jeter";
 

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -5,6 +5,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8917-mtp.dtb \
 	$(LOCAL_DIR)/msm8917-xiaomi-rolex.dtb \
 	$(LOCAL_DIR)/msm8917-xiaomi-riva.dtb \
+	$(LOCAL_DIR)/msm8920-motorola-jeter.dtb \
 	$(LOCAL_DIR)/msm8937-huawei-aum.dtb \
 	$(LOCAL_DIR)/msm8937-motorola-jeter.dtb \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \


### PR DESCRIPTION
Hello everyone, this pull request introduces device tree support for the Motorola Moto G6 Play (codenamed "jeter") on the MSM8952 platform, which utilizes the MSM8920 CPU (Snapdragon 427).

The DTS was handwritten based on downstream DTS extracted from [unofficial TWRP images found on XDA](https://xdaforums.com/t/g6-play-unofficial-twrp-xt1922-x.4038873/) and the [official TWRP of G6 (non-play variant)](https://twrp.me/motorola/motorolamotog6.html). Its functionality was tested and verified by @pryzhak, the device owner, via the Matrix community. The `gpio-keys` were explicitly set exactly as the downstream DTS, maybe we can strip down "down" and "power" keys after some more testing with @pryzhak.

Build command (needs bootsignature.py dependencies installed):
```bash
make TOOLCHAIN_PREFIX=arm-none-eabi- SIGN_BOOTIMG=1 LK2ND_ADTBS="msm8920-motorola-jeter.dtb" LK2ND_DTBS="" lk2nd-msm8952  
```

Below is a reference image for the device:
![image](https://github.com/user-attachments/assets/691117c3-bb3d-432b-bf36-36c4fa366fda)
