### PR TITLE
msm8953: motorola-potter: change to QCDTB

### DIFF
--- a/lk2nd/device/dts/msm8953/rules.mk
+++ b/lk2nd/device/dts/msm8953/rules.mk
@@ -7,7 +7,6 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8953-huawei-milan.dtb  \
 	$(LOCAL_DIR)/msm8953-lenovo-kuntao.dtb  \
 	$(LOCAL_DIR)/msm8953-motorola-deen.dtb  \
-	$(LOCAL_DIR)/msm8953-motorola-potter.dtb  \
 	$(LOCAL_DIR)/msm8953-motorola-sanders.dtb  \
 	$(LOCAL_DIR)/msm8953-mtp.dtb  \
 	$(LOCAL_DIR)/msm8953-oppo-r9s.dtb  \
@@ -24,3 +23,5 @@ ADTBS += \
 	$(LOCAL_DIR)/sdm632-motorola-ocean.dtb  \
 	$(LOCAL_DIR)/sdm632-mtp.dtb  \
 
+QCDTBS += \
+	$(LOCAL_DIR)/msm8953-motorola-potter.dtb  \


### PR DESCRIPTION
motorola-potter is only booting with QCDTB.