### PR TITLE
Feature: Add optional delay before booting via `fastboot boot`

### DIFF
--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -66,6 +66,11 @@ to override the version (i.e. if you want to package lk2nd build), set this vara
 By setting this option to 1 lk2nd will always enter the menu upon boot instead of
 continuing with the usual workflow. This is useful for debugging and development.
 
+#### `LK2ND_FASTBOOT_DELAY=` - Add delay before booting via `fastboot boot` (ms)
+
+This can help with debugging on devices with carkit uart.
+You need to switch the cable before starting linux to see all the logs.
+
 ### lk2nd specific
 
 #### `LK2ND_ADTBS=`, `LK2ND_QCDTBS=`, `LK2ND_DTBS=` - Only build listed dtbs

--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -3466,6 +3466,12 @@ void cmd_boot(const char *arg, void *data, unsigned sz)
 	fastboot_okay("");
 	fastboot_stop();
 
+	#ifdef LK2ND_FASTBOOT_DELAY
+	/* This can help with debugging on devices with carkit uart. You need to switch the cable before starting linux to see all the logs */
+	dprintf(INFO, "Waiting %ums before boot\n", LK2ND_FASTBOOT_DELAY);
+	thread_sleep(LK2ND_FASTBOOT_DELAY);
+	#endif
+
 	boot_linux((void*) hdr->kernel_addr, (void*) hdr->tags_addr,
 		   (const char*) hdr->cmdline, board_machtype(),
 		   (void*) hdr->ramdisk_addr, hdr->ramdisk_size,

--- a/lk2nd/project/base.mk
+++ b/lk2nd/project/base.mk
@@ -56,6 +56,10 @@ ifeq ($(LK2ND_FORCE_FASTBOOT), 1)
 	DEFINES += LK2ND_FORCE_FASTBOOT=1
 endif
 
+ifdef LK2ND_FASTBOOT_DELAY
+	DEFINES += LK2ND_FASTBOOT_DELAY=$(LK2ND_FASTBOOT_DELAY)
+endif
+
 # Keep the kernel command line clean when booting other operating systems
 DEFINES += GENERATE_CMDLINE_ONLY_FOR_ANDROID=1
 


### PR DESCRIPTION
Useful when a kernel panic occurs before a debugger is attached