### PR TITLE
dts: msm8952: xiaomi-rolex: fix panel selection

### DIFF
--- a/lk2nd/device/dts/msm8952/msm8917-xiaomi-rolex.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-xiaomi-rolex.dts
@@ -20,10 +20,10 @@
 	panel {
 		compatible = "xiaomi,rolex-panel", "lk2nd,panel";
 
-		qcom,mdss_dsi_hx8394f_boe_c3a_720p_video {
+		qcom,mdss_dsi_hx8394f_boe_720p_video {
 			compatible = "xiaomi,rolex-hx8394f-boe";
 		};
-		qcom,mdss_dsi_ili9881c_ebbg_c3a_720p_video {
+		qcom,mdss_dsi_ili9881c_ebbg_720p_video {
 			compatible = "xiaomi,rolex-ili9881c-ebbg";
 		};
 		qcom,mdss_dsi_nt35521s_ebbg_720p_video {


### PR DESCRIPTION
Downstream node names was miss typed what cause panel selection not worked as expected.