### PR TITLE
MSM8952: Add more devices + fixes

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -80,6 +80,7 @@
 - Huawei MediaPad T3 10 (ags- l09/l03/w09) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8917-huawei-agassi.dts`)
 - Leeco s2
 - Lenovo K5 Play (l38011)
+- Motorola Moto E5 Plus (hannah) (MSM8937)
 - Motorola Moto G5 (cedric)
 - Motorola Moto G5S (montana)
 - Motorola Moto G6 Play (jeter)

--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -90,6 +90,7 @@
 - Redmi 4A (rolex)
 - Redmi 4X (santoni)
 - Redmi 5A (riva)
+- Redmi 7A (pine)
 - Redmi Note 3 Pro (kenzo)
 - Redmi Note 5A (ugglite)
 - Redmi Note 5A Prime (ugg)

--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -84,7 +84,7 @@
 - Motorola Moto G5S (montana)
 - Motorola Moto G6 Play (jeter)
 - OPPO A57 (A57) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8940-oppo-a57.dts`)
-- Redmi 3S (land) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-xiaomi-land.dts`)
+- Redmi 3S (land)
 - Redmi 4 (prada)
 - Redmi 4A (rolex)
 - Redmi 4X (santoni)

--- a/lk2nd/device/dts/msm8952/msm8917-xiaomi-riva.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-xiaomi-riva.dts
@@ -22,15 +22,23 @@
 
 		qcom,mdss_dsi_hx8394f_boe_c3b_720p_video {
 			compatible = "xiaomi,riva-hx8394f-boe";
+			touchscreen-compatible = "goodix,gt911";
+			// touchscreen-compatible = "edt,edt-ft5306";
 		};
 		qcom,mdss_dsi_ili9881c_ebbg_c3b_720p_video {
 			compatible = "xiaomi,riva-ili9881c-ebbg";
+			touchscreen-compatible = "edt,edt-ft5306";
+			// touchscreen-compatible = "goodix,gt911";
 		};
 		qcom,mdss_dsi_ili9881c_ebbgDJN_c3b_720p_video {
 			compatible = "xiaomi,riva-ili9881c-ebbgdjn";
+			touchscreen-compatible = "edt,edt-ft5306";
+			// touchscreen-compatible = "goodix,gt911";
 		};
 		qcom,mdss_dsi_ili9881c_tianma_c3b_720p_video {
 			compatible = "xiaomi,riva-ili9881c-tianma";
+			touchscreen-compatible = "edt,edt-ft5306";
+			// touchscreen-compatible = "goodix,gt911";
 		};
 	};
 };

--- a/lk2nd/device/dts/msm8952/msm8917-xiaomi-rolex.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-xiaomi-rolex.dts
@@ -22,12 +22,18 @@
 
 		qcom,mdss_dsi_hx8394f_boe_720p_video {
 			compatible = "xiaomi,rolex-hx8394f-boe";
+			touchscreen-compatible = "goodix,gt911";
+			// touchscreen-compatible = "edt,edt-ft5306";
 		};
 		qcom,mdss_dsi_ili9881c_ebbg_720p_video {
 			compatible = "xiaomi,rolex-ili9881c-ebbg";
+			touchscreen-compatible = "goodix,gt911";
+			// touchscreen-compatible = "edt,edt-ft5306";
 		};
 		qcom,mdss_dsi_nt35521s_ebbg_720p_video {
 			compatible = "xiaomi,rolex-nt35521s-ebbg";
+			touchscreen-compatible = "goodix,gt911";
+			// touchscreen-compatible = "edt,edt-ft5306";
 		};
 	};
 };

--- a/lk2nd/device/dts/msm8952/msm8937-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-mtp.dts
@@ -17,6 +17,30 @@
 		lk2nd,dtb-files = "msm8937-motorola-cedric";
 	};
 
+	hannah {
+		model = "Motorola Moto E5 Plus (hannah) (MSM8937)";
+		compatible = "motorola,hannah";
+		lk2nd,match-device = "hannah";
+
+		lk2nd,dtb-files = "msm8937-motorola-hannah";
+
+		lk2nd,match-panel;
+		panel {
+			compatible = "motorola,hannah-panel", "lk2nd,panel";
+			qcom,mdss_dsi_mot_tianma_599_hd_video_v0 {
+				compatible = "motorola,hannah-599-tianma";
+			};
+
+			qcom,mdss_dsi_mot_djn_599_hd_video_v0 {
+				compatible = "motorola,hannah-599-djn";
+			};
+
+			qcom,qcom,mdss_dsi_mot_djn_600_hd_video_v0 {
+				compatible = "motorola,hannah-600-djn";
+			};
+		};
+	};
+
 	l38011 {
 		model = "Lenovo K5 Play (l38011)";
 		compatible = "lenovo,l38011";

--- a/lk2nd/device/dts/msm8952/msm8937-xiaomi-land.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-xiaomi-land.dts
@@ -5,13 +5,6 @@
 #include <skeleton64.dtsi>
 #include <lk2nd.dtsi>
 
-/*
- * To build for xiaomi-land, add LK2ND_DTBS="" LK2ND_ADTBS="msm8937-xiaomi-land.dtb"
- * to your make cmdline.
- * land does not work with all dtbs enabled; the bootloader gets upset and
- * goes into bootloop.
- */
-
 / {
 	qcom,msm-id = <QCOM_ID_MSM8937 0>;
 	qcom,board-id = <0x1000b 1>, <0x2000b 1>;

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -18,7 +18,8 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8956-mtp.dtb \
 	$(LOCAL_DIR)/msm8956-xiaomi-hydrogen.dtb \
 	$(LOCAL_DIR)/msm8976-qrd.dtb \
+	$(LOCAL_DIR)/sdm439-xiaomi-pine.dtb \
 
 DTBS += \
-    $(LOCAL_DIR)/msm8917-huawei-agassi.dtb \
+	$(LOCAL_DIR)/msm8917-huawei-agassi.dtb \
 

--- a/lk2nd/device/dts/msm8952/sdm439-xiaomi-pine.dts
+++ b/lk2nd/device/dts/msm8952/sdm439-xiaomi-pine.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_SDM439 0>;
+	qcom,board-id = <QCOM_BOARD_ID_QRD 2>;
+	/* Bootloader appears to really want to access symbols */
+	__symbols__ {};
+};
+
+&lk2nd {
+	model = "Xiaomi Redmi 7A (pine)";
+	compatible = "xiaomi,pine";
+
+	lk2nd,dtb-files = "sdm439-xiaomi-pine";
+
+	lk2nd,match-panel;
+	panel {
+		compatible = "xiaomi,pine-panel", "lk2nd,panel";
+
+		qcom,mdss_dsi_ili9881c_hdplus_video {
+			compatible = "xiaomi,pine-ili9881c";
+		};
+
+		qcom,mdss_dsi_ili9881c_hdplus_video_c3e {
+			compatible = "xiaomi,pine-ili9881c-c3e";
+		};
+
+		qcom,mdss_dsi_ili9881d_hdplus_video_c3e {
+			compatible = "xiaomi,pine-ili9881d-c3e";
+		};
+
+		qcom,mdss_dsi_jd9365z_hdplus_video_c3e {
+			compatible = "xiaomi,pine-jd9365z-c3e";
+		};
+	};
+};


### PR DESCRIPTION
New Devices:
- SDM439 Redmi 7A (it needs custom minimal dtbo.img to work)
- MSM8937 Motorola Moto E5 Plus (MSM8940 and MSM8917 variants are not supported)

Changes:
- Remove Redmi 3S workaround documentation it is not needed anymore
- Add touchscreen-compatible for Redmi 4A and 5A