### PR TITLE
menu: Add a custom menu key description feature

### DIFF
--- a/Documentation/dt-bindings.md
+++ b/Documentation/dt-bindings.md
@@ -161,6 +161,31 @@ used to switch the navigation scheme to short/long press of a single key.
 	lk2nd,single-key-navigation;
 ```
 
+### Custom menu navigation key hint
+
+If your device uses re-mapped keys you can customize the hint that is shown in
+the lk2nd boot menu.
+
+For example, if your device only has `Volume Up` and `Volume Down` keys and no
+`Power` key you can add the following optional property:
+
+```
+	lk2nd,menu-key-strings = "Volume Down", "Volume Up";
+```
+
+The first string describes the key(s) used for navigating the menu, the second
+string describes the key used for selecting a menu item.
+
+With the example setting shown above the boot menu would read:
+
+  Volume Down to navigate.
+  Volume Up to select.
+
+If the property is not set the default hint will be shown:
+
+  Volume keys to navigate.
+  Power key to select.
+
 ## Additional drivers
 
 lk2nd provides a set of optional nodes, following a simple driver

--- a/Documentation/dt-bindings.md
+++ b/Documentation/dt-bindings.md
@@ -212,4 +212,38 @@ binding with an exception of the new `lk2nd,code` property.
 	};
 ```
 
+You can also use this to re-map keys to allow for navigating the menu if the
+default keys are not available on the device.
 
+The following example is for a device that only has Volume Up and Down keys, but
+no Power key. It re-maps the Volume Up key to the Power key to allow selecting
+items in the menu.
+
+Note that you may need to unmap a particular key from its original function by
+assigning an unused GPIO in its place. In this case the order of nodes in your
+device tree matters, so ensure that you unmap the key first before you assign a
+new keycode to the actual key.
+
+```
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		/* HACK: map KEY_VOLUMEUP to non-existent button so the actual
+		 * Volume Up button will successfully re-map to KEY_POWER below.
+		 */
+		volume-up-unmap {
+			lk2nd,code = <KEY_VOLUMEUP>;
+			gpios = <&pmic_pon 0 0>;
+		};
+
+		/*
+		 * Remap Volume Up to KEY_POWER to allow selecting menu items as
+		 * there is no power button present on the device.
+		 * Use Volume Down to navigate the menu and Volume Up to select.
+		 */
+		volume-up {
+			lk2nd,code = <KEY_POWER>;
+			gpios = <&tlmm 85 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+	};
+```

--- a/lk2nd/device/device.c
+++ b/lk2nd/device/device.c
@@ -126,6 +126,14 @@ static void parse_dtb(const void *dtb)
 	if (len >= 0)
 		lk2nd_dev.single_key = true;
 
+	val = fdt_stringlist_get(dtb, node, "lk2nd,menu-key-strings", 0, &len);
+	if (val && len > 0)
+		lk2nd_dev.menu_keys.navigate = strndup(val, len);
+
+	val = fdt_stringlist_get(dtb, node, "lk2nd,menu-key-strings", 1, &len);
+	if (val && len > 0)
+		lk2nd_dev.menu_keys.select = strndup(val, len);
+
 	dprintf(INFO, "Detected device: %s (compatible: %s)\n",
 		lk2nd_dev.model, lk2nd_dev.compatible);
 

--- a/lk2nd/device/device.h
+++ b/lk2nd/device/device.h
@@ -17,6 +17,11 @@ struct lk2nd_panel {
 #endif
 };
 
+struct lk2nd_menu_keys {
+	const char *navigate;
+	const char *select;
+};
+
 struct lk2nd_device {
 	const void *dtb;
 
@@ -26,6 +31,7 @@ struct lk2nd_device {
 
 	const char *const *dtbfiles;
 	bool single_key;
+	struct lk2nd_menu_keys menu_keys;
 
 	struct lk2nd_panel panel;
 

--- a/lk2nd/device/dts/msm8953/apq8053-lenovo-cd-18781y.dts
+++ b/lk2nd/device/dts/msm8953/apq8053-lenovo-cd-18781y.dts
@@ -43,6 +43,7 @@
 	compatible = "lenovo,cd-18781y";
 
 	lk2nd,dtb-files = "apq8053-lenovo-cd-18781y";
+	lk2nd,menu-key-strings = "Volume Down", "Volume Up";
 
 	gpio-keys {
 		compatible = "gpio-keys";

--- a/lk2nd/device/menu/menu.c
+++ b/lk2nd/device/menu/menu.c
@@ -203,8 +203,10 @@ void display_fastboot_menu(void)
 		fbcon_puts_ln(SILVER, y, incr, true, "Short press to navigate.");
 		fbcon_puts_ln(SILVER, y, incr, true, "Long press to select.");
 	} else {
-		fbcon_puts_ln(SILVER, y, incr, true, "Volume keys to navigate.");
-		fbcon_puts_ln(SILVER, y, incr, true, "Power key to select.");
+		fbcon_printf_ln(SILVER, y, incr, true, "%s to navigate.",
+				(lk2nd_dev.menu_keys.navigate ? lk2nd_dev.menu_keys.navigate : "Volume keys"));
+		fbcon_printf_ln(SILVER, y, incr, true, "%s to select.",
+				(lk2nd_dev.menu_keys.select ? lk2nd_dev.menu_keys.select : "Power key"));
 	}
 
 	/*


### PR DESCRIPTION
This adds a feature to specify custom key descriptions for the navigation hint in the menu.
This is mostly useful for devices that need to re-map keys, such as https://github.com/msm8916-mainline/lk2nd/blob/main/lk2nd/device/dts/msm8953/apq8053-lenovo-cd-18781y.dts

Please let me know if this creates ginormous memory leaks and security issues, as my C is certainly getting better but it's still not great. I'm aware that you'd eventually have to call `free()` on a `strdup()` but it seems this is done nowhere in the code for all the other fields of the `lk2nd_dev` struct that have something `strdup`'d into it via `lk2nd_device2nd_parse_cmdline` (for example).

Before and after, showing the incorrect key descriptions on the left device (without this patch) and the correct key descriptions on the device on the right:
![tsv-lk2nd-custom-keys](https://github.com/user-attachments/assets/22a912e4-c67f-4658-b525-b04dc63528bb)
