### PR TITLE
dts: msm8939-huawei-rio: fix panel selection

### DIFF
--- a/lk2nd/device/dts/msm8916/msm8939-huawei-rio.dts
+++ b/lk2nd/device/dts/msm8916/msm8939-huawei-rio.dts
@@ -18,7 +18,7 @@
 	lk2nd,dtb-files = "msm8939-huawei-rio";
 
 	panel {
-		compatible = "huawei,rio-panel";
+		compatible = "huawei,rio-panel", "lk2nd,panel";;
 		
 		qcom,mdss_dsi_boe_otm1901_5p5_1080p_video {
 			compatible = "huawei,rio-boe-otm1901";


### PR DESCRIPTION
fixup panel selection for huawei rio