### PR TITLE
dts: msm8952: Add Motorola Moto E5 (nora)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -80,6 +80,7 @@
 - Huawei MediaPad T3 10 (ags- l09/l03/w09) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8917-huawei-agassi.dts`)
 - Leeco s2
 - Lenovo K5 Play (l38011)
+- Motorola Moto E5 (nora)
 - Motorola Moto E5 Plus (hannah) (MSM8937)
 - Motorola Moto G5 (cedric)
 - Motorola Moto G5S (montana)

--- a/lk2nd/device/dts/msm8952/msm8920-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8920-mtp.dts
@@ -6,17 +6,17 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <QCOM_ID_MSM8917 0>;
+	qcom,msm-id = <QCOM_ID_MSM8920 0>;
 	qcom,board-id = <QCOM_BOARD_ID_MTP 0>;
 };
 
 &lk2nd {
 	motorola-nora {
-		model = "Motorola Moto E5 (nora) (MSM8917)";
+		model = "Motorola Moto E5 (nora) (MSM8920)";
 		compatible = "motorola,nora";
 		lk2nd,match-device = "nora";
 
-		lk2nd,dtb-files = "msm8917-motorola-nora";
+		lk2nd,dtb-files = "msm8920-motorola-nora";
 
 		panel {
 			compatible = "motorola,nora-panel", "lk2nd,panel";
@@ -35,28 +35,6 @@
 			};
 			qcom,mdss_dsi_mot_wistron_570_hd_video_v0 {
 				compatible = "motorola,jeter-570-wistron";
-			};
-		};
-	};
-
-	xiaomi-ugglite {
-		model = "Xiaomi Redmi Note 5A (ugglite)";
-		compatible = "xiaomi,ugglite";
-
-		lk2nd,dtb-files = "msm8917-xiaomi-ugglite";
-
-		lk2nd,match-panel;
-		panel {
-			compatible = "xiaomi,ugglite-panel", "lk2nd,panel";
-
-			qcom,mdss_dsi_tm_otm1901a_720p_video {
-				compatible = "xiaomi,ugglite-otm1901a-tm";
-			};
-			qcom,mdss_dsi_sc_ili9881c_720p_video {
-				compatible = "xiaomi,ugglite-ili9881c-sc";
-			};
-			qcom,mdss_dsi_hx_otm1901a_720p_video {
-				compatible = "xiaomi,ugglite-otm1901a-hx";
 			};
 		};
 	};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -6,6 +6,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8917-xiaomi-rolex.dtb \
 	$(LOCAL_DIR)/msm8917-xiaomi-riva.dtb \
 	$(LOCAL_DIR)/msm8920-motorola-jeter.dtb \
+	$(LOCAL_DIR)/msm8920-mtp.dtb \
 	$(LOCAL_DIR)/msm8937-huawei-aum.dtb \
 	$(LOCAL_DIR)/msm8937-motorola-jeter.dtb \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \


### PR DESCRIPTION
Nora is an MTP device (even though Android DTs have different board-id, ref: [msm8917-nora-p0.dts](https://github.com/motoe5/android_kernel_motorola_msm8937/blob/lineage-17.1/arch/arm/boot/dts/qcom/msm8917-nora-p0.dts) [msm8920-nora-p0.dts](https://github.com/motoe5/android_kernel_motorola_msm8937/blob/lineage-17.1/arch/arm/boot/dts/qcom/msm8920-nora-p0.dts); same deal as #416 – maybe all these IDs should be put into the device node as in the "msm-id override" doc section) available in MSM8917 and MSM8920 variants.

![IMG_20250119_040934143_HDR](https://github.com/user-attachments/assets/b2d303f3-9617-47f7-8783-ca69e3c70ed4)

upd: tianma 571 → ili9881h is the only IC i could find in [commits](https://github.com/motoe5/android_kernel_motorola_msm8937/commit/b0adda93fcc70860f9cdc1f28fa15cad8a1378c9)
