### PR TITLE
dts: msm8952: motorola-nora: align panel compatibles with dev tree

### DIFF
--- a/lk2nd/device/dts/msm8952/msm8917-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-mtp.dts
@@ -25,7 +25,7 @@
 				compatible = "motorola,jeter-570-tianma";
 			};
 			qcom,mdss_dsi_mot_tianma_571_hd_video_v0 {
-				compatible = "motorola,jeter-ili9881h-tianma";
+				compatible = "motorola,jeter-571-tianma";
 			};
 			qcom,mdss_dsi_mot_djn_570_hd_video_v0 {
 				compatible = "motorola,jeter-570-djn";

--- a/lk2nd/device/dts/msm8952/msm8920-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8920-mtp.dts
@@ -25,7 +25,7 @@
 				compatible = "motorola,jeter-570-tianma";
 			};
 			qcom,mdss_dsi_mot_tianma_571_hd_video_v0 {
-				compatible = "motorola,jeter-ili9881h-tianma";
+				compatible = "motorola,jeter-571-tianma";
 			};
 			qcom,mdss_dsi_mot_djn_570_hd_video_v0 {
 				compatible = "motorola,jeter-570-djn";


### PR DESCRIPTION
We have decided not to list the IC for the only variant where we know it. (https://github.com/msm89x7-mainline/linux-panel-drivers/pull/5)