### PR TITLE
dts: msm8939: Add support for Huawei MediaPad T2 10.0 Pro (federer)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -17,6 +17,7 @@
 - Huawei Ascend G7 - G7-L01
 - Huawei G7 Plus / G8 / GX8 - rio
 - Huawei Honor 5X / GR5 (2016) - kiwi
+- Huawei MediaPad T2 10.0 Pro - federer
 - Huawei Y635 - Y635-L01 (quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-huawei-y635-l01.dts`)
 - Lenovo A6000
 - Lenovo A6010

--- a/lk2nd/device/dts/msm8916/msm8939-huawei-federer.dts
+++ b/lk2nd/device/dts/msm8916/msm8939-huawei-federer.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8939 0>;
+	qcom,board-id =
+		<8000 0>, <8000 4>, 
+		<8016 0>, <8016 4>,
+		<8032 0>, <8032 4>,
+		<8112 0>, <8112 4>,
+		<8128 0>, <8128 4>;
+};
+
+&lk2nd {
+	model = "Huawei MediaPad T2 10.0 Pro";
+	compatible = "huawei,federer";
+
+	lk2nd,dtb-files = "msm8939-huawei-federer";
+
+	panel {
+		compatible = "huawei,federer-panel", "lk2nd,panel";
+
+		qcom,mdss_dsi_boe_nt51021_10_1200p_video {
+			compatible = "huawei,boe-nt51021";
+		};
+		qcom,mdss_dsi_cmi_nt51021_10_1200p_video {
+			compatible = "huawei,cmi-nt51021";
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8916/rules.mk
+++ b/lk2nd/device/dts/msm8916/rules.mk
@@ -33,6 +33,7 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8929-samsung.dtb \
 	$(LOCAL_DIR)/msm8929-qrd-wt82918hd.dtb \
 	$(LOCAL_DIR)/msm8939-asus-z00t.dtb \
+	$(LOCAL_DIR)/msm8939-huawei-federer.dtb \
 	$(LOCAL_DIR)/msm8939-huawei-kiwi.dtb \
 	$(LOCAL_DIR)/msm8939-huawei-rio.dtb \
 	$(LOCAL_DIR)/msm8939-mtp.dtb \


### PR DESCRIPTION
![20250126_203654](https://github.com/user-attachments/assets/ab9e10c6-102d-4bc8-b215-66376fa6968c)
