### PR TITLE
lk2nd: device: panel: remove failure on status is missing

### DIFF
--- a/lk2nd/device/panel.c
+++ b/lk2nd/device/panel.c
@@ -97,9 +97,14 @@ static int lk2nd_panel_dt_update(void *dtb, const char *cmdline,
 
 		ret = fdt_nop_property(dtb, node, "status");
 		if (ret < 0) {
-			dprintf(CRITICAL, "Failed to enable %s touchscreen: %d\n",
-				panel->ts_compatible, ret);
-			return ret;
+			dprintf(CRITICAL,
+				"WARNING!!!!\n"
+				"Failed to enable %s touchscreen: %d\n"
+				"Please check your device tree.\n"
+				"Maybe a status property is missing from touchscreen nodes.\n",
+				panel->ts_compatible,
+				ret);
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
Remove failure when ts-compatible is in use and status property is missing from touchscreen node. Make a warning instead of fail.

Issues:
- Message is not appearing in the logs yet.
- Maybe it would be great show this warning on splash.

Fixes: #482 