### PR TITLE
msm_shared_ dwc: Stop device in dwc_device_reset

### DIFF
--- a/platform/msm_shared/usb30_dwc_hw.c
+++ b/platform/msm_shared/usb30_dwc_hw.c
@@ -366,6 +366,7 @@ void dwc_device_reset(dwc_dev_t *dev)
 {
 	/* start reset */
 	REG_WRITE_FIELD(dev, DCTL, CSFTRST, 1);
+	dwc_device_run(dev, 0);
 
 	/* wait until done */
 	while(REG_READ_FIELD(dev, DCTL, CSFTRST));


### PR DESCRIPTION
Based on:
https://github.com/torvalds/linux/blob/master/drivers/usb/dwc3/core.c#L319
https://github.com/torvalds/linux/commit/f4fd84ae0765a80494b28c43b756a95100351a94
