### PR TITLE
msm8953: add support for Samsung Galaxy Tab A (2018, 10.5) LTE 

### DIFF
--- a/lk2nd/device/dts/msm8953/rules.mk
+++ b/lk2nd/device/dts/msm8953/rules.mk
@@ -27,3 +27,4 @@ ADTBS += \
 
 QCDTBS += \
 	$(LOCAL_DIR)/msm8953-motorola-potter.dtb  \
+	$(LOCAL_DIR)/sdm450-samsung-r04.dtb  \

--- a/lk2nd/device/dts/msm8953/sdm450-samsung-r04.dts
+++ b/lk2nd/device/dts/msm8953/sdm450-samsung-r04.dts
@@ -70,4 +70,13 @@
 
 		lk2nd,dtb-files = "sdm450-samsung-a6plte-r4";
 	};	
+
+	gta2xllte-generic {
+		model = "Samsung Tab A2 XL LTE Rev04";
+		compatible = "samsung,gta2xllte";
+		lk2nd,match-bootloader = "T595*";
+
+		lk2nd,dtb-files = "sdm450-samsung-gta2xllte";
+	};
+
 };


### PR DESCRIPTION
This MR is for adding support for the Samsung SM-T595 Tablet.

Status:
it boots, things like fastboot flash and fastboot boot work

Quirks: 
sometimes USB breaks, even after cold booting, sometimes i noticed it happening when a Kernel initialized usb, and going to Download mode fixed it (survives cold boots), but i can't constantly reproduce it