### PR TITLE
Add support for LG G5 (H850)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -164,6 +164,7 @@
 
 ### lk2nd-msm8996
 
+- LG G5 - h850
 - LG V20 - h990
 - OnePlus 3T
 - Xiaomi Mi5 - Gemini

--- a/lk2nd/device/dts/msm8996/msm8996-lg-h850.dts
+++ b/lk2nd/device/dts/msm8996/msm8996-lg-h850.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8996 0x10000>;
+	qcom,board-id = <0xc08 0x00>;
+	qcom,pmic-id = <0x20009 0x10013 0x00 0x00>;
+};
+
+&lk2nd {
+	model = "LG G5 (H850)";
+	compatible = "lg,h850";
+};

--- a/lk2nd/device/dts/msm8996/rules.mk
+++ b/lk2nd/device/dts/msm8996/rules.mk
@@ -3,5 +3,6 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 
 ADTBS += \
 	$(LOCAL_DIR)/msm8996pro-oneplus3t.dtb \
+	$(LOCAL_DIR)/msm8996-lg-h850.dtb \
 	$(LOCAL_DIR)/msm8996-lg-h990.dtb \
 	$(LOCAL_DIR)/msm8996-xiaomi-mi5.dtb \


### PR DESCRIPTION
Working device tree for the LG G5 (H850, EU model.)

Confirmed that menu navigation keys work, and am able to boot a TWRP image using fastboot boot.