### PR TITLE
dts: msm8916: Add support for Wiko Pulp 4G

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -54,6 +54,7 @@
 - Vivo Y21L
 - Vodafone Smart prime 6
 - Wileyfox Swift - crackling
+- Wiko Pulp 4G
 - Xiaomi Mi 4i - ferrari
 - Xiaomi Redmi 2 - wt86047, wt88047
 - Xiaomi Redmi 3 - ido

--- a/lk2nd/device/dts/msm8916/msm8916-wiko-chuppito.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-wiko-chuppito.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause
+ 
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8916 0>;
+	qcom,board-id = <QCOM_BOARD_ID(QRD, 1, 0) 5>;
+};
+
+&lk2nd {
+	model = "Wiko Pulp 4G";
+	compatible = "wiko,chuppito";
+	lk2nd,dtb-files = "msm8916-wiko-chuppito";
+};

--- a/lk2nd/device/dts/msm8916/rules.mk
+++ b/lk2nd/device/dts/msm8916/rules.mk
@@ -30,6 +30,7 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8916-qrd-skut1.dtb \
 	$(LOCAL_DIR)/msm8916-samsung.dtb \
 	$(LOCAL_DIR)/msm8916-vivo-y21l.dtb \
+	$(LOCAL_DIR)/msm8916-wiko-chuppito.dtb \
 	$(LOCAL_DIR)/msm8929-samsung.dtb \
 	$(LOCAL_DIR)/msm8929-qrd-wt82918hd.dtb \
 	$(LOCAL_DIR)/msm8939-asus-z00t.dtb \


### PR DESCRIPTION
Adds support for `wiko-chuppito`.
