### PR TITLE
Add device variant RS988 (US)

### DIFF
--- a/lk2nd/device/dts/msm8996/msm8996-lg-h850.dts
+++ b/lk2nd/device/dts/msm8996/msm8996-lg-h850.dts
@@ -10,6 +10,15 @@
 };
 
 &lk2nd {
-	model = "LG G5 (H850)";
-	compatible = "lg,h850";
+        h850 {
+        model = "LG G5 (H850)";
+        compatible = "lg,h850";
+        lk2nd,match-cmdline = "*androidboot.serialno=LGH850*";
+        };
+
+        rs988 {
+        model = "LG G5 (RS988)";
+        compatible = "lg,rs988";
+        lk2nd,match-cmdline = "*androidboot.serialno=RS988*";
+        };
 };

--- a/lk2nd/device/dts/msm8996/msm8996-lg-h850.dts
+++ b/lk2nd/device/dts/msm8996/msm8996-lg-h850.dts
@@ -10,15 +10,15 @@
 };
 
 &lk2nd {
-        h850 {
-        model = "LG G5 (H850)";
-        compatible = "lg,h850";
-        lk2nd,match-cmdline = "*androidboot.serialno=LGH850*";
-        };
+	h850 {
+		model = "LG G5 (H850)";
+		compatible = "lg,h850";
+		lk2nd,match-cmdline = "*androidboot.serialno=LGH850*";
+	};
 
-        rs988 {
-        model = "LG G5 (RS988)";
-        compatible = "lg,rs988";
-        lk2nd,match-cmdline = "*androidboot.serialno=RS988*";
-        };
+	rs988 {
+		model = "LG G5 (RS988)";
+		compatible = "lg,rs988";
+		lk2nd,match-cmdline = "*androidboot.serialno=RS988*";
+	};
 };


### PR DESCRIPTION
H850 and RS988 variants have the same board-id. This DTS fully works on both, so use lk2nd,match-cmdline to just tell us which variant we're running on.

