### PR TITLE
lk2nd: device: Add an LED driver

### DIFF
--- a/Documentation/dt-bindings.md
+++ b/Documentation/dt-bindings.md
@@ -247,3 +247,34 @@ new keycode to the actual key.
 		};
 	};
 ```
+
+### GPIO leds
+
+lk2nd supports the `gpio-leds` node. This node follows upstream binding except
+that most properties are not supported. Currently only `gpios` and
+`default-state` are supported in lk2nd.
+
+```
+gpio-leds {
+    compatible = "gpio-leds";
+
+    red {
+        gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+        default-state = "on";
+    };
+
+    green {
+        gpios = <&tlmm 4 GPIO_ACTIVE_HIGH>;
+        default-state = "off";
+    };
+};
+```
+
+This driver is mainly for lk1st since no previous boot-loader is capable to
+light up an LED in this case. This makes it unclear what state currently the
+device is in. If you wish to make sure some leds are enabled or disabled by
+lk1st on boot, you can use this driver.
+
+lk2nd doesn't implement a fully-fledged led subsystem. The only purpose for
+this driver is for debugging and the LED behavior consistancy between lk1st
+and lk2nd.

--- a/lk2nd/device/leds.c
+++ b/lk2nd/device/leds.c
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright (c) 2025 Yang Xiwen <forbidden405@outlook.com> */
+
+#include <debug.h>
+#include <libfdt.h>
+
+#include <lk2nd/hw/gpio.h>
+
+#include "device.h"
+
+static int lk2nd_leds_init(const void *dtb, int node)
+{
+	int i = 0, subnode, len;
+	struct gpiol_desc desc;
+	const char *state;
+
+	dprintf(SPEW, " Initializing LEDs\n");
+	dprintf(SPEW, " | label | gpio        | state |\n");
+
+	fdt_for_each_subnode(subnode, dtb, node) {
+		state = fdt_getprop(dtb, subnode, "default-state", &len);
+		if (len < 0 || state[len - 1] != '\0') {
+			dprintf(CRITICAL, "leds: Failed to get property \"default-state\". Broken dtb?\n");
+			continue;
+		}
+
+		if (!strcmp(state, "on")) {
+			gpiol_get(dtb, subnode, NULL, &desc, GPIOL_FLAGS_OUT_ASSERTED);
+		} else if (!strcmp(state, "off")) {
+			gpiol_get(dtb, subnode, NULL, &desc, GPIOL_FLAGS_OUT_DEASSERTED);
+		} else if (!strcmp(state, "keep")) {
+			/* do nothing */
+		} else {
+			dprintf(CRITICAL, "leds: Unknown \"default-state\" value: %s\n", state);
+			continue;
+		}
+
+		i++;
+
+		dprintf(SPEW, " | %5s | 0x%02x 0x%04x | %5s |\n",
+			fdt_get_name(dtb, subnode, NULL), desc.dev, desc.pin, state);
+	}
+	dprintf(INFO, "leds: %d leds configured\n", i);
+
+	if (subnode < 0 && subnode != -FDT_ERR_NOTFOUND) {
+		dprintf(CRITICAL, "leds: Failed to parse subnodes: %d\n", subnode);
+		return subnode;
+	}
+
+	return 0;
+}
+
+LK2ND_DEVICE_INIT("gpio-leds", lk2nd_leds_init);

--- a/lk2nd/device/rules.mk
+++ b/lk2nd/device/rules.mk
@@ -18,6 +18,7 @@ OBJS += \
 	$(LK2ND_DEVICE_OBJ) \
 	$(LOCAL_DIR)/panel.o \
 	$(LOCAL_DIR)/keys.o \
+	$(LOCAL_DIR)/leds.o \
 
 ifneq ($(LK2ND_COMPATIBLE),)
 DEFINES += LK2ND_COMPATIBLE="$(LK2ND_COMPATIBLE)"


### PR DESCRIPTION
I use lk1st for most of the time and find it really annoying to has no LED indication in lk1st. So here is the driver to resolve the issue. The code is based on keymap.c, though much simpler and provides no API for other modules. You need to add a node to the dts like below:
```dts
leds {
    compatible = "gpio-leds";
    red {
        gpios = <&tlmm 3 GPIO_ACTIVE_LOW>;
        default-state = "on" // or "off", "keep"
    };
};
```

Tested on a downstream zhihe device with lk2nd.

Not all error paths are tested yet. Need review.