### PR TITLE
Msm8996 zte axon7

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -172,6 +172,7 @@
 - LG V20 - h990
 - OnePlus 3T
 - Xiaomi Mi5 - Gemini
+- ZTE Axon 7
 
 ### lk2nd-msm8960
 

--- a/lk2nd/boot/boot.c
+++ b/lk2nd/boot/boot.c
@@ -59,7 +59,7 @@ static void lk2nd_scan_devices(void)
 		lk2nd_try_extlinux(mountpoint);
 	}
 
-	dprintf(INFO, "boot: Bootable file system not found. Reverting to android boot.");
+	dprintf(INFO, "boot: Bootable file system not found. Reverting to android boot.\n");
 }
 
 /**

--- a/lk2nd/device/dts/msm8996/msm8996-zte-axon7.dts
+++ b/lk2nd/device/dts/msm8996/msm8996-zte-axon7.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8996 0x30001>;
+	qcom,board-id = <100 0>;
+	qcom,pmic-id = <0x20009 0x10013 0x0 0x0>;
+};
+
+&lk2nd {
+	model = "ZTE Axon 7";
+	compatible = "zte,axon7";
+	lk2nd,dtb-files = "msm8996-zte-axon7";
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		volume-up {
+			lk2nd,code = <KEY_VOLUMEUP>;
+			gpios = <&pmic 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+
+		volume-down {
+			lk2nd,code = <KEY_VOLUMEDOWN>;
+			gpios = <&pmic 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8996/rules.mk
+++ b/lk2nd/device/dts/msm8996/rules.mk
@@ -6,3 +6,4 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8996-lg-h850.dtb \
 	$(LOCAL_DIR)/msm8996-lg-h990.dtb \
 	$(LOCAL_DIR)/msm8996-xiaomi-mi5.dtb \
+	$(LOCAL_DIR)/msm8996-zte-axon7.dtb \


### PR DESCRIPTION
Unfortunately, flashing in lk2nd does not work. Could this be possibly related to ZTE removing the stock fastboot interface on the latest Oreo firmware?

```
[10] platform_init()
[10] target_init()
[10] RPM GLink Init
[10] Opening RPM Glink Port success
[10] Opening SSR Glink Port success
[20] Glink Connection between APPS and RPM established
[20] Glink Connection between APPS and RPM established
[30] UFS init success
[30] lk2nd_init()
[30] Booted @ 0x80008000, r0=0x0, r1=0x0, r2=0x82400000
[30] MMU mapping mismatch @ 0x82400000: 0x82401c1e != 0x82400c1a
[40] Found valid DTB with 1856 bytes total
[40] Command line from previous bootloader: lk2nd androidboot.bootdevice=624000.ufshc androidboot.verifiedbootstate=orange androidboot.veritymode=eio androidboot.keymaster=1 androidboot.serialno=12345678 androidboot.baseband=msm mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_zte_samsung_5p5_wqhd_dualmipi_cmd:1:qcom,mdss_dsi_zte_samsung_5p5_wqhd_dualmipi_cmd:cfg:split_dsi androidboot.dmverity_disabled=0 androidboot.fastboot=0 androidboot.adbtradefed=0 androidboot.emmcid=12345678 androidboot.wp.check= N_OTA_O
[90] Detected device: ZTE Axon 7 (compatible: zte,axon7)
[90] keys: 2 keymap overrides applied
[100] MDP continuous splash detected: pipe VIG_0, base: 0x83401000, stride: 4320, src: 720x2560 (0,0), img: 1440x2560, out: 720x2560 (0,0), format: 0x2243f (bpp: 3)
[110] Display refresh: cmd mode: 1, auto refresh: 0 (sel: 0x21f20)
[120] Registering wrapper bio devices...
[130] Registering mmc_sdhci bio devices...
[130] SD card MMC is unavailable.
[130] block devices:
[140]  | dev        | label           | size       | Leaf |
[140]  | wrp0p45    | lk2nd           |    512 KiB | Yes  |
[150]  | wrp0p44    | persist         |     32 MiB | Yes  |
[150]  | wrp0p43    | ztecfg          |    512 KiB | Yes  |
[160]  | wrp0p42    | fsc             |      4 KiB | Yes  |
[160]  | wrp0p41    | modemst2        |      2 MiB | Yes  |
[170]  | wrp0p40    | modemst1        |      2 MiB | Yes  |
[170]  | wrp0p39    | sti             |      2 MiB | Yes  |
[180]  | wrp0p38    | echarge         |     40 MiB | Yes  |
[180]  | wrp0p37    | splash          |     32 MiB | Yes  |
[190]  | wrp0p36    | dpo             |      4 KiB | Yes  |
[190]  | wrp0p35    | msadp           |    256 KiB | Yes  |
[200]  | wrp0p34    | apdp            |    256 KiB | Yes  |
[200]  | wrp0p33    | cmnlib64        |    256 KiB | Yes  |
[210]  | wrp0p32    | cmnlib          |    256 KiB | Yes  |
[210]  | wrp0p31    | keymaster       |    256 KiB | Yes  |
[220]  | wrp0p30    | lksecapp        |    128 KiB | Yes  |
[230]  | wrp0p29    | bluetooth       |   1024 KiB | Yes  |
[230]  | wrp0p28    | devinfo         |      4 KiB | Yes  |
[240]  | wrp0p27    | recovery        |     64 MiB | Yes  |
[240]  | wrp0p26    | system          |   6144 MiB | Yes  |
[250]  | wrp0p25    | boot            |     63 MiB | Yes  |
[250]  | wrp0p24    | aboot           |   1024 KiB | Yes  |
[260]  | wrp0p23    | mdtp            |     32 MiB | Yes  |
[260]  | wrp0p22    | dip             |   1024 KiB | Yes  |
[270]  | wrp0p21    | dsp             |     16 MiB | Yes  |
[270]  | wrp0p20    | modem           |     95 MiB | Yes  |
[280]  | wrp0p19    | pmic            |    512 KiB | Yes  |
[280]  | wrp0p18    | sec             |     16 KiB | Yes  |
[290]  | wrp0p17    | fsg             |      2 MiB | Yes  |
[290]  | wrp0p16    | hyp             |    512 KiB | Yes  |
[300]  | wrp0p15    | tz              |      2 MiB | Yes  |
[300]  | wrp0p14    | rpm             |    512 KiB | Yes  |
[310]  | wrp0p13    | ddr             |   1024 KiB | Yes  |
[320]  | wrp0p12    | cdt             |      4 KiB | Yes  |
[320]  | wrp0p11    | reserve         |     32 KiB | Yes  |
[330]  | wrp0p10    | xblbak          |      3 MiB | Yes  |
[330]  | wrp0p9     | xbl             |      3 MiB | Yes  |
[340]  | wrp0p8     | userdata        |  53669 MiB | Yes  |
[340]  | wrp0p7     | cryptkey        |    512 KiB | Yes  |
[350]  | wrp0p6     | frp             |    512 KiB | Yes  |
[350]  | wrp0p5     | fbop            |    128 KiB | Yes  |
[360]  | wrp0p4     | devcfg          |    128 KiB | Yes  |
[360]  | wrp0p3     | keystore        |    512 KiB | Yes  |
[370]  | wrp0p2     | misc            |   1024 KiB | Yes  |
[370]  | wrp0p1     | cache           |    800 MiB | Yes  |
[380]  | wrp0p0     | ssd             |      8 KiB | Yes  |
[380]  | wrp0       |                 |  54472 MiB |      |
[390] boot: Trying to boot from the file system...
[390] boot: Bootable file system not found. Reverting to android boot.
[400] ERROR: Invalid boot image header
[400] ERROR: Could not do normal boot. Reverting to fastboot mode.
[410] fastboot_init()
[1120] fastboot: processing commands
[8350] fastboot: getvar:has-slot:lk2nd
[8370] fastboot: getvar:max-download-size
[8390] fastboot: getvar:is-logical:lk2nd
[8410] fastboot: getvar:is-logical:lk2nd
[8430] fastboot: getvar:partition-size:lk2nd
[8450] fastboot: download:00059010
[8490] fastboot: flash:lk2nd
[8490] Data segment length: 14
[8490] SCSI Request failed and we have sense data
[8490] Sense Data Length/Response Code: 0x12/0x7000
[8500] Sense Key: 0x7
[8500] DATA PROTECT: Read/Write operation attempted on a block that is protected from this operation
[8510] Sense Buffer (HEX): 0x740a5f7 0xa0000 0x2700 0x0
[8510] ucs_do_scsi_cmd failed status = 2
[8520] ucs_do_scsi_write: failed
[8520] UFS write failed.
[8520] ------Host controller register dump ---------
[8530] UFS_UECPA 0x0
[8530] UFS_UECDL 0x0
[8530] UFS_UECN 0x0
[8530] UFS_UECT 0x0
[8540] UFS_UECDME 0x0
[8540] UFS_HCS 0x10f
[8540] -----------End--------------------------------
[8540] Error: UFS write failed writing to block: 157851648
[10850] fastboot: getvar:has-slot:boot
[10870] fastboot: getvar:max-download-size
[10890] fastboot: getvar:is-logical:boot
[10910] fastboot: getvar:is-logical:boot
[10930] fastboot: getvar:partition-size:boot
[10950] fastboot: download:00059010
[10990] fastboot: flash:boot
[10990] Data segment length: 14
[10990] SCSI Request failed and we have sense data
[10990] Sense Data Length/Response Code: 0x12/0x7000
[11000] Sense Key: 0x7
[11000] DATA PROTECT: Read/Write operation attempted on a block that is protected from this operation
[11010] Sense Buffer (HEX): 0x740ca79 0x440a0000 0x2700 0x0
[11010] ucs_do_scsi_cmd failed status = 2
[11020] ucs_do_scsi_write: failed
[11020] UFS write failed.
[11020] ------Host controller register dump ---------
[11030] UFS_UECPA 0x0
[11030] UFS_UECDL 0x0
[11030] UFS_UECN 0x0
[11030] UFS_UECT 0x0
[11040] UFS_UECDME 0x0
[11040] UFS_HCS 0x10f
[11040] -----------End--------------------------------
[11050] Error: UFS write failed writing to block: 158375936
[13440] fastboot: getvar:has-slot:system
[13460] fastboot: getvar:max-download-size
[13480] fastboot: getvar:is-logical:system
[13500] fastboot: getvar:is-logical:system
[13520] fastboot: getvar:partition-size:system
[13540] fastboot: download:00059010
[13580] fastboot: flash:system
[13580] Data segment length: 14
[13580] SCSI Request failed and we have sense data
[13580] Sense Data Length/Response Code: 0x12/0x7000
[13590] Sense Key: 0x7
[13590] DATA PROTECT: Read/Write operation attempted on a block that is protected from this operation
[13600] Sense Buffer (HEX): 0x740f04d 0xe30a0000 0x2700 0x0
[13610] ucs_do_scsi_cmd failed status = 2
[13610] ucs_do_scsi_write: failed
[13610] UFS write failed.
[13610] ------Host controller register dump ---------
[13620] UFS_UECPA 0x0
[13620] UFS_UECDL 0x0
[13620] UFS_UECN 0x0
[13620] UFS_UECT 0x0
[13630] UFS_UECDME 0x0
[13630] UFS_HCS 0x10f
[13630] -----------End--------------------------------
[13640] Error: UFS write failed writing to block: 224960512
[15680] fastboot: oem log
```