### PR TITLE
Add hltetmo (N900T) and kltetmo (G900T) variants

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -142,7 +142,7 @@
 - Motorola Moto X 2014 - victara
 - OnePlus One - bacon <!--(use `lk2nd-msm8974-appended-dtb.img`)-->
 - Samsung Galaxy Note 3 - SM-N9005, SM-N900T
-- Samsung Galaxy S5 - SM-G900F
+- Samsung Galaxy S5 - SM-G900F, SM-G900T
 - Samsung Galaxy S5 China LTE (Duos) - SM-G9006V/W, SM-G9008V/W, SM-G9009W
 - Sony Xperia Z3 - leo
 

--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -141,7 +141,7 @@
 - LG Google Nexus 5 - hammerhead D820, D821 (quirky - see comment in `lk2nd/device/dts/msm8974/msm8974-lge-hammerhead.dts`)
 - Motorola Moto X 2014 - victara
 - OnePlus One - bacon <!--(use `lk2nd-msm8974-appended-dtb.img`)-->
-- Samsung Galaxy Note 3 - SM-N9005
+- Samsung Galaxy Note 3 - SM-N9005, SM-N900T
 - Samsung Galaxy S5 - SM-G900F
 - Samsung Galaxy S5 China LTE (Duos) - SM-G9006V/W, SM-G9008V/W, SM-G9009W
 - Sony Xperia Z3 - leo

--- a/lk2nd/device/dts/msm8974/samsung.dts
+++ b/lk2nd/device/dts/msm8974/samsung.dts
@@ -131,4 +131,20 @@
 			};
 		};
 	};
+
+	kltetmo {
+		model = "Samsung Galaxy S5 (SM-G900T)";
+		compatible = "samsung,klte";
+		lk2nd,match-bootloader = "G900T*";
+
+		lk2nd,dtb-files = "msm8974pro-samsung-klte";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			home {
+				lk2nd,code = <KEY_HOME>;
+				gpios = <&pmic 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
 };

--- a/lk2nd/device/dts/msm8974/samsung.dts
+++ b/lk2nd/device/dts/msm8974/samsung.dts
@@ -38,6 +38,32 @@
 		};
 	};
 
+	hltetmo {
+		model = "Samsung Galaxy Note 3 (SM-N900T)";
+		compatible = "samsung,hlte";
+		qcom,msm-id = <0x7E01FF01 7 0>;
+		lk2nd,match-bootloader = "N900T*";
+
+		lk2nd,dtb-files = "msm8974-samsung-hlte";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			home {
+				lk2nd,code = <KEY_HOME>;
+				gpios = <&pmic 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&pmic 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+
+			up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&pmic 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
+
 	/* rev 10 */
 
 	kltechn-unicom {


### PR DESCRIPTION
These are the T-Mobile US variants of the Samsung Galaxy Note 3 and Samsung Galaxy S5.  They are functionally identical from what I can tell except have the T suffix on the bootloader name.  Tested on both, though I haven't gotten hlte to actually boot anything but I think it's related to a postmarketOS build issue (boot.img too large).  I was able to get klte to boot postmarketOS following the wiki guide.

![IMG_20250403_003320](https://github.com/user-attachments/assets/fd8f81d3-c013-4f68-861f-2fb5d07fed29)
