### PR TITLE
Add Samsung Galaxy J5 2016 U+ (SM-J510L)

### DIFF
--- a/lk2nd/device/dts/msm8916/msm8916-samsung.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-samsung.dts
@@ -561,6 +561,24 @@
 			i2c-scl-gpios = <&tlmm 106 I2C_GPIO_FLAGS>;
 		};
 	};
+	
+	j5xltekl {
+		model = "Samsung Galaxy J5 2016 (SM-J510L)";
+		compatible = "samsung,j5xnlte", "samsung,j5x";
+		lk2nd,match-bootloader = "J510L*";
+
+		lk2nd,dtb-files = "msm8916-samsung-j5x";
+
+		qcom,msm-id = <QCOM_ID_MSM8916 0>;
+		qcom,board-id = <0xCE08FF01 4>;
+
+		muic-reset {
+			compatible = "samsung,muic-reset";
+			i2c-reg = <0x25>;
+			i2c-sda-gpios = <&tlmm 105 I2C_GPIO_FLAGS>;
+			i2c-scl-gpios = <&tlmm 106 I2C_GPIO_FLAGS>;
+		};
+	};
 
 	grandmaxlteub {
 		model = "Samsung Galaxy Grand Max (SM-G720AX)";


### PR DESCRIPTION
SM-J510L is a S. Korean U+ carrier variant of SM-J510x. AFAICT no additional tweaks are needed other than just adding it as a supported device in the DTS.

There are other variants such as J510S/K (for different carriers) but this is the only hardware I have and thus have tested on.
![2025-04-11-18-02-46-300](https://github.com/user-attachments/assets/023fdbc5-e1d7-4ae1-bd1c-795876a1c63d)
