### PR TITLE
Add touch selection for Redmi Note 5A/5A Prime

### DIFF
--- a/lk2nd/device/dts/msm8952/msm8917-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-mtp.dts
@@ -75,12 +75,15 @@
 
 			qcom,mdss_dsi_tm_otm1901a_720p_video {
 				compatible = "xiaomi,ugglite-otm1901a-tm";
+				touchscreen-compatible = "goodix,gt911";
 			};
 			qcom,mdss_dsi_sc_ili9881c_720p_video {
 				compatible = "xiaomi,ugglite-ili9881c-sc";
+				touchscreen-compatible = "edt,edt-ft5406";
 			};
 			qcom,mdss_dsi_hx_otm1901a_720p_video {
 				compatible = "xiaomi,ugglite-otm1901a-hx";
+				touchscreen-compatible = "goodix,gt911";
 			};
 		};
 	};

--- a/lk2nd/device/dts/msm8952/msm8940-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8940-mtp.dts
@@ -23,12 +23,15 @@
 
 			qcom,mdss_dsi_tm_otm1901a_720p_video {
 				compatible = "xiaomi,ugglite-otm1901a-tm";
+				touchscreen-compatible = "goodix,gt911";
 			};
 			qcom,mdss_dsi_sc_ili9881c_720p_video {
 				compatible = "xiaomi,ugglite-ili9881c-sc";
+				touchscreen-compatible = "edt,edt-ft5406";
 			};
 			qcom,mdss_dsi_hx_otm1901a_720p_video {
 				compatible = "xiaomi,ugglite-otm1901a-hx";
+				touchscreen-compatible = "goodix,gt911";
 			};
 		};
 	};


### PR DESCRIPTION
Redmi Note 5A and 5A Prime's touch controllers are bind to the panels.