### PR TITLE
Add support for Lenovo Tab 10 (TB-X103F)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -69,6 +69,7 @@
 - Haier G151 / Andromax A (quirky - see comment in `lk2nd/device/dts/msm8909/msm8909-1gb-qrd-skuc.dts`)
 - Lenovo Yoga Tab 3 10 LTE
 - Lenovo Yoga Tab 3 10 WIFI
+- Lenovo Tab 10 (TB-X103F)
 - Mobvoi TicWatch Pro (WF12096)
 - Nokia 6300 4G
 - Nokia 8000 4G

--- a/lk2nd/device/dts/msm8909/apq8009-lenovo-tb-x103f.dts
+++ b/lk2nd/device/dts/msm8909/apq8009-lenovo-tb-x103f.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+#include <skeleton32.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id   = <QCOM_ID_APQ8009 0x00020000>;
+	qcom,board-id = <0x0801000b 8>;
+};
+
+&lk2nd {
+	model = "Lenovo Tab 10 (TB-X103F)";
+	compatible = "lenovo,tb-x103f", "qcom,msm8909", "lk2nd,device";
+
+	lk2nd,dtb-files = "msm8909-lenovo-tb-x103f";
+	lk2nd,match-panel;
+
+	panel {
+		compatible = "lenovo,tb-x103f-panel", "lk2nd,panel";
+
+		qcom,mdss_dsi_nt35521s_xingyuan_wxga_video {
+			compatible = "lenovo,nt35521s-xingyuan";
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		volume-up {
+			lk2nd,code = <KEY_VOLUMEUP>;
+			gpios = <&tlmm 90 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8909/apq8009-lenovo-tb-x103f.dts
+++ b/lk2nd/device/dts/msm8909/apq8009-lenovo-tb-x103f.dts
@@ -11,7 +11,7 @@
 
 &lk2nd {
 	model = "Lenovo Tab 10 (TB-X103F)";
-	compatible = "lenovo,tb-x103f", "qcom,msm8909", "lk2nd,device";
+	compatible = "lenovo,tb-x103f";
 
 	lk2nd,dtb-files = "msm8909-lenovo-tb-x103f";
 	lk2nd,match-panel;

--- a/lk2nd/device/dts/msm8909/rules.mk
+++ b/lk2nd/device/dts/msm8909/rules.mk
@@ -4,6 +4,7 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 
 QCDTBS += \
 	$(LOCAL_DIR)/apq8009-qrd-skue.dtb \
+	$(LOCAL_DIR)/apq8009-lenovo-tb-x103f.dtb \
 	$(LOCAL_DIR)/msm8905-qrd-skub.dtb \
 	$(LOCAL_DIR)/msm8909-1gb-qrd-skuc.dtb \
 	$(LOCAL_DIR)/msm8909-mtp.dtb \


### PR DESCRIPTION
Basic boot testing only.


- Screen working
- Buttons working


![PXL_20250430_082133106 MP-min](https://github.com/user-attachments/assets/4090010a-10c0-42c9-a2f6-7f7a75c1863b)
