### PR TITLE
dts: msm8952: Add Alcatel Idol 4 (idol4)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -77,6 +77,7 @@
 
 ### lk2nd-msm8952
 
+- Alcatel Idol 4 (6055*)
 - BQ X5 Plus (Longcheer L9360)
 - HMD Global Nokia 5 (nd1)
 - HMD Global Nokia 6 (ple)

--- a/lk2nd/device/dts/msm8952/msm8952-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8952-mtp.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8952 0>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0>;
+};
+
+&lk2nd {
+	idol4 {
+		model = "Alcatel Idol 4";
+		compatible = "alcatel,idol4";
+		lk2nd,match-panel;
+
+		lk2nd,dtb-files = "msm8952-alcatel-idol4";
+
+		panel {
+			compatible = "alcatel,idol4-panel", "lk2nd,panel";
+
+			qcom,mdss_dsi_nt35596_1080p_video {
+				compatible = "alcatel,idol4-nt35596";
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -16,6 +16,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8940-mtp.dtb \
 	$(LOCAL_DIR)/msm8940-oppo-a57.dtb \
 	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb \
+	$(LOCAL_DIR)/msm8952-mtp.dtb \
 	$(LOCAL_DIR)/msm8956-mtp.dtb \
 	$(LOCAL_DIR)/msm8956-xiaomi-hydrogen.dtb \
 	$(LOCAL_DIR)/msm8976-qrd.dtb \


### PR DESCRIPTION
Add support for msm8952 based alcatel-idol4.

Looking at some downstream, there seem to be only one panel variant.
There are 2 touchpanels declared tho, but it will take a while until that's usable, so...