### PR TITLE
msm8909-1gb-qrd-skue: rename and clean up

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -67,8 +67,7 @@
 - CAT B35
 - FarEasTone Smart 506 (quirky - see comment in `lk2nd/device/dts/msm8909/msm8909-1gb-qrd-skuc.dts`)
 - Haier G151 / Andromax A (quirky - see comment in `lk2nd/device/dts/msm8909/msm8909-1gb-qrd-skuc.dts`)
-- Lenovo Yoga Tab 3 10 LTE
-- Lenovo Yoga Tab 3 10 WIFI
+- Lenovo Yoga Tab 3 10 LTE / WIFI
 - Lenovo Tab 10 (TB-X103F)
 - Mobvoi TicWatch Pro (WF12096)
 - Nokia 6300 4G

--- a/lk2nd/device/dts/msm8909/apq8009-1gb-qrd-skue.dts
+++ b/lk2nd/device/dts/msm8909/apq8009-1gb-qrd-skue.dts
@@ -4,14 +4,14 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <QCOM_ID_MSM8909 0>;
-	qcom,board-id = <QCOM_BOARD_ID_QRD 0x09>,
-			<QCOM_BOARD_ID(QRD, 1, 0) 0x09>;
+	qcom,msm-id = <QCOM_ID_APQ8009 0>;
+	qcom,board-id = <QCOM_BOARD_ID_QRD 0x9>,
+			<QCOM_BOARD_ID(QRD, 1, 0) 0x9>;
 };
 
 &lk2nd {
-	lxf_p5100 {
-		model = "Lenovo Yoga Tab 3 10 LTE";
+	lxf-p5100 {
+		model = "Lenovo Yoga Tab 3 10 WIFI";
 		compatible = "lenovo,lxf-p5100";
 		
 		lk2nd,dtb-files = "msm8909-lenovo-lxf-p5100";

--- a/lk2nd/device/dts/msm8909/msm8909-1gb-qrd-skue.dts
+++ b/lk2nd/device/dts/msm8909/msm8909-1gb-qrd-skue.dts
@@ -4,14 +4,14 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <QCOM_ID_APQ8009 0>;
-	qcom,board-id = <QCOM_BOARD_ID_QRD 0x09>,
-			<QCOM_BOARD_ID(QRD, 1, 0) 0x09>;
+	qcom,msm-id = <QCOM_ID_MSM8909 0>;
+	qcom,board-id = <QCOM_BOARD_ID_QRD 0x9>,
+			<QCOM_BOARD_ID(QRD, 1, 0) 0x9>;
 };
 
 &lk2nd {
-	lxf_p5100 {
-		model = "Lenovo Yoga Tab 3 10 WIFI";
+	lxf-p5100 {
+		model = "Lenovo Yoga Tab 3 10 LTE";
 		compatible = "lenovo,lxf-p5100";
 		
 		lk2nd,dtb-files = "msm8909-lenovo-lxf-p5100";

--- a/lk2nd/device/dts/msm8909/rules.mk
+++ b/lk2nd/device/dts/msm8909/rules.mk
@@ -3,12 +3,12 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 
 
 QCDTBS += \
-	$(LOCAL_DIR)/apq8009-qrd-skue.dtb \
+	$(LOCAL_DIR)/apq8009-1gb-qrd-skue.dtb \
 	$(LOCAL_DIR)/apq8009-lenovo-tb-x103f.dtb \
 	$(LOCAL_DIR)/msm8905-qrd-skub.dtb \
 	$(LOCAL_DIR)/msm8909-1gb-qrd-skuc.dtb \
+	$(LOCAL_DIR)/msm8909-1gb-qrd-skue.dtb \
 	$(LOCAL_DIR)/msm8909-mtp.dtb \
-	$(LOCAL_DIR)/msm8909-qrd-skue.dtb \
 	$(LOCAL_DIR)/msm8909-zte-sapphire.dtb \
 
 ADTBS += \


### PR DESCRIPTION
Real apq8009-qrd-skue and msm8909-qrd-skue has property `qcom,board-id = <0x1000b 0x109>`.