### PR TITLE
lk2nd: dts: msm8916: Add EE Harrier Mini (harrier_mini)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -12,6 +12,7 @@
 - BQ Aquaris M5 - piccolo
 - BQ Aquaris X5 - paella, picmt
 - DragonBoard 410c - apq8016-sbc
+- EE Harrier Mini - harrier-mini
 - GPLUS FL8005A
 - HTC One M8s - m8qlul (quirky - see comment in `lk2nd/device/dts/msm8916/msm8939-htc-m8qlul.dts`)
 - Huawei Ascend G7 - G7-L01

--- a/lk2nd/device/dts/msm8916/msm8916-ee-harrier-mini.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-ee-harrier-mini.dts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8916 0>;
+	qcom,board-id = <0x21300000 1>;
+
+	/*
+	 * HACK: EE / BenQ's bootloader expects these nodes to exist in
+	 * the dtb as it tries to populate these nodes. Without the
+	 * nodes existing the bootloader will crash or invalidate the
+	 * FDT.
+	 */
+
+	customer {
+		boardadc = "4294967295";
+		boardid = "FFFFFFFF";
+		btmac = "000000000000";
+		device_sn = "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ";
+		do_fsck = "0";
+		emmc_wp_size = "4294967295";
+		imei = "ZZZZZZZZZZZZZZZ";
+		lcm_exist = "1";
+		meid = "ZZZZZZZZZZZZZZZ";
+		picasso = "ZZZZZZZZZZ";
+		wifibin = "0";
+		wlanmac = "000000000000";
+	};
+
+	soc: soc@0 {
+	};
+};
+
+&lk2nd {
+	model = "EE Harrier Mini";
+	compatible = "ee,harrier-mini";
+
+	lk2nd,dtb-files = "msm8916-ee-harrier-mini";
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		down {
+			lk2nd,code = <KEY_VOLUMEDOWN>;
+			gpios = <&tlmm 107 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+
+		up {
+			lk2nd,code = <KEY_VOLUMEUP>;
+			gpios = <&pmic_pon GPIO_PMIC_RESIN 0>;
+		};
+	};
+
+	panel {
+		compatible = "ee,harrier-mini-panel", "lk2nd,panel";
+
+		qcom,mdss_dsi_hx8394a_720p_video {
+			compatible = "ee,harrier-mini-hx8394a";
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8916/rules.mk
+++ b/lk2nd/device/dts/msm8916/rules.mk
@@ -12,6 +12,7 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8916-512mb-qrd-skuh.dtb \
 	$(LOCAL_DIR)/msm8916-asus-z00e.dtb \
 	$(LOCAL_DIR)/msm8916-asus-z00l.dtb \
+	$(LOCAL_DIR)/msm8916-ee-harrier-mini.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-g7-l01.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-hwt1a21l.dtb \
 	$(LOCAL_DIR)/msm8916-huawei-y635-l01.dtb \


### PR DESCRIPTION
Based on the msm8916 board.

Currently a draft as of right now as the volume keys are inverted and defining the correct GPIOs for them (that hasn't been pushed here for the following reason) seem to not work, the volume up key will work as expected but the rest stop responding.