### PR TITLE
dts: msm8960: add Casio G'zOne (CA-201L)

### DIFF
--- a/lk2nd/device/dts/msm8960/bundle.dts
+++ b/lk2nd/device/dts/msm8960/bundle.dts
@@ -116,4 +116,26 @@
 			};
 		};
 	};
+	casio-ca201l {
+		model = "Casio GzOne (CA-201L)";
+		compatible = "casio,ca201l";
+		lk2nd,match-cmdline = "* androidboot.err_folder_lock=true *";
+		lk2nd,dtb-files = "msm8960-casio-ca201l";
+		gpio-keys {
+			compatible = "gpio-keys";
+
+			volume-up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&pmic 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			volume-down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&pmic 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			home {
+				lk2nd,code = <KEY_HOME>;
+				gpios = <&pmic 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
 };


### PR DESCRIPTION
The device itself is quite old: https://wiki.postmarketos.org/wiki/Casio_G%27zOne_(casio-ca201l)

The cmdline set by the stock bootloader does not contain the device model/codename, so relying on the other parameter instead. Although the dts is not yet included in the mainline kernel, the filename will likely be as indicated here.

Caveats: the panel is mounted upside down, and seems like the color format is different from default. So display is incorrect at this moment, but bootloader functionality is tested. But keys are working as expected.