### PR TITLE
lk2nd: dts: msm8953: Add Billion Capture+ (rimob)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -112,6 +112,7 @@
 ### lk2nd-msm8953
 
 - Asus Zenfone 3 ZE520KL/ZE552KL (zenfone3)
+- Billion Capture+ (rimob)
 - Fairphone 3
 - Huawei Maimang 5 / Nova Plus / G9 (Plus) (milan)
 - Huawei Nova (cannes)

--- a/lk2nd/device/dts/msm8953/msm8953-billion-rimob.dts
+++ b/lk2nd/device/dts/msm8953/msm8953-billion-rimob.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+ 
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8953 0>;
+	qcom,board-id = <0x340008 0>;
+};
+
+&lk2nd {
+	model = "Billion Capture+";
+	compatible = "billion,rimob";
+
+	lk2nd,dtb-files = "msm8953-billion-rimob";
+};

--- a/lk2nd/device/dts/msm8953/rules.mk
+++ b/lk2nd/device/dts/msm8953/rules.mk
@@ -4,6 +4,7 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 ADTBS += \
 	$(LOCAL_DIR)/apq8053-lenovo-cd-18781y.dtb \
 	$(LOCAL_DIR)/msm8953-asus-zenfone3.dtb \
+	$(LOCAL_DIR)/msm8953-billion-rimob.dtb \
 	$(LOCAL_DIR)/msm8953-huawei-cannes.dtb  \
 	$(LOCAL_DIR)/msm8953-huawei-milan.dtb  \
 	$(LOCAL_DIR)/msm8953-lenovo-kuntao.dtb  \


### PR DESCRIPTION
Add support for msm8953 based billion-rimob.

Looking at downstream dts (no kernel sources, extracted dtb from running system), there seem to be  a few panel variants. Though, they seem to be part of the reference board (so I've not added panel node).