### PR TITLE
dts: msm8952: add support for Mobvoi TicWatch Pro 3 LTE (rover)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -91,6 +91,7 @@
 - Leeco s2
 - Lenovo K5 Play (l38011)
 - Lenovo Tab M10 HD (TB-X505X)
+- Mobvoi TicWatch Pro 4 LTE (rover) (quirky - see comment in `lk2nd/device/dts/msm8952/sdm429w-mobvoi-rover.dts`)
 - Motorola Moto E5 (nora)
 - Motorola Moto E5 Plus (hannah) (MSM8917)
 - Motorola Moto E5 Plus (hannah) (MSM8937)

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -22,6 +22,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8976-qrd.dtb \
 	$(LOCAL_DIR)/sdm429-lenovo-tbx505x.dtb \
 	$(LOCAL_DIR)/sdm429w-fossil-hoki.dtb \
+	$(LOCAL_DIR)/sdm429w-mobvoi-rover.dtb \
 	$(LOCAL_DIR)/sdm439-xiaomi-pine.dtb \
 
 DTBS += \

--- a/lk2nd/device/dts/msm8952/sdm429w-mobvoi-rover.dts
+++ b/lk2nd/device/dts/msm8952/sdm429w-mobvoi-rover.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * This device is quirky.
+ * To run lk2nd on this device you need to flash custom dtbo.
+ * Read more https://wiki.postmarketos.org/wiki/Mobvoi_Ticwatch_Pro_3_LTE_(mobvoi-rover)#lk2nd
+ */
+/ {
+	qcom,msm-id = <QCOM_ID_SDM429W 0x00>;
+	qcom,board-id = <0x10b 0x08>;
+	/* Bootloader appears to really want to access symbols */
+	__symbols__ {};
+};
+
+&lk2nd {
+	model = "Mobvoi TicWatch Pro 3 LTE (rover)";
+	compatible = "mobvoi,rover";
+
+	lk2nd,dtb-files = "sdm429w-mobvoi-rover";
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		down {
+			lk2nd,code = <KEY_VOLUMEDOWN>;
+			gpios = <&tlmm 48 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+
+		power {
+			lk2nd,code = <KEY_POWER>;
+			gpios = <&pmic_pon GPIO_PMIC_PWRKEY 0>;
+		};
+	};
+};


### PR DESCRIPTION
![2025-07-01-23-03-56](https://github.com/user-attachments/assets/57827ea1-5dc0-4183-a791-d3da7296139e)