### PR TITLE
Add menu option to skip lk2nd_boot

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -4680,6 +4680,27 @@ void cmd_continue(const char *arg, void *data, unsigned sz)
 	}
 }
 
+#if WITH_LK2ND_BOOT
+void cmd_continue_skip_lk2ndboot(const char *arg, void *data, unsigned sz)
+{
+	fastboot_okay("");
+	fastboot_stop();
+
+	if (target_is_emmc_boot())
+	{
+#if FBCON_DISPLAY_MSG
+		/* Exit keys' detection thread firstly */
+		exit_menu_keys_detection();
+#endif
+		boot_linux_from_mmc();
+	}
+	else
+	{
+		boot_linux_from_flash();
+	}
+}
+#endif
+
 void cmd_reboot(const char *arg, void *data, unsigned sz)
 {
 	dprintf(INFO, "rebooting the device\n");

--- a/lk2nd/device/menu/menu.c
+++ b/lk2nd/device/menu/menu.c
@@ -20,6 +20,9 @@
 
 // Defined in app/aboot/aboot.c
 extern void cmd_continue(const char *arg, void *data, unsigned sz);
+#if WITH_LK2ND_BOOT
+extern void cmd_continue_skip_lk2ndboot(const char *arg, void *data, unsigned sz);
+#endif
 
 #define FONT_WIDTH	(5+1)
 #define FONT_HEIGHT	12
@@ -122,6 +125,9 @@ static uint16_t wait_key(void)
 #define str(s) #s
 
 static void opt_continue(void)   { cmd_continue(NULL, NULL, 0); }
+#ifdef WITH_LK2ND_BOOT
+static void opt_continue_skip_lk2nd(void) { cmd_continue_skip_lk2ndboot(NULL, NULL, 0); }
+#endif
 static void opt_reboot(void)     { reboot_device(0); }
 static void opt_recovery(void)
 {
@@ -141,6 +147,9 @@ static struct {
 } menu_options[] = {
 	{ "  Reboot  ", GREEN,  opt_reboot },
 	{ " Continue ", WHITE,  opt_continue },
+#ifdef WITH_LK2ND_BOOT
+	{ "Skip lk2nd", WHITE,  opt_continue_skip_lk2nd },
+#endif
 	{ " Recovery ", ORANGE, opt_recovery },
 	{ "Bootloader", ORANGE, opt_bootloader },
 	{ "    EDL   ", RED,    opt_edl },


### PR DESCRIPTION
This can be useful when dual-booting Android on the internal storage and postmarketOS on an SD card without physically removing it or using fastboot boot with the flashed Android boot image. This can be useful considering Android is required to charge the battery (safely) for some devices.