### PR TITLE
Add support for Galaxy S5 Active (SM-G870x)

### DIFF
--- a/lk2nd/device/dts/msm8974/samsung.dts
+++ b/lk2nd/device/dts/msm8974/samsung.dts
@@ -5,6 +5,7 @@
 
 / {
 	qcom,msm-id = <0x7E01FF01 7 0>,
+		      <0xC208FF01 1 0x10000>,
 		      <0xC208FF01 10 0x10000>,
 		      <0xC208FF01 14 0x10000>;
 };
@@ -147,4 +148,29 @@
 			};
 		};
 	};
+
+	/* rev 01 */
+
+	kltecanactive {
+    model = "Samsung Galaxy S5 Active (SM-G870x)";
+    compatible = "samsung,klteactivexx", "samsung,klte";
+    lk2nd,match-bootloader = "G870*";
+    lk2nd,dtb-files = "msm8974pro-samsung-klte";
+
+    gpio-keys {
+        compatible = "gpio-keys";
+        home {
+            lk2nd,code = <KEY_HOME>;
+            gpios = <&pmic 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+        };
+        down {
+            lk2nd,code = <KEY_VOLUMEDOWN>;
+            gpios = <&pmic 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+        };
+        up {
+            lk2nd,code = <KEY_VOLUMEUP>;
+            gpios = <&pmic 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+        };
+    };
+};
 };


### PR DESCRIPTION
https://github.com/msm8916-mainline/lk2nd/pull/55#issuecomment-1096577439

Hello,
Thanks to this comment I was able to get lk2nd working on my Canadian Galaxy S5 Active (SM-G870W).
I guess it should work on other variants of the S5 Active but I have no way of testing.

SoC revision of my particular unit was `1` so adding this to `qcom,msm-id` got it working.

This is literally my first time forking/pulling anything on GitHub and I am also not a programmer so please let me know if I did anything wrong or if you need more info :)

![IMG_20250810_142056](https://github.com/user-attachments/assets/6385fe71-86f0-45b6-a0fa-f140ece56492)
