### PR TITLE
dts: msm8610: add support for Huawei C8816

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -195,6 +195,10 @@
 - Samsung Galaxy S4 Mini (GT-I9195)
 - Sony Xperia SP (huashan) (quirky - see comment in `lk2nd/device/dts/msm8960/bundle.dts`)
 
+### lk2nd-msm8610
+
+- Huawei C8816
+
 ## Porting new devices
 
 If you are considering adding support for a new device, you would need to add a

--- a/lk2nd/device/dts/msm8610/msm8612-huawei-c8816.dts
+++ b/lk2nd/device/dts/msm8610/msm8612-huawei-c8816.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,board-id = <8016 4>;
+	qcom,msm-id = <QCOM_ID_MSM8612 0x10001>;
+};
+
+&lk2nd {
+	model = "Huawei C8816";
+	compatible = "huawei,c8816", "lk2nd,device";
+
+	qcom,board-id = <8016 4>;
+	qcom,msm-id = <QCOM_ID_MSM8612 0x10001>;
+
+	lk2nd,dtb-files = "msm8612-huawei-c8816";
+	lk2nd,match-panel;
+
+	panel {
+		compatible = "huawei,c8816-panel", "lk2nd,panel";
+
+		qcom,mdss_dsi_emulator_qhd_video{
+			compatible = "huawei,emulator-lcd";
+		};
+
+		qcom,mdss_dsi_boe_nt35517_5_qhd_video{
+			compatible = "huawei,boe-nt35517";
+		};
+
+		qcom,mdss_dsi_tianma_otm9605a_5_qhd_video{
+			compatible = "huawei,tianma-otm9605a";
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8610/rules.mk
+++ b/lk2nd/device/dts/msm8610/rules.mk
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+ADTBS =
+QCDTBS +=  \
+	$(LOCAL_DIR)/msm8612-huawei-c8816.dtb
+

--- a/target/msm8610/init.c
+++ b/target/msm8610/init.c
@@ -84,6 +84,7 @@ enum target_subtype {
 	HW_PLATFORM_SUBTYPE_SKUAA = 1,
 	HW_PLATFORM_SUBTYPE_SKUF = 2,
 	HW_PLATFORM_SUBTYPE_SKUAB = 3,
+	HW_PLATFORM_SUBTYPE_NO4 = 4,
 };
 
 static void set_sdc_power_ctrl(void);
@@ -314,6 +315,8 @@ void target_baseband_detect(struct board_data *board)
 	case HW_PLATFORM_SUBTYPE_SKUF:
 		break;
 	case HW_PLATFORM_SUBTYPE_SKUAB:
+		break;
+	case HW_PLATFORM_SUBTYPE_NO4:
 		break;
 	default:
 		dprintf(CRITICAL, "Platform Subtype : %u is not supported\n", platform_subtype);


### PR DESCRIPTION
### Summary
1. Make dts folder for msm8610, firstly the dts of Huawei C8816
2. Add enum const 'HW_PLATFORM_SUBTYPE_NO4 = 4' for 'qcom,board-id = <8016 4>'.
### Reason
Without it, target_baseband_detect() mismatches board-subid and hits ASSERT(), causing panic / EDL:
```c
Format: Log Type - Time(microsec) - Message
Log type: B - since boot(excluding boot rom).  D - delta
B -    500627 - Error code 302a at boot_error_handler.c Line 456
BL_ERR_DATA_ABORT
```
### Result
Tested OK on all panels!
