### PR TITLE
Add SM-G360V (coreprimeltevzw) support

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -37,7 +37,7 @@
 - Samsung Galaxy A7 (2015) - SM-A700YD
 - Samsung Galaxy Ace 4 - SM-G357FZ (quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-samsung.dts`)
 - Samsung Galaxy Core Max - SM-G5108Q (quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-samsung.dts`)
-- Samsung Galaxy Core Prime LTE - SM-G360F, SM-G360G, SM-G360T (rossaltezt is quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-samsung.dts`)
+- Samsung Galaxy Core Prime LTE - SM-G360F, SM-G360G, SM-G360T, SM-G360V (rossaltezt is quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-samsung.dts`)
 - Samsung Galaxy E5 - SM-E500F, SM-E500H
 - Samsung Galaxy E7 - SM-E7000, SM-E700F
 - Samsung Galaxy Grand Max - SM-G720AX

--- a/lk2nd/device/dts/msm8916/msm8916-samsung.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-samsung.dts
@@ -232,6 +232,33 @@
 
 	/* rev 2 */
 
+	coreprimeltevzw {
+		model = "Samsung Galaxy Core Prime LTE (SM-G360V)";
+		compatible = "samsung,coreprimeltevzw", "samsung,rossa";
+		lk2nd,match-bootloader = "G360V*";
+
+		lk2nd,dtb-files = "msm8916-samsung-rossa";
+
+		qcom,msm-id = <QCOM_ID_MSM8916 0>;
+		qcom,board-id = <0xCE08FF01 2>;
+
+		panel {
+			compatible = "samsung,cprime-panel", "lk2nd,panel";
+
+			ss_dsi_panel_HX8369B_BV045WVM_WVGA {
+				compatible = "samsung,hx8369b-bv045wvm";
+			};
+
+			ss_dsi_panel_SC7798A_BV045WVM_WVGA {
+				compatible = "samsung,sc7798a-bv045wvm";
+			};
+
+			ss_dsi_panel_SC7798D_BV045WVM_WVGA {
+				compatible = "samsung,sc7798d-bv045wvm";
+			};
+		};
+	};
+
 	gprimeltecan {
 		model = "Samsung Galaxy Grand Prime (SM-G530W)";
 		compatible = "samsung,gprimeltecan";


### PR DESCRIPTION
This adds support for the Verizon Wireless variant of the Samsung Galaxy Core Prime LTE (which can run unsigned images through [an exploit](https://code.chipmunk.land/chipmunkmc/rossa-vzw-tethered-exploit)).