### PR TITLE
Add support for setting OS version and patch level and add new Palm Phone device

### DIFF
--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -104,3 +104,11 @@ from the AOSP 13 source tree located in `lk2nd/certs/` are used to sign the
 image.
 `BOOTIMG_CERT` is expected to be in X.509 PEM format and `BOOTIMG_KEY` is
 expected to be in PKCS#8 format.
+
+### OS Version and OS Patch Level in lk2nd.img
+
+#### `MKBOOTIMG_OS_VERSION=` AND `MKBOOTIMG_OS_PATCH_LEVEL=` - Set `lk2nd.img` OS version and patch level
+
+Set the OS version and patch level to specific values, as some bootloaders
+may check this. `MKBOOTIMG_OS_VERSION` is in format x.y.z and
+`MKBOOTIMG_OS_PATCH_LEVEL` is in format YYYY-MM-DD

--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -100,6 +100,7 @@
 - Motorola Moto G5S (montana)
 - Motorola Moto G6 Play (jeter)
 - OPPO A57 (A57) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8940-oppo-a57.dts`)
+- Palm Phone (pepito) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8940-palm-pepito.dts`)
 - Redmi 3S (land)
 - Redmi 4 (prada)
 - Redmi 4A (rolex)

--- a/lk2nd/device/2nd/rules.mk
+++ b/lk2nd/device/2nd/rules.mk
@@ -66,6 +66,8 @@ $(OUTBOOTIMG): $(OUTBINDTB) $(OUTQCDT) $(RAMDISK)
 		$(if $(OUTQCDT),--qcdt=$(OUTQCDT)) \
 		$(if $(MKBOOTIMG_BASE),--base=$(MKBOOTIMG_BASE)) \
 		$(if $(MKBOOTIMG_PAGESIZE),--pagesize=$(MKBOOTIMG_PAGESIZE)) \
+		$(if $(MKBOOTIMG_OS_VERSION),--os_version=$(MKBOOTIMG_OS_VERSION)) \
+		$(if $(MKBOOTIMG_OS_PATCH_LEVEL),--os_patch_level=$(MKBOOTIMG_OS_PATCH_LEVEL)) \
 		--ramdisk=$(RAMDISK) \
 		$(MKBOOTIMG_ARGS)
 

--- a/lk2nd/device/dts/msm8952/msm8940-palm-pepito.dts
+++ b/lk2nd/device/dts/msm8952/msm8940-palm-pepito.dts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * There are a few quirks to be aware of
+ *
+ * - Fastboot is not available on this device, lk2nd must be flashed via EDL.
+ *   Some EDL programs (or versions thereof) do not work properly with available
+ *   firehoses (or else need responses ignored).  QDL is a known working implementation
+ *
+ * - The stock bootloader checks the OS version and the OS patch level in the boot.img as
+ *   well as ensuring there is a signature in the boot.img (it does not matter the signature).
+ *   When compiling lk2nd, set MKBOOTIMG_OS_VERSION=8.1.0 MKBOOTIMG_OS_PATCH_LEVEL=2020-09-01
+ *   and SIGN_BOOTIMG=1
+ */
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8940 0>;
+	qcom,board-id = <0xaa000008 0x00>;
+};
+
+&lk2nd {
+	model = "Palm Phone (pepito)";
+	compatible = "palm,pepito";
+
+	lk2nd,dtb-files = "qcom,msm8940-mtp", "qcom,msm8940", "qcom,mtp";
+
+	lk2nd,single-key-navigation;
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -15,6 +15,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8937-xiaomi-land.dtb \
 	$(LOCAL_DIR)/msm8940-mtp.dtb \
 	$(LOCAL_DIR)/msm8940-oppo-a57.dtb \
+	$(LOCAL_DIR)/msm8940-palm-pepito.dtb \
 	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb \
 	$(LOCAL_DIR)/msm8952-mtp.dtb \
 	$(LOCAL_DIR)/msm8956-mtp.dtb \


### PR DESCRIPTION
The Palm phone bootloader has a few quirks, so need to add some code to set the OS version and patch level in the generated lk2nd image.  Then add support for the device itself.  It only has a single power button, so use the short/long press control for it.