### PR TITLE
dts: msm8909: Add support for  Andromax A (A16C3H)

### DIFF
--- a/lk2nd/device/dts/msm8909/msm8909-andromax-a16c3h.dts
+++ b/lk2nd/device/dts/msm8909/msm8909-andromax-a16c3h.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+ 
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <206 0>;
+	qcom,board-id = <0x1000b 0x8>, <0x11000b 0x8>, <0x21000b 0x8>;
+};
+
+&lk2nd {
+	model = "Andromax A"; // FIXME
+	compatible = "andromax,a16c3h"; // FIXME
+
+  lk2nd,dtb-files = "msm8916-andromax-a16c3h";
+
+};


### PR DESCRIPTION
Adding Andromax A (A16C3H) To lk2nd