### PR TITLE
app: aboot: Fix building unit test with msm8996

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -1487,7 +1487,9 @@ static void verify_signed_bootimg(uint32_t bootimg_addr, uint32_t bootimg_size)
 #if !VERIFIED_BOOT
 	if(device.is_tampered)
 	{
+	#if !ABOOT_STANDALONE
 		write_device_info_mmc(&device);
+	#endif
 	#ifdef TZ_TAMPER_FUSE
 		set_tamper_fuse_cmd(HLOS_IMG_TAMPER_FUSE);
 	#endif

--- a/app/aboot/fastboot_test.c
+++ b/app/aboot/fastboot_test.c
@@ -46,7 +46,7 @@ extern void ramdump_table_map(void);
 extern void kauth_test(void);
 extern int ufs_get_boot_lun(void);
 extern int ufs_set_boot_lun(uint32_t bootlunid);
-extern int fastboot_init(void);
+extern int fastboot_init(void *xfer_buffer, unsigned max);
 static bool enable_test_mode = false;
 
 bool is_test_mode_enabled(void)
@@ -54,7 +54,7 @@ bool is_test_mode_enabled(void)
 	return enable_test_mode;
 }
 
-void cmd_oem_runtests(void)
+void cmd_oem_runtests(const char *arg, void *data, unsigned sz)
 {
 	dprintf(INFO, "Running LK tests ... \n");
 	enable_test_mode = true;

--- a/app/aboot/fastboot_test.h
+++ b/app/aboot/fastboot_test.h
@@ -31,7 +31,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define __FASTBOOT_TEST_H__
 #include <sys/types.h>
 extern void ramdump_table_map(void);
-void cmd_oem_runtests(void);
+void cmd_oem_runtests(const char *arg, void *data, unsigned sz);
 
 #if UNITTEST_FW_SUPPORT
 bool is_test_mode_enabled(void);


### PR DESCRIPTION
This fixes building tests with the following command. make ENABLE_UNITTEST_FW=1 TOOLCHAIN_PREFIX=arm-none-eabi- lk2nd-msm8996

The changes are:
* Match cmd_oem_runtests() prototype with fastboot_cmd_desc structure.
* Match fastboot_init() prototype as declared in fastboot.h.
* Hide write_device_info_mmc() call with ABOOT_STANDALONE macro. That function definition was hidden in f0d012dc762c9284dc7bc7fea40c4f21c61ee3af