### PR TITLE
app: aboot: Add support for tests with msm8952

### DIFF
--- a/platform/msm8952/include/platform/gpio.h
+++ b/platform/msm8952/include/platform/gpio.h
@@ -62,6 +62,7 @@
 
 void gpio_config_uart_dm(uint8_t id);
 uint32_t gpio_status(uint32_t gpio);
+void gpio_set(uint32_t gpio, uint32_t dir);
 void gpio_set_dir(uint32_t gpio, uint32_t dir);
 void gpio_tlmm_config(uint32_t gpio,
 			uint8_t func,

--- a/project/msm8952.mk
+++ b/project/msm8952.mk
@@ -138,3 +138,8 @@ DEFINES += CHECK_BAT_VOLTAGE=1
 #Use PON register for reboot reason
 ENABLE_REBOOT_MODULE := 1
 DEFINES += USE_PON_REBOOT_REG=1
+
+# Enable unit test FW
+ifeq ($(ENABLE_UNITTEST_FW),1)
+DEFINES += UNITTEST_FW_SUPPORT=1
+endif


### PR DESCRIPTION
This commit is similar as 736c49638e1532eb6842cbdeba8ab2b90697a07d commit but with msm8952. The tests can be run with 'fastboot oem run-tests` command. It helps to check various functions after lk2nd is booted.

The changes are:
* Add gpio_set() declaration for spi_test.c file.
* Add a condition to enable UNITTEST_FW_SUPPORT option with makefile.