### PR TITLE
dts: msm8952: Add support for Huawei Honor 7A Pro

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -88,7 +88,8 @@
 - HMD Global Nokia 4.2 (panther)
 - HMD Global Nokia 5 (nd1)
 - HMD Global Nokia 6 (ple)
-- Huawei Honor 7C (aum-l41) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-huawei-aum.dts`)
+- Huawei Honor 7A Pro (autumn-l29) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-huawei-autumn-l29.dts`)
+- Huawei Honor 7C (autumn-l41) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-huawei-autumn-l41.dts`)
 - Huawei MediaPad T3 10 (ags- l09/l03/w09) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8917-huawei-agassi.dts`)
 - Leeco s2
 - Lenovo K5 Play (l38011)

--- a/lk2nd/device/dts/msm8952/msm8937-huawei-autumn-l29.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-huawei-autumn-l29.dts
@@ -21,17 +21,17 @@
  */
 
 / {
-	qcom,msm-id = <QCOM_ID_MSM8937 0x8192>;
-	qcom,board-id = <8331 0>;
+	qcom,msm-id = <QCOM_ID_MSM8937 0x00>;
+	qcom,board-id = <8319 0>;
 };
 
 &lk2nd {
-	aum {
-		model = "Huawei Honor 7C (aum-l41)";
-		compatible = "huawei,aum";
+	autumn-l29 {
+		model = "Huawei Honor 7A Pro (autumn-l29)";
+		compatible = "huawei,autumn-l29";
 		lk2nd,match-panel;
 
-		lk2nd,dtb-files = "msm8937-huawei-aum";
+		lk2nd,dtb-files = "msm8937-huawei-autumn-l29";
 
 		gpio-keys {
 			compatible = "gpio-keys";
@@ -42,25 +42,25 @@
 		};
 
 		panel {
-			compatible = "huawei,aum-panel", "lk2nd,panel";
+			compatible = "huawei,autumn-l29-panel", "lk2nd,panel";
 
-			lcdkit_aum_l41_va_djn_cpt_ili9881c_5p7_hd_video {
-				compatible = "huawei,aum-ili9881c";
+			lcdkit_aum_l29_va_djn_cpt_ili9881c_5p7_hd_video {
+				compatible = "huawei,autumn-ili9881c";
 			};
-			lcdkit_aum_l41_va_djn_inx_ili9881c_5p7_hd_video {
-				compatible = "huawei,aum-ili9881c";
+			lcdkit_aum_l29_va_djn_inx_ili9881c_5p7_hd_video {
+				compatible = "huawei,autumn-ili9881c";
 			};
-			lcdkit_aum_l41_va_ofilm_inx_ili9881c_5p7_hd_video {
-				compatible = "huawei,aum-ili9881c";
+			lcdkit_aum_l29_va_ofilm_inx_ili9881c_5p7_hd_video {
+				compatible = "huawei,autumn-ili9881c";
 			};
-			lcdkit_aum_l41_va_tcl_csot_ft8613_5p7_hd_video {
-				compatible = "huawei,aum-ft8613";
+			lcdkit_aum_l29_va_tcl_csot_ft8613_5p7_hd_video {
+				compatible = "huawei,autumn-ft8613";
 			};
-			lcdkit_aum_l41_va_txd_hsd_hx8394f_5p7_hd_video {
-				compatible = "huawei,aum-hx8394f";
+			lcdkit_aum_l29_va_txd_hsd_hx8394f_5p7_hd_video {
+				compatible = "huawei,autumn-hx8394f";
 			};
-			lcdkit_aum_l41_va_txd_inx_hx8394f_5p7_hd_video {
-				compatible = "huawei,aum-hx8394f";
+			lcdkit_aum_l29_va_txd_inx_hx8394f_5p7_hd_video {
+				compatible = "huawei,autumn-hx8394f";
 			};
 		};
 	};

--- a/lk2nd/device/dts/msm8952/msm8937-huawei-autumn-l41.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-huawei-autumn-l41.dts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * To flash lk2nd onto the device, you need to flash lk2nd as the
+ * kernel and flash an empty image in place of the ramdisk.
+ * To create an empty image use the following command:
+ * mkbootimg --kernel /dev/null --ramdisk /dev/null --base 0x80000000 --kernel_offset 0x00008000 --ramdisk_offset 0x02000000 --second_offset 0x00f00000 --tags_offset 0x00000100 --pagesize 2048 --header_version 0 -o ramdisk.img"
+ *
+ * As this device has no boot partition, you'll have to create
+ * one yourself.
+ * To create the partition follow these steps:
+ * ./parted /dev/block/mmcblk0
+ * unit kB
+ * resizepart 55 31209799kB
+ * mkpart boot ext2 31209799kB 100%
+ * quit
+ * dd if=/dev/block/mmcblk0p41 of=/dev/block/mmcblk0p56 bs=1 seek=446 count=64
+ */
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8937 0x00>;
+	qcom,board-id = <8331 0>;
+};
+
+&lk2nd {
+	autumn-l41 {
+		model = "Huawei Honor 7C (autumn-l41)";
+		compatible = "huawei,autumn-l41";
+		lk2nd,match-panel;
+
+		lk2nd,dtb-files = "msm8937-huawei-autumn-l41";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&tlmm 91 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+
+		panel {
+			compatible = "huawei,autumn-l41-panel", "lk2nd,panel";
+
+			lcdkit_aum_l41_va_djn_cpt_ili9881c_5p7_hd_video {
+				compatible = "huawei,autumn-ili9881c";
+			};
+			lcdkit_aum_l41_va_djn_inx_ili9881c_5p7_hd_video {
+				compatible = "huawei,autumn-ili9881c";
+			};
+			lcdkit_aum_l41_va_ofilm_inx_ili9881c_5p7_hd_video {
+				compatible = "huawei,autumn-ili9881c";
+			};
+			lcdkit_aum_l41_va_tcl_csot_ft8613_5p7_hd_video {
+				compatible = "huawei,autumn-ft8613";
+			};
+			lcdkit_aum_l41_va_txd_hsd_hx8394f_5p7_hd_video {
+				compatible = "huawei,autumn-hx8394f";
+			};
+			lcdkit_aum_l41_va_txd_inx_hx8394f_5p7_hd_video {
+				compatible = "huawei,autumn-hx8394f";
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -7,7 +7,8 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8917-xiaomi-riva.dtb \
 	$(LOCAL_DIR)/msm8920-motorola-jeter.dtb \
 	$(LOCAL_DIR)/msm8920-mtp.dtb \
-	$(LOCAL_DIR)/msm8937-huawei-aum.dtb \
+	$(LOCAL_DIR)/msm8937-huawei-autumn-l29.dtb \
+	$(LOCAL_DIR)/msm8937-huawei-autumn-l41.dtb \
 	$(LOCAL_DIR)/msm8937-motorola-jeter.dtb \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \
 	$(LOCAL_DIR)/msm8937-nokia-nd1.dtb \


### PR DESCRIPTION
Add initial support for Huawei Honor 7A Pro (AUM-L29).
It is different from Huawei Honor 7C in panel names and in hardware (it doesn't have a second back camera). 