### PR TITLE
Add support for Oppo Realme 2 (RMX1805/RMX1809) and C1 (RMX1811)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -133,6 +133,7 @@
 - Motorola Moto G7 Power (ocean)
 - Motorola One (deen)
 - OPPO R9s/R9sk (R9s/R9sk) (quirky - see comments in `lk2nd/device/dts/msm8953/msm8953-oppo-r9s.dts`)
+- OPPO Realme 2 (RMX1805/RMX1809) / C1 (RMX1811)
 - Samsung Galaxy A6+
 - Samsung Galaxy J8 LTE
 - Samsung Tab A2 XL WIFI

--- a/lk2nd/device/dts/msm8953/rules.mk
+++ b/lk2nd/device/dts/msm8953/rules.mk
@@ -19,6 +19,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8953-xiaomi-oxygen.dtb \
 	$(LOCAL_DIR)/msm8953-xiaomi-vince.dtb \
 	$(LOCAL_DIR)/sdm450-motorola-ali.dtb \
+	$(LOCAL_DIR)/sdm450-mtp.dtb \
 	$(LOCAL_DIR)/sdm450-samsung-r04.dtb \
 	$(LOCAL_DIR)/sdm450-samsung-r05.dtb \
 	$(LOCAL_DIR)/sdm450-xiaomi-rosy.dtb \

--- a/lk2nd/device/dts/msm8953/sdm450-mtp.dts
+++ b/lk2nd/device/dts/msm8953/sdm450-mtp.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_SDM450 0>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0>;
+	/* Bootloader appears to really want to access symbols */
+	__symbols__ {};
+};
+
+&lk2nd {
+	rmx1805 {
+		model = "OPPO Realme 2/C1";
+		compatible = "oppo,rmx1805";
+		lk2nd,dtb-files="sdm450-oppo-rmx1805";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+
+			volume-down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&tlmm 85 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			volume-up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&pmic_pon GPIO_PMIC_RESIN 0>;
+			};
+		};
+
+	};
+};


### PR DESCRIPTION
<img width="720" height="1520" alt="screenshot" src="https://github.com/user-attachments/assets/f2b2c7fe-c1e5-471c-a609-117586ee43b4" />

- This device requires flashing the dtbo partition with the minimal dtbo.img (https://github.com/barni2000/dtbo-lk2nd/pull/5) for it to work.