### PR TITLE
device: add support for lt03lte

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -159,6 +159,7 @@
 - Motorola Moto X 2014 - victara
 - OnePlus One - bacon <!--(use `lk2nd-msm8974-appended-dtb.img`)-->
 - Samsung Galaxy Note 3 - SM-N9005, SM-N900T
+- Samsung Galaxy Note 10.1 2014 (LTE) - SM-P605 (lt03lte)
 - Samsung Galaxy S5 - SM-G900F, SM-G900T
 - Samsung Galaxy S5 China LTE (Duos) - SM-G9006V/W, SM-G9008V/W, SM-G9009W
 - Sony Xperia Z3 - leo

--- a/lk2nd/device/dts/msm8974/samsung.dts
+++ b/lk2nd/device/dts/msm8974/samsung.dts
@@ -64,6 +64,33 @@
 		};
 	};
 
+	lt03lte {
+		model = "Samsung Galaxy Note 10.1 2014 (LTE)";
+		compatible = "samsung,lt03lte";
+		qcom,msm-id = <0x7E01FF01 7 0>;
+		lk2nd,match-bootloader = "P605*";
+
+		lk2nd,dtb-files = "msm8974-samsung-lt03lte";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			home {
+				lk2nd,code = <KEY_HOME>;
+				gpios = <&pmic 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+
+			down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&pmic 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+
+			up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&pmic 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
+
 	/* rev 10 */
 
 	kltechn-unicom {


### PR DESCRIPTION
Adds support for the Samsung Galaxy Note 10.1 (2014 edition) LTE (SM-P605) with the MSM8974 SoC.

Things tested:
1. lk2nd boot works
2. lk2nd flashing newer lk2nd works
3. lk2nd flashing LineageOS kernel works
4. lk2nd booting LineageOS kernel works
5. lk2nd boot to lk2nd using Volume Down works
6. lk2nd boot to lk2nd using Volume Down -> Continue option -> booting to LineageOS works

Note: the LineageOS kernel tested with is based on Linux 3.4