### PR TITLE
dts: msm8939: asus-z00t: add a fixed regulator for sdcard

### DIFF
--- a/lk2nd/device/dts/msm8916/msm8939-asus-z00t.dts
+++ b/lk2nd/device/dts/msm8916/msm8939-asus-z00t.dts
@@ -4,7 +4,7 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <QCOM_ID_MSM8939 0>, <QCOM_ID_MSM8939 30000>;
+	qcom,msm-id = <QCOM_ID_MSM8939 0x0>, <QCOM_ID_MSM8939 0x30000>;
 	qcom,board-id = <21 0>, <31 0>, <41 0>, <51 0>;
 };
 


### PR DESCRIPTION
Add an external fixed regulator for powering the SD card slot. This fixes an issue where lk2nd would fail to communicate with SD card slot because no suitable voltages are available:
```
[140] Error: Command timeout error
[140] Failure getting OCR response from MMC Card
[140] MMC card failed to respond, try for SD card
[150] Error: Command timeout error
[150] The response for CMD8 does not match the supplied value
[150] Failed to initialize SD card
[160] Failed detecting MMC/SDC @ slot2
[160] SD card MMC is unavailable.
```
This would make booting the kernel from an SD card impossible.