### PR TITLE
dts: msm8952: Add Motorola Moto G5 (cedric) panel support

### DIFF
--- a/lk2nd/device/dts/msm8952/msm8937-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-mtp.dts
@@ -15,6 +15,18 @@
 		lk2nd,match-device = "cedric";
 
 		lk2nd,dtb-files = "msm8937-motorola-cedric";
+		
+		panel {
+			compatible = "motorola,cedric-panel", "lk2nd,panel";
+			
+			qcom,mdss_dsi_mot_tianma_497_1080p_video_v0 {
+				compatible = "motorola,cedric-nt35596-tianma";
+			};
+			
+			qcom,mdss_dsi_mot_inx_497_1080p_video_v0 {
+				compatible = "motorola,cedric-nt35596-inx";
+			};
+		};
 	};
 
 	hannah {


### PR DESCRIPTION
Added tianma panel support only as it's the one I could test.