### PR TITLE
Disable UZ801 gpio-keys to avoid keymap conflicts

### DIFF
--- a/lk2nd/device/dts/msm8916/msm8916-512mb-mtp.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-512mb-mtp.dts
@@ -88,6 +88,8 @@
 
 		lk2nd,dtb-files = "msm8916-yiming-uz801v3";
 
+		// commenting out to prevent keymap override
+		/*
 		gpio-keys {
 			compatible = "gpio-keys";
 			reset {
@@ -95,6 +97,7 @@
 				gpios = <&tlmm 23 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			};
 		};
+		*/
 	};
 
 	xiaoxun-jz0145-v33 {

--- a/lk2nd/device/dts/msm8916/msm8916-512mb-mtp.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-512mb-mtp.dts
@@ -87,17 +87,6 @@
 		lk2nd,match-cmdline = "* mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_jdi_1080p_video";
 
 		lk2nd,dtb-files = "msm8916-yiming-uz801v3";
-
-		// commenting out to prevent keymap override
-		/*
-		gpio-keys {
-			compatible = "gpio-keys";
-			reset {
-				lk2nd,code = <KEY_HOME>;
-				gpios = <&tlmm 23 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-			};
-		};
-		*/
 	};
 
 	xiaoxun-jz0145-v33 {


### PR DESCRIPTION
UZ801 has only one hardware button. the [dts defines one as home button](https://github.com/msm8916-mainline/lk2nd/blob/main/lk2nd/device/dts/msm8916/msm8916-512mb-mtp.dts#L30), but i'm not sure that is the physical one. the hardware button is only used when booting to EDL, and it is covered under plastic cover. 
but as it is defined in dts, `aboot.c` classifies the device has usable one that is triggered. so the device boot into bootloader instead of system, every time powers up.
i can confirm by flashing compressed pmOS `boot.img` to system and boot partition. note that i had to recompress the ramdisk to fit into tiny boot partition. also note that i flashed into both partition to ensure boot priority is not the issue.
UART log is here.
```
[0] welcome to lk

[10] platform_init()
[10] target_init()
[40] MMC card: 004GE0 (0.1, 01 2005), manufacturer: 11, OEM: 100, capacity: 3959422976 bytes
[40] SDHC Running in HS200 mode
[50] Done initialization of the card
[50] pm8x41_get_is_cold_boot: cold boot
[60] lk2nd_init()
[60] Detected device: uz801 v3.0 4G Modem Stick (compatible: yiming,uz801-v3)
[60] Unexpected DTB selected by bootloader, need to override
[70] keys: 1 keymap overrides applied
[90] fastboot_init()
[190] USB init ept @ 0x8f684000
[210] udc_start()
[310] -- reset --
[310] -- portchange --
[430] -- reset --
[430] -- portchange --
[550] fastboot: processing commands
[27220] fastboot: oem log
```
you see `[70] keys: 1 keymap overrides applied`.
i can boot into system by executing `fastboot continue` in USB Host computer. meaning boot sequence is fine.
after building and flashing my fork, i can boot into system without host computer.