### PR TITLE
platform: msm8960: increase kernel memory size to 128 MB

### DIFF
--- a/platform/msm8960/platform.c
+++ b/platform/msm8960/platform.c
@@ -76,7 +76,7 @@ static uint32_t ticks_per_sec = 0;
 mmu_section_t mmu_section_table[] = {
 /*  Physical addr,    Virtual addr,    Size (in MB),    Flags */
 	{MEMBASE, MEMBASE, (MEMSIZE / MB), LK_MEMORY},
-	{BASE_ADDR, BASE_ADDR, 44, KERNEL_MEMORY},
+	{BASE_ADDR, BASE_ADDR, 128, KERNEL_MEMORY},
 	{SCRATCH_ADDR, SCRATCH_ADDR, 768, SCRATCH_MEMORY},
 	{MSM_IOMAP_BASE, MSM_IOMAP_BASE, MSM_IOMAP_SIZE, IOMAP_MEMORY},
 	{MSM_IMEM_BASE, MSM_IMEM_BASE, 1, IMEM_MEMORY},


### PR DESCRIPTION
To accommodate larger kernels and ramdisks.

This change has been tested on the Sony Xperia SP, which is based on the MSM8960T SoC.