### PR TITLE
dts: msm8916: sort msm8916-samsung nodes

### DIFF
--- a/lk2nd/device/dts/msm8916/msm8916-samsung.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-samsung.dts
@@ -60,37 +60,6 @@
 		};
 	};
 
-	coreprimelte {
-		// In the downstream dts it is called Samsung ROSSA PROJECT Rev00
-		model = "Samsung Galaxy Core Prime LTE (SM-G360F)";
-		compatible = "samsung,coreprimelte", "samsung,rossa";
-		lk2nd,match-bootloader = "G360F*";
-
-		lk2nd,dtb-files = "msm8916-samsung-rossa";
-
-		qcom,msm-id = <QCOM_ID_MSM8916 0>;
-		qcom,board-id = <0xCE08FF01 1>;
-
-		muic-reset {
-			compatible = "samsung,muic-reset";
-			i2c-reg = <0x14>;
-			i2c-sda-gpios = <&tlmm 2 I2C_GPIO_FLAGS>;
-			i2c-scl-gpios = <&tlmm 3 I2C_GPIO_FLAGS>;
-		};
-
-		panel {
-			compatible = "samsung,cprime-panel", "lk2nd,panel";
-
-			ss_dsi_panel_HX8369B_BV045WVM_WVGA {
-				compatible = "samsung,hx8369b-bv045wvm";
-			};
-
-			ss_dsi_panel_SC7798A_BV045WVM_WVGA {
-				compatible = "samsung,sc7798a-bv045wvm";
-			};
-		};
-	};
-
 	/* rev 1 */
 
 	a3u-eur {
@@ -133,6 +102,17 @@
 		};
 	};
 
+	a5u-canbmc {
+		model = "Samsung Galaxy A5U (SM-A500W)";
+		compatible = "samsung,a5u-canbmc", "samsung,a5";
+		lk2nd,match-bootloader = "A500W*";
+
+		lk2nd,dtb-files = "msm8916-samsung-a5u-eur";
+
+		qcom,msm-id = <QCOM_ID_MSM8916 0>;
+		qcom,board-id = <0xCE08FF01 1>;
+	};
+
 	a5u-eur {
 		model = "Samsung Galaxy A5U (SM-A500FU)";
 		compatible = "samsung,a5u-eur", "samsung,a5";
@@ -142,6 +122,36 @@
 
 		qcom,msm-id = <QCOM_ID_MSM8916 0>;
 		qcom,board-id = <0xCE08FF01 1>;
+	};
+
+	coreprimelte {
+		model = "Samsung Galaxy Core Prime LTE (SM-G360F)";
+		compatible = "samsung,coreprimelte", "samsung,rossa";
+		lk2nd,match-bootloader = "G360F*";
+
+		lk2nd,dtb-files = "msm8916-samsung-rossa";
+
+		qcom,msm-id = <QCOM_ID_MSM8916 0>;
+		qcom,board-id = <0xCE08FF01 1>;
+
+		muic-reset {
+			compatible = "samsung,muic-reset";
+			i2c-reg = <0x14>;
+			i2c-sda-gpios = <&tlmm 2 I2C_GPIO_FLAGS>;
+			i2c-scl-gpios = <&tlmm 3 I2C_GPIO_FLAGS>;
+		};
+
+		panel {
+			compatible = "samsung,cprime-panel", "lk2nd,panel";
+
+			ss_dsi_panel_HX8369B_BV045WVM_WVGA {
+				compatible = "samsung,hx8369b-bv045wvm";
+			};
+
+			ss_dsi_panel_SC7798A_BV045WVM_WVGA {
+				compatible = "samsung,sc7798a-bv045wvm";
+			};
+		};
 	};
 
 	gt58lte {
@@ -548,6 +558,17 @@
 
 	/* rev 4 */
 
+	e5ltexx {
+		model = "Samsung Galaxy E5 (SM-E500F)";
+		compatible = "samsung,e5ltexx", "samsung,e5";
+		lk2nd,match-bootloader = "E500F*";
+
+		lk2nd,dtb-files = "msm8916-samsung-e5";
+
+		qcom,msm-id = <QCOM_ID_MSM8916 0>;
+		qcom,board-id = <0xCE08FF01 4>;
+	};
+
 	j5xnltedx {
 		model = "Samsung Galaxy J5 2016 (SM-J510GN)";
 		compatible = "samsung,j5xnlte", "samsung,j5x";
@@ -656,18 +677,7 @@
 		};
 	};
 
-	e5ltexx {
-		model = "Samsung Galaxy E5 (SM-E500F)";
-		compatible = "samsung,e5ltexx", "samsung,e5";
-		lk2nd,match-bootloader = "E500F*";
-
-		lk2nd,dtb-files = "msm8916-samsung-e5";
-
-		qcom,msm-id = <QCOM_ID_MSM8916 0>;
-		qcom,board-id = <0xCE08FF01 4>;
-	};
-
-	/* rev5 */
+	/* rev 5 */
 
 	j3lte-chnctc {
 		model = "Samsung Galaxy J3 2016 (SM-J320YZ)";
@@ -898,18 +908,7 @@
 		};
 	};
 
-	/* rev 8 */
-
-	a5lte {
-		model = "Samsung Galaxy A5 (SM-A500F)";
-		compatible = "samsung,a5lte", "samsung,a5u-eur", "samsung,a5";
-		lk2nd,match-bootloader = "A500F*";
-
-		lk2nd,dtb-files = "msm8916-samsung-a5u-eur";
-
-		qcom,msm-id = <QCOM_ID_MSM8916 0>;
-		qcom,board-id = <0xCE08FF01 8>;
-	};
+	/* rev 7 */
 
 	gt510lte {
 		model = "Samsung Galaxy Tab A 9.7 2015 (LTE, SM-T555)";
@@ -929,6 +928,19 @@
 				gpios = <&tlmm 109 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			};
 		};
+	};
+
+	/* rev 8 */
+
+	a5lte {
+		model = "Samsung Galaxy A5 (SM-A500F)";
+		compatible = "samsung,a5lte", "samsung,a5u-eur", "samsung,a5";
+		lk2nd,match-bootloader = "A500F*";
+
+		lk2nd,dtb-files = "msm8916-samsung-a5u-eur";
+
+		qcom,msm-id = <QCOM_ID_MSM8916 0>;
+		qcom,board-id = <0xCE08FF01 8>;
 	};
 
 	/*
@@ -976,17 +988,6 @@
 
 		qcom,msm-id = <QCOM_ID_MSM8916 0>;
 		qcom,board-id = <0xCE08FF01 11>;
-	};
-
-	a5u-canbmc {
-		model = "Samsung Galaxy A5U (SM-A500W)";
-		compatible = "samsung,a5u-canbmc", "samsung,a5";
-		lk2nd,match-bootloader = "A500W*";
-
-		lk2nd,dtb-files = "msm8916-samsung-a5u-eur";
-
-		qcom,msm-id = <QCOM_ID_MSM8916 0>;
-		qcom,board-id = <0xCE08FF01 1>;
 	};
 
 	/*


### PR DESCRIPTION
Sort the devices below:   
- coreprimelte (rev 1)
- a5u-canbmc (rev 1)
- e5ltexx (rev 4) 
- gt510lte (rev 7)