### PR TITLE
Fix detection of motorola-titan

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -181,7 +181,7 @@
 - LG G Watch R - lenok <!--(use `lk2nd-appended-dtb.img`)-->
 - Motorola Moto G 2013 - falcon
 - Motorola Moto G 4G 2013 - peregrine
-- Motorola Moto G 2014 - titan (quirky - see comment in `lk2nd/device/dts/msm8226/msm8226-motorola-titan.dts`)
+- Motorola Moto G 2014 - titan
 - Motorola Moto G 2014 LTE - thea
 - Samsung Galaxy Grand 2 - SM-G7102
 - Samsung Galaxy Tab 4 10.1 (2014) - SM-T530, SM-T532, SM-T535

--- a/lk2nd/device/dts/msm8226/msm8226-motorola-titan.dts
+++ b/lk2nd/device/dts/msm8226/msm8226-motorola-titan.dts
@@ -3,20 +3,6 @@
 #include <skeleton64.dtsi>
 #include <lk2nd.dtsi>
 
-/*
- * Motorola Moto G 2014 has a quirk to be aware of before working with lk2nd:
- *
- * - Custom board id is required by the bootloader
- *   The bootloader will attempt to load the first dtb with
- *   matching msm id, which fails as the board id does not match.
- *
- *   Add LK2ND_DTBS="msm8226-motorola-titan.dtb" to your make cmdline.
- *   eg. `make TOOLCHAIN_PREFIX=arm-none-eabi- lk2nd-msm8226 LK2ND_DTBS="msm8226-motorola-titan.dtb"`
- *
- *   Alternatively use LK2ND_ADTBS="" instead.
- *   eg. `make TOOLCHAIN_PREFIX=arm-none-eabi- lk2nd-msm8226 LK2ND_ADTBS=""`
- */
-
 / {
 	qcom,msm-id = <QCOM_ID_MSM8626 0x4b 0x8100>, <QCOM_ID_MSM8626 0x4b 0x8200>,
 		      <QCOM_ID_MSM8626 0x4b 0x8300>, <QCOM_ID_MSM8626 0x4b 0x8400>,

--- a/lk2nd/device/dts/msm8226/msm8226-motorola-titan.dts
+++ b/lk2nd/device/dts/msm8226/msm8226-motorola-titan.dts
@@ -33,7 +33,7 @@
 
 		key-volume-down {
 			lk2nd,code = <KEY_VOLUMEDOWN>;
-			gpios = <&tlmm 107 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			gpios = <&tlmm 107 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/lk2nd/device/dts/msm8226/rules.mk
+++ b/lk2nd/device/dts/msm8226/rules.mk
@@ -5,6 +5,7 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 ADTBS += \
 	$(LOCAL_DIR)/apq8026-lg-lenok.dtb \
 	$(LOCAL_DIR)/msm8226-motorola-falcon.dtb \
+	$(LOCAL_DIR)/msm8226-motorola-titan.dtb \
 	$(LOCAL_DIR)/msm8926-motorola-peregrine.dtb \
 	$(LOCAL_DIR)/msm8926-motorola-thea.dtb \
 
@@ -12,7 +13,6 @@ QCDTBS += \
 	$(LOCAL_DIR)/apq8026-asus-sparrow.dtb \
 	$(LOCAL_DIR)/apq8026-huawei-sturgeon.dtb \
 	$(LOCAL_DIR)/apq8026-samsung.dtb \
-	$(LOCAL_DIR)/msm8226-motorola-titan.dtb \
 	$(LOCAL_DIR)/msm8226-samsung.dtb \
 	$(LOCAL_DIR)/msm8926-htc-memul.dtb \
 	$(LOCAL_DIR)/msm8926-huawei-g6-l11-vb.dtb \


### PR DESCRIPTION
Move titan from QCDTBS to ADTBS. This enables the dts to be correctly detected, and prevents the bootloader from just picking the first ADTBS device in the list if no valid options are found. (Previously, it would pick the `lg-lenok` device tree.)

Revert a previous commit documenting the device as quirky, and remove quirkiness comment from device tree.

Remove unneeded `GPIO_PULL_UP` flag from `key-volume-down` device tree specification.