### PR TITLE
dts: msm8952: add support for Lenovo Tab 4 8 (tb8504f)

### DIFF
--- a/lk2nd/device/dts/msm8952/msm8917-lenovo-tb8504.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-lenovo-tb8504.dts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8917 0 QCOM_ID_MSM8217 0 QCOM_ID_MSM8617 0 QCOM_ID_APQ8017 0>;
+	qcom,board-id = <0x1000b 0>;
+};
+
+&lk2nd {
+	model = "Lenovo Tab 4 8";
+	compatible = "lenovo,tb8504";
+
+	lk2nd,dtb-files = "msm8917-lenovo-tb8504";
+
+	lk2nd,match-panel;
+	panel {
+		compatible = "lenovo,tb8504-panel", "lk2nd,panel";
+
+		qcom,mdss_dsi_auo_b080eab02_0_rm68200_800p_video {
+			compatible = "lenovo,tb8504-auo";
+			// touchscreen-compatible = "";
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -2,6 +2,7 @@
 LOCAL_DIR := $(GET_LOCAL_DIR)
 
 ADTBS += \
+	$(LOCAL_DIR)/msm8917-lenovo-tb8504.dtb \
 	$(LOCAL_DIR)/msm8917-mtp.dtb \
 	$(LOCAL_DIR)/msm8917-xiaomi-common.dtb \
 	$(LOCAL_DIR)/msm8917-xiaomi-riva.dtb \


### PR DESCRIPTION
This PR adds a device tree for Lenovo Tab 4 8, based on its [downstream dts](https://github.com/lenovo-devs/android_kernel_lenovo_msm8953/blob/070b6a871761481c2284ae2f862adaeb9b4d9d2f/arch/arm/boot/dts/qcom/tb8504-msm8917-pmi8937-qrd-sku5.dts).

I've noticed that #664 also targets the same generic device (msm8917 QRD SKU5), which could be turned into a single generic DTS, albeit booting fails when omitting `QCOM_ID_MSM8217 0 QCOM_ID_MSM8617 0 QCOM_ID_APQ8017 0` in `qcom,msm-id`.

```
Sending 'boot.img' (312 KB)                        OKAY [  0.011s]
Booting                                            FAILED (remote: 'dtb not found')
fastboot: error: Command failed
```