### PR TITLE
dts: msm8909: Add support for Lenovo Tab e10 (TB-X104F)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -84,6 +84,7 @@
 - Nokia 8000 4G
 - Nokia 8110 4G
 - ZTE N818S (sapphire)
+- Lenovo Tab e10 (TB-X104F)
 
 ### lk2nd-msm8952
 

--- a/lk2nd/device/dts/msm8909/apq8009-qrd.dts
+++ b/lk2nd/device/dts/msm8909/apq8009-qrd.dts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+#include <skeleton32.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id  = <QCOM_ID_APQ8009 2>;
+	qcom,board-id = <QCOM_BOARD_ID(QRD, 1, 0) 0>;
+};
+
+&lk2nd {
+	tb-x104f {
+		model = "Lenovo Tab e10 (TB-X104F)";
+		compatible = "lenovo,tb-x104f";
+
+		lk2nd,dtb-files = "msm8909-lenovo-tb-x104f";
+		lk2nd,match-panel;
+
+		panel {
+			compatible = "lenovo,tb-x104f-panel", "lk2nd,panel";
+
+			qcom,mdss_dsi_jd9365_boe_video {
+				compatible = "lenovo,jd9365-boe-video";
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8909/rules.mk
+++ b/lk2nd/device/dts/msm8909/rules.mk
@@ -12,3 +12,5 @@ QCDTBS += \
 
 ADTBS += \
 	$(LOCAL_DIR)/apq8009w-wtp.dtb \
+	$(LOCAL_DIR)/apq8009-qrd.dtb \
+


### PR DESCRIPTION
Pull request to add support for the above mentioned device.

There's the [`boot.img`](https://drive.google.com/file/d/1S-bxhux_tNKQSl1iD6Z6aFJzfQFs7h1d/view?usp=sharing) is available, and the downstream `dts` [file](https://drive.google.com/file/d/1LRVrY-qC5InqXU5kFqUPmQK7jELYOeub/view?usp=drive_link).

Thanks,
