### PR TITLE
dts: msm8952: dts for Huawei Mediapad T3 8 (kobe)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -97,6 +97,7 @@
 - HMD Global Nokia 6 (ple)
 - Huawei Honor 7C (aum-l41) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-huawei-aum.dts`)
 - Huawei MediaPad T3 10 (ags- l09/l03/w09) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8917-huawei-agassi.dts`)
+- Huawei MediaPad T3 8 (kob- l09/l09chn/w09/w09chn) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts`)
 - Leeco s2
 - Lenovo K5 Play (l38011)
 - Lenovo Tab M10 HD (TB-X505X) (requires flashing [minimal DTBO](#minimal-dtb-overlay))

--- a/lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts
@@ -7,27 +7,31 @@
 
 /*
  * This device is quirky. It excluded from generic build.
+ * To run lk2nd on this device you need to flash custom bootloader or buy unlock code and unlock it.
+ * Since there is multiple versions of tablet you may need to change qcom,board-id to match yours device firmware
+ * Read more https://wiki.postmarketos.org/wiki/Huawei_Mediapad_T3_8_(huawei-kobe)
  *
  * Compile lk2nd with the following flags to run on this device
  * LK2ND_ADTBS="msm8917-huawei-kobe.dtb"
  * LK2ND_COMPATIBLE="huawei,kobe"
- */
+ *//
 
 / {
-	qcom,msm-id = <0x12f 0x00 0x134 0x00 0x135 0x00>;
+	qcom,msm-id = <QCOM_ID_MSM8917 0>;
   qcom,board-id = <0x1f45 0x00>;
 };
 
 &lk2nd {
 	/*
-	 * There are 3 versions:
-	 *  - L-09 (Global)
-	 *  - L-03 (USA)
-	 *  - W-09 (WiFi only)
+	 * There are 4 versions:
+	 *  - L09 (Global)
+	 *  - L09CHN (China)
+	 *  - W09 (WiFi only Global)
+  	 *  - W09CHN (WIFI only China)
 	 */
 
 	huawei-kobe {
-		model = "Huawei Technologies, Inc. Kobe-W09";
+		model = "Huawei Mediapad T3 8 (kobe)";
 		compatible = "huawei,kobe";
 		lk2nd,dtb-files = "msm8917-huawei-kobe";
 	};

--- a/lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/dts-v1/;
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * This device is quirky. It excluded from generic build.
+ *
+ * Compile lk2nd with the following flags to run on this device
+ * LK2ND_ADTBS="msm8917-huawei-kobe.dtb"
+ * LK2ND_COMPATIBLE="huawei,kobe"
+ */
+
+/ {
+	qcom,msm-id = <0x12f 0x00 0x134 0x00 0x135 0x00>;
+  qcom,board-id = <0x1f45 0x00>;
+};
+
+&lk2nd {
+	/*
+	 * There are 3 versions:
+	 *  - L-09 (Global)
+	 *  - L-03 (USA)
+	 *  - W-09 (WiFi only)
+	 */
+
+	huawei-kobe {
+		model = "Huawei Technologies, Inc. Kobe-W09";
+		compatible = "huawei,kobe";
+		lk2nd,dtb-files = "msm8917-huawei-kobe";
+	};
+};

--- a/lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts
@@ -14,7 +14,7 @@
  * Compile lk2nd with the following flags to run on this device
  * LK2ND_ADTBS="msm8917-huawei-kobe.dtb"
  * LK2ND_COMPATIBLE="huawei,kobe"
- *//
+ */
 
 / {
 	qcom,msm-id = <QCOM_ID_MSM8917 0>;

--- a/lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts
+++ b/lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts
@@ -18,7 +18,7 @@
 
 / {
 	qcom,msm-id = <QCOM_ID_MSM8917 0>;
-  qcom,board-id = <0x1f45 0x00>;
+	qcom,board-id = <0x1f45 0x00>;
 };
 
 &lk2nd {

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -29,3 +29,4 @@ ADTBS += \
 
 DTBS += \
 	$(LOCAL_DIR)/msm8917-huawei-agassi.dtb \
+    $(LOCAL_DIR)/msm8917-huawei-kobe.dtb \

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -29,4 +29,4 @@ ADTBS += \
 
 DTBS += \
 	$(LOCAL_DIR)/msm8917-huawei-agassi.dtb \
-    $(LOCAL_DIR)/msm8917-huawei-kobe.dtb \
+	$(LOCAL_DIR)/msm8917-huawei-kobe.dtb \


### PR DESCRIPTION
Add initial device tree for Huawei MediaPad T3 8 (kobe).
- android boot tested with lk2nd
<img width="602" height="800" alt="image" src="https://github.com/user-attachments/assets/31c7f643-83c9-487d-9635-7e4e2e7d15e1" />
