### PR TITLE
`/chosen/rng-seed` support

### DIFF
--- a/lk2nd/project/base.mk
+++ b/lk2nd/project/base.mk
@@ -33,6 +33,10 @@ MODULES += \
 	lk2nd/smp/spin-table \
 	lk2nd/version \
 
+ifneq ($(filter ENABLE_KASLRSEED_SUPPORT=1,$(DEFINES)),)
+MODULES += lk2nd/rng-seed
+endif
+
 # Disable SMP spin table if unsupported (without throwing errors)
 LK2ND_SMP_OPTIONAL := 1
 

--- a/lk2nd/rng-seed/rng-seed.c
+++ b/lk2nd/rng-seed/rng-seed.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <boot.h>
+#include <debug.h>
+#include <libfdt.h>
+#include <scm.h>
+#include <string.h>
+#include <sys/types.h>
+
+#define RNG_SEED_BYTES 64
+
+/**
+ * lk2nd_rng_seed_dt_update() - write a random seed to /chosen/rng-seed
+ *
+ * scm_random() is used to generate the entropy in a best-effort manner.
+ * failures are logged, but do not fail the boot
+ */
+static int lk2nd_rng_seed_dt_update(void *dtb, const char *cmdline,
+				    enum boot_type boot_type)
+{
+	uintptr_t rngseed[RNG_SEED_BYTES / sizeof(uintptr_t)];
+	unsigned int i;
+	int offset, ret;
+
+	if (boot_type & (BOOT_DOWNSTREAM | BOOT_LK2ND))
+		return 0;
+
+	for (i = 0; i < ARRAY_SIZE(rngseed); i++) {
+		ret = scm_random(&rngseed[i], sizeof(rngseed[i]));
+		if (ret) {
+			dprintf(INFO, "rng-seed: scm_call for random failed: %d\n", ret);
+			return 0;
+		}
+	}
+
+	offset = fdt_path_offset(dtb, "/chosen");
+	if (offset < 0) {
+		dprintf(INFO, "rng-seed: couldn't find /chosen: %d\n", ret);
+		return 0;
+	}
+
+	ret = fdt_setprop(dtb, offset, "rng-seed", rngseed, sizeof(rngseed));
+	if (ret < 0)
+		dprintf(INFO, "rng-seed: failed to update /chosen/rng-seed: %d\n", ret);
+
+	return 0;
+}
+DEV_TREE_UPDATE(lk2nd_rng_seed_dt_update);

--- a/lk2nd/rng-seed/rules.mk
+++ b/lk2nd/rng-seed/rules.mk
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+LOCAL_DIR := $(GET_LOCAL_DIR)
+MODULES += lib/libfdt
+
+OBJS += \
+	$(LOCAL_DIR)/rng-seed.o

--- a/makefile
+++ b/makefile
@@ -169,8 +169,6 @@ endif
 #Enable kaslr seed support
 ifeq ($(ENABLE_KASLRSEED),1)
   DEFINES += ENABLE_KASLRSEED_SUPPORT=1
-else
-  DEFINES += ENABLE_KASLRSEED_SUPPORT=0
 endif
 
 ifeq ($(TARGET_USE_SYSTEM_AS_ROOT_IMAGE),1)

--- a/project/lk2nd-msm8960.mk
+++ b/project/lk2nd-msm8960.mk
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 TARGET := msm8960
 LK2ND_BUNDLE_DTB ?= bundle.dtb
+
+DEFINES += ENABLE_KASLRSEED_SUPPORT=1
+
 include lk2nd/project/lk2nd.mk


### PR DESCRIPTION
CAF LK already had scaffolding to obtain entropy from TZ (via `SVC_CRYPTO`) and shovel it into `/chosen/kaslr-seed`. It just wasn't wired up anywhere (the only thing that was pulling in `ENABLE_KASLRSEED_SUPPORT` was `AndroidBoot.mk`).

So, we piggy back this prior art to introduce `/chosen/rng-seed`. This DT prop is automatically credited into the entropy pool by the kernel: https://github.com/torvalds/linux/blob/6916d5703ddf9a38f1f6c2cc793381a24ee914c6/drivers/of/fdt.c#L1112

Note that I've only tested this on my msm8930 samsung-expressltexx. I don't have any msm8960-family devices to test with.