### PR TITLE
project: lk2nd-msm8952: enable kaslr seed support

### DIFF
--- a/project/lk2nd-msm8952.mk
+++ b/project/lk2nd-msm8952.mk
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 TARGET := msm8952
+
+DEFINES += ENABLE_KASLRSEED_SUPPORT=1
+
 include lk2nd/project/lk2nd.mk


### PR DESCRIPTION
This has been tested with Xiaomi Redmi 3s running postmarketos.