### PR TITLE
project: lk2nd-msm8953: enable KASLR seed support 

### DIFF
--- a/project/lk2nd-msm8953.mk
+++ b/project/lk2nd-msm8953.mk
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 TARGET := msm8953
+
+DEFINES += ENABLE_KASLRSEED_SUPPORT=1
+
 include lk2nd/project/lk2nd.mk


### PR DESCRIPTION
Enable KASLR seed support for MSM8953 platform.

Tested on SDM450 Redmi 5 (rosy), I can do more tests on different devices if it is necessary