### PR TITLE
mmc: avoid group erase for unaligned ranges

### DIFF
--- a/platform/msm_shared/mmc.c
+++ b/platform/msm_shared/mmc.c
@@ -3076,10 +3076,22 @@ mmc_erase_card(unsigned long long data_addr, unsigned long long size)
 		return MMC_BOOT_E_FAILURE;
 	}
 
-	if (size % erase_grp_size) {
-		dprintf(CRITICAL, "Overflow beyond ERASE_GROUP_SIZE:%llu\n",
-			(size % erase_grp_size));
-
+	if ((data_addr / 512) % erase_grp_size || size % erase_grp_size) {
+		// erase request doesn't fall cleanly on the erase_grp_size
+		// boundary. if we blindly issue this request we might erase data
+		// in other partitions.
+		// this has been confirmed to occur when erasing the virtual
+		// "boot" partition that lk2nd splits out.
+		size = MIN(size, 10240); // don't erase more than 5MiB
+		while (size) {
+			loop_count = MIN(size, sizeof(out) / 512);
+			mmc_ret = mmc_write(data_addr, loop_count * 512, out);
+			if (mmc_ret != MMC_BOOT_E_SUCCESS)
+				return mmc_ret;
+			data_addr += loop_count * 512;
+			size -= loop_count;
+		}
+		return MMC_BOOT_E_SUCCESS;
 	}
 	loop_count = (size / erase_grp_size);
 	/*


### PR DESCRIPTION
[As discussed in Matrix today.](https://matrix.to/#/!MSCNHeTqqpJdofYJgY:postmarketos.org/$Q6DR2ZS71kyoHH7ByrneaEsSXfoy9WJ84emsCzier_Y?via=matrix.org&via=tchncs.de&via=mainlining.org)

In brief: the CAF LK erase code does shady things on my samsung-expressltexx (msm8930, using lk2nd-msm8960 build). On this device, the eMMC controller has an erase group size of 1024 sectors (512KiB). Because the virtual "boot" (second half of the real boot partition) does not fall on this boundary, a request to erase it actually erases most (everything after the first `0x20000` bytes) of "lk2nd" (the first half of the real boot partition) too.

When we encounter any erase request with a size or offset that doesn't fall neatly on this boundary, we opt to do a manual erase, 1 sector at a time, up to a maximum of 5MiB.

I tested this on my expressltexx and it works:

```
➜  lk2nd git:(fix-unaligned-erase) fastboot -s 1eb16fab erase boot
Erasing 'boot'                                     OKAY [  1.411s]
Finished. Total time: 1.417s
```