### PR TITLE
lk2nd: display: cont-splash: Trigger display refresh for MDP3/4

### DIFF
--- a/lk2nd/display/cont-splash/mdp.h
+++ b/lk2nd/display/cont-splash/mdp.h
@@ -4,9 +4,11 @@
 
 #if MDP3
 #include <mdp3.h>
+#include <mipi_dsi.h>
 #elif MDP4
 #include <dev/lcdc.h>
 #include <mdp4.h>
+#include <mipi_dsi.h>
 #elif MDP5
 #include <mdp5.h>
 #else

--- a/lk2nd/display/cont-splash/refresh.c
+++ b/lk2nd/display/cont-splash/refresh.c
@@ -17,6 +17,9 @@ static void mdp_refresh(void)
 {
 #if MDP3 || MDP4
 	writel(1, MDP_DMA_P_START);
+#ifdef DSI_CMD_MODE_MDP_SW_TRIGGER
+	writel(1, DSI_CMD_MODE_MDP_SW_TRIGGER);
+#endif
 #elif MDP5
 	writel(1, MDP_CTL_0_BASE + CTL_START);
 #endif

--- a/platform/msm_shared/include/mipi_dsi.h
+++ b/platform/msm_shared/include/mipi_dsi.h
@@ -79,7 +79,9 @@
 #define DTYPE_GEN_LWRITE 0x29	/* 4th Byte is 0xc0 */
 #define DTYPE_DCS_WRITE1 0x15	/* 4th Byte is 0x80 */
 
+#ifndef RDBK_DATA0
 #define RDBK_DATA0 0x06C
+#endif
 
 #define MIPI_VIDEO_MODE	        1
 #define MIPI_CMD_MODE           2


### PR DESCRIPTION
This fixes display refresh for the Asus Nexus 7 (flo), which is in command mode with no auto refresh.

The #ifndef RDBK_DATA0 allows msm8610 to set the define when compiling
dma.c, which includes mdp.h. I could have instead moved the mipi_dsi.h
include out of mdp.h, but the pre-existing undef goo in msm8610 made
this seem the best mirror for the current RDBK_DATA0 handling.

@user0-07161, you may want to check if this fixes Samsung Galaxy Ace 3 LTE.