### PR TITLE
dts: msm8960: Add Asus Nexus 7 (flo) support

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -215,6 +215,7 @@
 
 ### lk2nd-msm8960
 
+- Asus Nexus 7 (flo)
 - Samsung Galaxy Ace 3 LTE (GT-S7275R) (display refresh doesn't work)
 - Samsung Galaxy Express (SGH-I437)
 - Samsung Galaxy S4 Mini (GT-I9195)

--- a/lk2nd/device/dts/msm8960/bundle.dts
+++ b/lk2nd/device/dts/msm8960/bundle.dts
@@ -3,6 +3,25 @@
 #include <lk2nd.dtsi>
 
 &lk2nd {
+	asus-nexus7 {
+		model = "Asus Nexus 7 (flo)";
+		compatible = "asus,nexus7-flo";
+		lk2nd,match-bootloader = "FLO-*";
+		lk2nd,dtb-files = "apq8064-asus-nexus7-flo";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+
+			volume-up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&pmic 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			volume-down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&pmic 37 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
 	samsung-serrano {
 		model = "Samsung Galaxy S4 Mini (GT-I9195)";
 		compatible = "samsung,serranolte", "samsung,serrano";


### PR DESCRIPTION
For the display to actually work, #696 is needed.