### PR TITLE
dts: msm8952: Add support for Huawei Enjoy 7 Plus

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -95,6 +95,7 @@
 - HMD Global Nokia 4.2 (panther) (requires flashing [minimal DTBO](#minimal-dtb-overlay))
 - HMD Global Nokia 5 (nd1)
 - HMD Global Nokia 6 (ple)
+- Huawei Enjoy 7 Plus (trt-tl10)
 - Huawei Honor 7C (aum-l41) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8937-huawei-aum.dts`)
 - Huawei MediaPad T3 10 (ags- l09/l03/w09) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8917-huawei-agassi.dts`)
 - Huawei MediaPad T3 8 (kob- l09/l09chn/w09/w09chn) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8917-huawei-kobe.dts`)

--- a/lk2nd/device/dts/msm8952/msm8940-huawei-trt-tl10.dts
+++ b/lk2nd/device/dts/msm8952/msm8940-huawei-trt-tl10.dts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <0x139 0x00>;
+	qcom,board-id = <0x1fa5 0x00>,
+			<0x1fb5 0x00>;
+};
+
+&lk2nd {
+	model = "Huawei Enjoy 7 Plus";
+	compatible = "huawei,trt-tl10";
+
+	lk2nd,dtb-files = "msm8940-huawei-trt-tl10";
+	
+	panel {
+		compatible = "huawei,trt-tl10-panel", "lk2nd,panel";
+
+		lcdkit_trt_tl10_vd_boe_td4100_5p5_720p_video {
+			compatible = "boe,td4100-5p5xa";
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/msm8940-huawei-trt-tl10.dts
+++ b/lk2nd/device/dts/msm8952/msm8940-huawei-trt-tl10.dts
@@ -4,7 +4,7 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <0x139 0x00>;
+	qcom,msm-id = <QCOM_ID_MSM8940 0>;
 	qcom,board-id = <0x1fa5 0x00>,
 			<0x1fb5 0x00>;
 };

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -13,6 +13,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8937-nokia-nd1.dtb \
 	$(LOCAL_DIR)/msm8937-nokia-ple.dtb \
 	$(LOCAL_DIR)/msm8937-xiaomi-land.dtb \
+	$(LOCAL_DIR)/msm8940-huawei-trt-tl10.dtb \
 	$(LOCAL_DIR)/msm8940-mtp.dtb \
 	$(LOCAL_DIR)/msm8940-oppo-a57.dtb \
 	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb \


### PR DESCRIPTION
This device is known to have two configuration combinations, corresponding to two board IDs.
The storage options are 3 / 32 and 4 / 64 respectively.