### PR TITLE
lk2nd: boot: extlinux: Maximize kernel image memory

### DIFF
--- a/Documentation/boot.md
+++ b/Documentation/boot.md
@@ -61,6 +61,24 @@ label MyOS
     append earlycon console=ttyMSM0,115200
 ```
 
+### Boot memory layout with extlinux.conf
+
+When booting via `extlinux.conf`, lk2nd needs to choose addresses after the
+kernel to provide the initramfs and devicetree.
+
+The available boot memory is limited by nearby reserved memory regions and
+varies by platform. Platforms can set `LK2ND_BOOT_MEM_SIZE` to adjust the size.
+lk2nd will use:
+- All current platforms: 50 MiB
+
+That memory is shared by the kernel, initramfs, and devicetree. Booting will
+fail if that limit is exceeded. The memory needed by the kernel includes the
+size after self-decompression, not just the on-disk size of the kernel. ARM
+32-bit kernels and older 64-bit kernels don't provide details on how much
+memory they need for self-decompression so lk2nd will place the initramfs and
+devicetree at the end of the boot memory, to give all the remaining memory to
+the kernel to decompress.
+
 ## lk2nd cmdline arguments
 
 lk2nd can read OS cmdline argument and make some decisions while booting it.

--- a/Documentation/boot.md
+++ b/Documentation/boot.md
@@ -69,7 +69,8 @@ kernel to provide the initramfs and devicetree.
 The available boot memory is limited by nearby reserved memory regions and
 varies by platform. Platforms can set `LK2ND_BOOT_MEM_SIZE` to adjust the size.
 lk2nd will use:
-- All current platforms: 50 MiB
+- `msm8960`: 128 MiB
+- All other platforms: 50 MiB
 
 That memory is shared by the kernel, initramfs, and devicetree. Booting will
 fail if that limit is exceeded. The memory needed by the kernel includes the

--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -77,6 +77,11 @@ You need to switch the cable before starting linux to see all the logs.
 
 #### `LK2ND_ADTBS=`, `LK2ND_QCDTBS=`, `LK2ND_DTBS=` - Only build listed dtbs
 
+#### `LK2ND_BOOT_MEM_SIZE=` - Max boot memory size in bytes
+
+Set the maximum amount of memory available for booting (kernel, device tree,
+and initramfs). Default is `0x03200000` (50 MiB).
+
 ### lk1st specific
 
 #### `LK2ND_COMPATIBLE=` - Board compatible

--- a/lk2nd/boot/extlinux.c
+++ b/lk2nd/boot/extlinux.c
@@ -476,9 +476,9 @@ extern void boot_linux(void *kernel, unsigned *tags,
 
 #define IS_ARM64(ptr) (ptr->magic_64 == KERNEL64_HDR_MAGIC)
 
-#define MAX_KERNEL_SIZE			(32 * 1024 * 1024)
+#define LK2ND_BOOT_MEM_SIZE		(50 * 1024 * 1024)
+
 #define MAX_TAGS_SIZE			(2 * 1024 * 1024)
-#define MAX_RAMDISK_SIZE		(16 * 1024 * 1024)
 
 struct load_addrs {
 	void *kernel;
@@ -488,9 +488,9 @@ struct load_addrs {
 	uint32_t ramdisk_max_size;
 };
 
-static void choose_addrs(const struct kernel64_hdr *kptr, struct load_addrs *addrs)
+static void choose_addrs(const struct kernel64_hdr *kptr, uint32_t ramdisk_size, struct load_addrs *addrs)
 {
-	uint32_t kernel_offset;
+	uint32_t kernel_offset, ramdisk_offset, tags_offset;
 	void *base;
 
 #ifdef DDR_START
@@ -499,10 +499,12 @@ static void choose_addrs(const struct kernel64_hdr *kptr, struct load_addrs *add
 	base = (void *)(uintptr_t)BASE_ADDR;
 #endif
 
-	/* FIXME: Find a better approach to allow larger ramdisks */
-	addrs->tags = base + MAX_KERNEL_SIZE;
-	addrs->ramdisk = addrs->tags + MAX_TAGS_SIZE;
-	addrs->ramdisk_max_size = MAX_RAMDISK_SIZE;
+	ramdisk_offset = ROUNDDOWN(LK2ND_BOOT_MEM_SIZE - ramdisk_size, 4096);
+	tags_offset = ramdisk_offset - MAX_TAGS_SIZE;
+
+	addrs->tags = base + tags_offset;
+	addrs->ramdisk = base + ramdisk_offset;
+	addrs->ramdisk_max_size = LK2ND_BOOT_MEM_SIZE - ramdisk_offset;
 
 	/*
 	 * ARM64 kernels specify the expected text offset in kptr->text_offset.
@@ -527,7 +529,11 @@ static void choose_addrs(const struct kernel64_hdr *kptr, struct load_addrs *add
 	}
 
 	addrs->kernel = base + kernel_offset;
-	addrs->kernel_max_size = MAX_KERNEL_SIZE - kernel_offset;
+	if (tags_offset > kernel_offset) {
+		addrs->kernel_max_size = tags_offset - kernel_offset;
+	} else {
+		addrs->kernel_max_size = 0;
+	}
 }
 
 /**
@@ -543,6 +549,25 @@ static void lk2nd_boot_label(struct label *label)
 	int ret, i = 0;
 
 	dprintf(INFO, "Trying to boot '%s'\n", label->name);
+
+	if (label->initramfs) {
+		struct filehandle *fileh;
+		struct file_stat stat;
+
+		ret = fs_open_file(label->initramfs, &fileh);
+		if (ret < 0) {
+			dprintf(INFO, "Failed to open initramfs: %d\n", ret);
+			return;
+		}
+		ret = fs_stat_file(fileh, &stat);
+		if (ret < 0) {
+			dprintf(INFO, "Failed to stat initramfs: %d\n", ret);
+			fs_close_file(fileh);
+			return;
+		}
+		ramdisk_size = stat.size;
+		fs_close_file(fileh);
+	}
 
 	ret = fs_load_file(label->kernel, scratch, scratch_size);
 	if (ret < 0) {
@@ -565,7 +590,7 @@ static void lk2nd_boot_label(struct label *label)
 		kernel_scratch = scratch;
 	}
 
-	choose_addrs(kernel_scratch, &addrs);
+	choose_addrs(kernel_scratch, ramdisk_size, &addrs);
 
 	if (kernel_size > addrs.kernel_max_size) {
 		dprintf(INFO, "Kernel too big: %u > %u\n",
@@ -614,16 +639,15 @@ static void lk2nd_boot_label(struct label *label)
 	}
 
 	if (label->initramfs) {
-		ret = fs_load_file(label->initramfs, addrs.ramdisk, addrs.ramdisk_max_size);
+		ret = fs_load_file(label->initramfs, addrs.ramdisk, ramdisk_size);
 		if (ret < 0) {
 			dprintf(INFO, "Failed to load the initramfs: %d\n", ret);
 			return;
 		}
-		if ((uint32_t)ret == addrs.ramdisk_max_size) {
-			dprintf(INFO, "Initramfs is too big\n");
+		if ((uint32_t)ret != ramdisk_size) {
+			dprintf(INFO, "Failed to read full initramfs: %d != %u\n", ret, ramdisk_size);
 			return;
 		}
-		ramdisk_size = ret;
 		arch_clean_invalidate_cache_range((addr_t)addrs.ramdisk, ramdisk_size);
 	}
 

--- a/lk2nd/boot/extlinux.c
+++ b/lk2nd/boot/extlinux.c
@@ -476,8 +476,6 @@ extern void boot_linux(void *kernel, unsigned *tags,
 
 #define IS_ARM64(ptr) (ptr->magic_64 == KERNEL64_HDR_MAGIC)
 
-#define LK2ND_BOOT_MEM_SIZE		(50 * 1024 * 1024)
-
 #define MAX_TAGS_SIZE			(2 * 1024 * 1024)
 
 struct load_addrs {

--- a/lk2nd/boot/rules.mk
+++ b/lk2nd/boot/rules.mk
@@ -10,3 +10,8 @@ OBJS += \
 	$(LOCAL_DIR)/boot.o \
 	$(LOCAL_DIR)/extlinux.o \
 	$(LOCAL_DIR)/util.o \
+
+# Default boot memory size limit (50 MiB)
+LK2ND_BOOT_MEM_SIZE ?= 0x03200000
+
+DEFINES += LK2ND_BOOT_MEM_SIZE=$(LK2ND_BOOT_MEM_SIZE)

--- a/project/lk2nd-msm8960.mk
+++ b/project/lk2nd-msm8960.mk
@@ -3,5 +3,8 @@ TARGET := msm8960
 LK2ND_BUNDLE_DTB ?= bundle.dtb
 
 DEFINES += ENABLE_KASLRSEED_SUPPORT=1
+# Constrained by MIPI_FB_ADDR at 0x89000000. ramoops@88d00000 for flo and mako.
+# The mmu_section_table doesn't map beyond 0x88000000, which is still plenty.
+LK2ND_BOOT_MEM_SIZE := 0x08000000
 
 include lk2nd/project/lk2nd.mk


### PR DESCRIPTION
And also:
```
lk2nd: boot: extlinux: Allow to configure the amount of boot memory
project: lk2nd-msm8960: Increase boot memory to 128MiB
```

The each commit message provides a description.