### PR TITLE
lk2nd: device: msm8909: Add support for Huawei Honor 4A (SCL-AL00)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -76,6 +76,7 @@
 - CAT B35
 - FarEasTone Smart 506 (quirky - see comment in `lk2nd/device/dts/msm8909/msm8909-1gb-qrd-skuc.dts`)
 - Haier G151 / Andromax A (quirky - see comment in `lk2nd/device/dts/msm8909/msm8909-1gb-qrd-skuc.dts`)
+- Huawei Honor 4A - scale
 - Lenovo Yoga Tab 3 8 LTE / WIFI
 - Lenovo Yoga Tab 3 10 LTE / WIFI
 - Lenovo Tab 10 (TB-X103F)

--- a/lk2nd/device/dts/msm8909/msm8909-huawei-scale.dts
+++ b/lk2nd/device/dts/msm8909/msm8909-huawei-scale.dts
@@ -4,7 +4,7 @@
 #include <lk2nd.dtsi>
 
 / {
-	qcom,msm-id = <0xf5 0x00 0x102 0x00 0x109 0x00 0x113 0x00>;
+	qcom,msm-id = <QCOM_ID_MSM8909 0>;
 	qcom,board-id = <0x1fb2 0x00>;
 	compatible = "qcom,msm8909-qrd", "qcom,msm8909", "qcom,qrd";
 };

--- a/lk2nd/device/dts/msm8909/msm8909-huawei-scale.dts
+++ b/lk2nd/device/dts/msm8909/msm8909-huawei-scale.dts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton32.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <0xf5 0x00 0x102 0x00 0x109 0x00 0x113 0x00>;
+	qcom,board-id = <0x1fb2 0x00>;
+	compatible = "qcom,msm8909-qrd", "qcom,msm8909", "qcom,qrd";
+};
+
+&lk2nd {
+	huawei-scale {
+		model = "Honor 4A (SCL-AL00)";
+		compatible = "huawei,scale";
+		lk2nd,match-panel;
+		lk2nd,dtb-files = "msm8909-huawei-scale";
+
+		panel {
+			compatible = "huawei,scale-panel", "lk2nd,panel";
+
+			qcom,mdss_dsi_boe_nt35521s_5_720pxa_video {
+				compatible = "huawei,boe-nt35521s";
+			};
+
+			qcom,mdss_dsi_boe_nt35521_5_720pxa_video {
+				compatible = "huawei,boe-nt35521";
+			};
+
+			qcom,mdss_dsi_boe_otm1284a_5_720pxa_video {
+				compatible = "huawei,boe-otm1284a";
+			};
+
+			qcom,mdss_dsi_cmi_nt35521s_5_720pxa_video {
+				compatible = "huawei,cmi-nt35521s";
+			};
+
+			qcom,mdss_dsi_cmi_otm1283a_5_720pxa_video {
+				compatible = "huawei,cmi-otm1283a";
+			};
+
+			qcom,mdss_dsi_tianma_otm1287a_5_720pxa_video {
+				compatible = "huawei,tianma-otm1287a";
+			};
+		};
+
+		regulator-lcd-io {
+			compatible = "regulator-fixed";
+			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+		};
+
+		regulator-lcd-3v3 {
+			compatible = "regulator-fixed";
+			gpios = <&tlmm 95 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8909/rules.mk
+++ b/lk2nd/device/dts/msm8909/rules.mk
@@ -9,6 +9,7 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8909-1gb-qrd-skue.dtb \
 	$(LOCAL_DIR)/msm8909-mtp.dtb \
 	$(LOCAL_DIR)/msm8909-zte-sapphire.dtb \
+	$(LOCAL_DIR)/msm8909-huawei-scale.dtb \
 
 ADTBS += \
 	$(LOCAL_DIR)/apq8009w-wtp.dtb \

--- a/lk2nd/device/dts/msm8909/rules.mk
+++ b/lk2nd/device/dts/msm8909/rules.mk
@@ -7,9 +7,9 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8905-qrd-skub.dtb \
 	$(LOCAL_DIR)/msm8909-1gb-qrd-skuc.dtb \
 	$(LOCAL_DIR)/msm8909-1gb-qrd-skue.dtb \
+	$(LOCAL_DIR)/msm8909-huawei-scale.dtb \
 	$(LOCAL_DIR)/msm8909-mtp.dtb \
 	$(LOCAL_DIR)/msm8909-zte-sapphire.dtb \
-	$(LOCAL_DIR)/msm8909-huawei-scale.dtb \
 
 ADTBS += \
 	$(LOCAL_DIR)/apq8009w-wtp.dtb \


### PR DESCRIPTION
The Huawei Honor 4A (SCL-AL00, codename "scale") is based on the
Qualcomm MSM8909 SoC. It features a 5" 720p display with multiple
panel suppliers (BOE, CMI, Tianma), Cypress touchscreen, BQ24296M
charger, and various sensors.

Add device tree with panel detection via lk2nd,match-panel and
display regulators for the TPS65132 PMIC (GPIO 32, 95).