### PR TITLE
project: lk2nd-msm8960: Limit samsung,jflte boot memory to 64MiB

### DIFF
--- a/project/lk2nd-msm8960.mk
+++ b/project/lk2nd-msm8960.mk
@@ -7,4 +7,10 @@ DEFINES += ENABLE_KASLRSEED_SUPPORT=1
 # The mmu_section_table doesn't map beyond 0x88000000, which is still plenty.
 LK2ND_BOOT_MEM_SIZE := 0x08000000
 
+# jflte shows display artifacts with the generic 128 MiB boot window.
+# While booting still works, it's safer to keep initramfs/DTB to 64 MiB
+ifeq ($(BOOTLOADER_OUT),samsung-jflte)
+LK2ND_BOOT_MEM_SIZE := 0x04000000
+endif
+
 include lk2nd/project/lk2nd.mk


### PR DESCRIPTION
Limit jflte to a 64 MiB lk2nd boot memory window. This still leaves more than the stock bootloader layout, while avoiding display artifacts seen with the generic msm8960 128 MiB window.

While jflte still boots with 128 Mib, the display artefacts hints that this could be unsafe.

Photo of the problem with 128 Mib: 

<img height="1000" alt="Screenshot_20260608_223331_Gallery" src="https://github.com/user-attachments/assets/46bd570f-a5fc-4c41-a6df-4c12b364f2f4" />
