### PR TITLE
project: lk2nd-msm8960: Limit boot memory to 124MiB

### DIFF
--- a/project/lk2nd-msm8960.mk
+++ b/project/lk2nd-msm8960.mk
@@ -5,6 +5,7 @@ LK2ND_BUNDLE_DTB ?= bundle.dtb
 DEFINES += ENABLE_KASLRSEED_SUPPORT=1
 # Constrained by MIPI_FB_ADDR at 0x89000000. ramoops@88d00000 for flo and mako.
 # The mmu_section_table doesn't map beyond 0x88000000, which is still plenty.
-LK2ND_BOOT_MEM_SIZE := 0x08000000
+# samsung-jflte constrained to 124 MiB (0x07c00000) as the framebuffer is at 0x87E00000 
+LK2ND_BOOT_MEM_SIZE := 0x07c00000
 
 include lk2nd/project/lk2nd.mk


### PR DESCRIPTION
Limit jflte to a 124 MiB lk2nd boot memory window. This still leaves more than the stock bootloader layout, while avoiding display artifacts seen with the generic msm8960 128 MiB window.

Photo of the problem with 128 Mib:
<img height="800" alt="Screenshot_20260608_223331_Gallery" src="https://github.com/user-attachments/assets/825f7f20-f0fb-4b1c-8566-21ad89a100a2" />
