### PR TITLE
dts: msm8952: add support for Medion Lifetab P10610 (Malata)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -103,6 +103,7 @@
 - Leeco s2
 - Lenovo K5 Play (l38011)
 - Lenovo Tab M10 HD (TB-X505X) (requires flashing [minimal DTBO](#minimal-dtb-overlay))
+- Medion Lifetab P10610 (Malata)
 - Motorola Moto E4 (perry) (MSM8917)
 - Motorola Moto E4 (perry) (MSM8920)
 - Motorola Moto E5 (nora)

--- a/lk2nd/device/dts/msm8952/msm8937-medion-malata.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-medion-malata.dts
@@ -5,7 +5,7 @@
 
 / {
 	qcom,msm-id = <QCOM_ID_MSM8937 0>;
-	qcom,board-id = <0x0b 0x00>;
+	qcom,board-id = <QCOM_BOARD_ID_QRD 0>;
 };
 
 &lk2nd {
@@ -15,6 +15,7 @@
 	lk2nd,dtb-files = "msm8937-medion-malata";
 
 	lk2nd,match-panel;
+
 	panel {
 		compatible = "medion,malata-panel", "lk2nd,panel";
 

--- a/lk2nd/device/dts/msm8952/msm8937-medion-malata.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-medion-malata.dts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8937 0>;
+	qcom,board-id = <0x0b 0x00>;
+};
+
+&lk2nd {
+	model = "Medion Lifetab P10610 (Malata)";
+	compatible = "medion,malata";
+
+	lk2nd,dtb-files = "msm8937-medion-malata";
+
+	lk2nd,match-panel;
+	panel {
+		compatible = "medion,malata-panel", "lk2nd,panel";
+
+		qcom,mdss_dsi_malata_b101uan08_1200_1900_video {
+			compatible = "medion,gama-wuxga";
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -8,6 +8,7 @@ ADTBS += \
 	$(LOCAL_DIR)/msm8920-motorola-jeter.dtb \
 	$(LOCAL_DIR)/msm8920-mtp.dtb \
 	$(LOCAL_DIR)/msm8937-huawei-aum.dtb \
+	$(LOCAL_DIR)/msm8937-medion-malata.dtb \
 	$(LOCAL_DIR)/msm8937-motorola-jeter.dtb \
 	$(LOCAL_DIR)/msm8937-mtp.dtb \
 	$(LOCAL_DIR)/msm8937-nokia-nd1.dtb \


### PR DESCRIPTION
Added support for the Medion Lifetab P10610 (10.1“ FHD display).
<img width="1536" height="2048" alt="1000093632" src="https://github.com/user-attachments/assets/3d54fbc3-7496-49b6-90e6-90061597b5a2" />
