### PR TITLE
fastboot: fix truncated serial

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -368,7 +368,7 @@ struct getvar_partition_info part_type_known[] =
 
 char max_download_size[MAX_RSP_SIZE];
 char charger_screen_enabled[MAX_RSP_SIZE];
-char sn_buf[13];
+char sn_buf[MAX_RSP_SIZE];
 char display_panel_buf[MAX_PANEL_BUF_SIZE];
 char panel_display_mode[MAX_RSP_SIZE];
 char soc_version_str[MAX_RSP_SIZE];

--- a/app/aboot/fastboot.c
+++ b/app/aboot/fastboot.c
@@ -665,7 +665,8 @@ static void fastboot_notify(struct udc_gadget *gadget, unsigned event)
 
 int fastboot_init(void *base, unsigned size)
 {
-	char sn_buf[13];
+	extern char sn_buf[MAX_RSP_SIZE];
+	char serialno[MAX_RSP_SIZE] = "";
 	thread_t *thr;
 	dprintf(INFO, "fastboot_init()\n");
 
@@ -676,9 +677,12 @@ int fastboot_init(void *base, unsigned size)
 	target_fastboot_init();
 
 	/* setup serialno */
-	target_serialno((unsigned char *) sn_buf);
-	dprintf(SPEW,"serial number: %s\n",sn_buf);
-	surf_udc_device.serialno = sn_buf;
+	if (sn_buf[0])
+		strlcpy(serialno, sn_buf, sizeof(serialno));
+	else
+		target_serialno((unsigned char *) serialno);
+	dprintf(SPEW, "serial number: %s\n", serialno);
+	surf_udc_device.serialno = serialno;
 
 	if(!strcmp(target_usb_controller(), "dwc"))
 	{

--- a/lk2nd/device/2nd/device.c
+++ b/lk2nd/device/2nd/device.c
@@ -9,7 +9,7 @@
 
 static void lk2nd_device2nd_update_serialno(const char *serialno)
 {
-	extern char sn_buf[13]; /* aboot.c */
+	extern char sn_buf[MAX_RSP_SIZE]; /* aboot.c */
 
 	if (serialno)
 		strlcpy(sn_buf, serialno, sizeof(sn_buf));


### PR DESCRIPTION
My samsung-gt510 has a 16-char serial number. This revealed two issues:

 * target_serialno() is using eMMC PSN, which is only 32bit (8 hex chars)
 * fastboot serialno buffers were too small