### PR TITLE
dts: msm8916: use QCOM_BOARD_ID_CDP

### DIFF
--- a/lk2nd/device/dts/msm8916/msm8916-vivo-pd1304.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-vivo-pd1304.dts
@@ -5,7 +5,7 @@
 
 / {
 	qcom,msm-id = <QCOM_ID_MSM8916 0>;
-	qcom,board-id = <0x01 0x01>;
+	qcom,board-id = <QCOM_BOARD_ID_CDP 0x01>;
 };
 
 /*

--- a/lk2nd/device/dts/msm8916/msm8939-htc-m8qlul.dts
+++ b/lk2nd/device/dts/msm8916/msm8939-htc-m8qlul.dts
@@ -14,7 +14,7 @@
 	qcom,msm-id = <382 0x10000>;
 	htc,project-id = <382 0x10000>;
 	htc,hw-id = <0 0>, <1 0>, <2 0>, <128 0>;
-	qcom,board-id = <1 0>;
+	qcom,board-id = <QCOM_BOARD_ID_CDP 0>;
 };
 
 &lk2nd {


### PR DESCRIPTION
Keep msm8939-htc-m8qlul not renamed to msm8939-cdp for now.