### PR TITLE
lk2nd: hw: gpio: pm8921: Add devicetree flag for GPIO polarity inversion

### DIFF
--- a/lk2nd/device/dts/msm8960/bundle.dts
+++ b/lk2nd/device/dts/msm8960/bundle.dts
@@ -14,11 +14,11 @@
 
 			volume-up {
 				lk2nd,code = <KEY_VOLUMEUP>;
-				gpios = <&pmic 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+				gpios = <&pmic 3 (GPIO_ACTIVE_HIGH | GPIO_PMIC_INVERTED)>;
 			};
 			volume-down {
 				lk2nd,code = <KEY_VOLUMEDOWN>;
-				gpios = <&pmic 37 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+				gpios = <&pmic 37 (GPIO_ACTIVE_HIGH | GPIO_PMIC_INVERTED)>;
 			};
 		};
 	};

--- a/lk2nd/hw/gpio/pm8921.c
+++ b/lk2nd/hw/gpio/pm8921.c
@@ -18,6 +18,7 @@ int lk2nd_gpio_pmic_config(uint32_t num, int flags)
 		.function	= !!(flags & GPIOL_FLAGS_ASSERTED),
 		.vin_sel	= PMIC_FLAGS_VIN_SEL(flags),
 		.out_strength	= clamp(GPIOL_CONF_DRVSTR(flags), 0, 3),
+		.inv_int_pol	= !!(flags & PMIC_FLAGS_INVERTED),
 	};
 
 	if (flags & GPIO_PULL_UP)

--- a/lk2nd/hw/gpio/supplier.h
+++ b/lk2nd/hw/gpio/supplier.h
@@ -14,6 +14,7 @@
 
 #define PMIC_FLAGS_VIN_SEL(x)		BITS_SHIFT(num, 26, 24)
 #define PMIC_NON_DEFAULT_VIN_SEL	BIT(27)
+#define PMIC_FLAGS_INVERTED		BIT(28)
 
 /* tlmm.c */
 int lk2nd_gpio_tlmm_config(uint32_t num, int flags);

--- a/lk2nd/include/dt-bindings/lk2nd/gpio.h
+++ b/lk2nd/include/dt-bindings/lk2nd/gpio.h
@@ -45,6 +45,7 @@
 /* 24:31 - Device-specific config flags */
 
 #define GPIO_PMIC_VIN_SEL(x)	(((x) & 0x07) << 24 | BIT(27)) /* bits 24:27 */
+#define GPIO_PMIC_INVERTED	BIT(28)
 
 /* device-specific definitions */
 


### PR DESCRIPTION
Allow configuring PMIC GPIO interrupt/input polarity inversion dynamically via a custom devicetree flag `GPIO_PMIC_INVERTED`.

On the Asus Nexus 7 (flo), the primary bootloader configures the volume keys with inversion enabled and Linux does not seem to reconfigure this. When lk2nd configured the buttons, it cleared the inversion causing Linux to believe the buttons were pressed.

-------

I'm not beholden to this particular strategy, but it was simple, shows what I'm trying to achieve, and won't break other devices. I played with trying to preserve the inversion flag, and wasn't happy with it. I don't know if we think this is just a linux bug and it should be fixed there instead. I've only seen upstream linux break; I haven't tried with android. I can try out things like that if it helps.