### PR TITLE
aboot: Don't do extlinux boot when selected recovery from menu

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -4672,7 +4672,8 @@ void cmd_continue(const char *arg, void *data, unsigned sz)
 		exit_menu_keys_detection();
 #endif
 #if WITH_LK2ND_BOOT
-		lk2nd_boot();
+		if (!boot_into_recovery)
+			lk2nd_boot();
 #endif
 		boot_linux_from_mmc();
 	}


### PR DESCRIPTION
When I have an ext2 partition with `extlinux.conf` flashed into the virtual `boot` partition (512k after lk2nd if I understand correctly), **selecting "Recovery" in Fastboot menu still boots mainline for me, but it should boot device into recovery mode**.

(my device is using msm8952 platform)

it was annoying and as a workaround I always had to temporarily erase my `boot`

it seems like `extlinux` boot handlings is done by a function called `lk2nd_boot()`:

https://github.com/msm8916-mainline/lk2nd/blob/1250da01ff81d52357f9667908d3bb4cb6b7a265/lk2nd/boot/boot.c#L66-L74

so if that function is called it would try to find a partition with `extlinux.conf` to boot unconditionally

I found `lk2nd_boot()` is already guarded in another usage in `aboot.c` (seems that code path is for normal boot, i.e. when not entering Fastboot menu):

https://github.com/msm8916-mainline/lk2nd/blob/1250da01ff81d52357f9667908d3bb4cb6b7a265/app/aboot/aboot.c#L5657-L5658

My understanding is: currently when ABOOT starts up it detects if volume key is held and sets `boot_into_recovery` flag

https://github.com/msm8916-mainline/lk2nd/blob/1250da01ff81d52357f9667908d3bb4cb6b7a265/app/aboot/aboot.c#L5595-L5596

so `lk2nd_boot()` is bypassed if should boot into recovery mode

if I understand correctly when "Recovery" is selected from menu, it sets `boot_into_recovery` flag eventually calls `cmd_continue()`:

https://github.com/msm8916-mainline/lk2nd/blob/1250da01ff81d52357f9667908d3bb4cb6b7a265/lk2nd/device/menu/menu.c#L126-L132

`cmd_continue()`  also lives in `aboot.c` but it seems to lack a check on `boot_into_recovery`:

https://github.com/msm8916-mainline/lk2nd/blob/1250da01ff81d52357f9667908d3bb4cb6b7a265/app/aboot/aboot.c#L4674-L4677

this commit adds that missing check

(I know I can also just use key combinations to force a recovery boot but still)