### PR TITLE
dts: msm8952: Add tree for QiKU 360 N5

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -118,6 +118,7 @@
 - Motorola Moto G5S (montana)
 - Motorola Moto G6 Play (jeter)
 - OPPO A57 (A57) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8940-oppo-a57.dts`)
+- QiKU 360 N5 (qk1605-a01) (quirky - see comment in `lk2nd/device/dts/msm8952/msm8976-360-qk1605-a01.dts`)
 - Redmi 3S (land)
 - Redmi 4 (prada)
 - Redmi 4A (rolex)

--- a/lk2nd/device/dts/msm8952/msm8976-360-qk1605-a01.dts
+++ b/lk2nd/device/dts/msm8952/msm8976-360-qk1605-a01.dts
@@ -1,0 +1,25 @@
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/*
+ * To build for 360-qk1605-a01, add LK2ND_ADTBS="msm8976-360-qk1605-a01.dtb"
+ * to your make cmdline.
+ * qk1605-a01 does not work with all dtbs enabled; the bootloader gets upset
+ * and goes into the phone's fastboot.
+ *
+ * lk2nd cannot be flashed in fastboot mode
+ * Instead, use a Rooted shell (with dd command), EDL or a custom recovery
+ * (e.g. TWRP) to write the lk2nd.img to the boot partition.
+ */
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8976 0x10001>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0x0>;
+	qiku,pcb-id = <0xa>;
+	qiku,project-id = "1605_A01";
+};
+
+&lk2nd {
+	model = "QiKU 360 N5 (QK1605-A01)";
+	compatible = "360,qk1605-a01", "360,qk1605";
+};


### PR DESCRIPTION
QiKU 360 N5 is a mid-range smartphone released only in China

QiKU is probably related to Coolpad (?) clue is it uses same proprietary firmware package format with `.CPB` extension

> **specs**: https://4pda.to/devdb/qiku_n5
> **device page** (official, in chinese): https://qiku.com/product/n5/index.html
> **stock rom DL** (official, DDLs dead, still has version list and checksums): http://bbs.360.cn/forum.php?mod=romproduct

this PR only adds a bare bone device tree needed to boot mainline, but it also seems to boot TWRP and downstream fine

(this may be a horrible idea as LK2nd doesn't have logics to filter DTB by `qiku,*` properties, but QK1605-A01 DTB happens to be the first, that's probably why it works?)

SDcard isn't detected, log says OCR request timed out, need more investigations

[lk2nd_log.txt](https://github.com/user-attachments/files/29285697/lk2nd_log.txt)

### photos

| LK2nd | mainline booting | test points map |
| --- | --- | --- |
| <img width="1080" height="1920" alt="photo" src="https://github.com/user-attachments/assets/672f900e-7f6f-46ba-afe4-16791df80fb3" /> | <img width="1651" height="817" alt="スクリーンショット_20260624_170843" src="https://github.com/user-attachments/assets/985c7fb3-82be-42c6-9f39-51dd42f9d781" /> | <img width="659" height="489" alt="スクリーンショット_20260616_192418" src="https://github.com/user-attachments/assets/6b33c5f2-8843-472c-a427-dd0ef195cb60" /> |

stock LK checks `qiku,pcb-id` and `qiku,project-id`, I copied that from downstream, if they are missing / wrong, some message prints in UART and device refuses to boot:

```
[580] DTB offset is incorrect, kernel image does not have appended DTB
[580] ERROR: Appended Device Tree Blob not found
[590] ERROR: Could not do normal boot. Reverting to fastboot mode.
```

this device has at least two variants, A01 (in this PR) and A02 (which probably has carrier lock or just rebranded version for promotion stuffs), i have not found any hardware differences between them (by comparing decompiled DTBs, the only difference seems to be `qiku,*` properties)

the bootloader is not unlockable but custom ROMs and recoveries can be flashed and booted

(the device has EDL test point and firehose from unpacked firmware package, but stock bootloader banned most fastboot commands)