### PR TITLE
project: add support for arm-none-eabi- toolchain prefix

### DIFF
--- a/makefile
+++ b/makefile
@@ -75,7 +75,7 @@ ifeq ($(ENABLE_EARLY_ETHERNET),1)
 endif
 
 # setup toolchain prefix
-TOOLCHAIN_PREFIX ?= arm-eabi-
+TOOLCHAIN_PREFIX ?= arm-none-eabi-
 CFLAGS += -fstack-protector-all
 CFLAGS += -fno-strict-overflow
 CPPFLAGS := -fno-exceptions -fno-rtti -fno-threadsafe-statics

--- a/makefile
+++ b/makefile
@@ -75,7 +75,14 @@ ifeq ($(ENABLE_EARLY_ETHERNET),1)
 endif
 
 # setup toolchain prefix
-TOOLCHAIN_PREFIX ?= arm-eabi-
+# default to arm-eabi-, fall back to arm-none-eabi- if not found
+ifeq ($(origin TOOLCHAIN_PREFIX), undefined)
+  ifneq ($(shell which arm-eabi-gcc 2>/dev/null),)
+    TOOLCHAIN_PREFIX := arm-eabi-
+  else
+    TOOLCHAIN_PREFIX := arm-none-eabi-
+  endif
+endif
 CFLAGS += -fstack-protector-all
 CFLAGS += -fno-strict-overflow
 CPPFLAGS := -fno-exceptions -fno-rtti -fno-threadsafe-statics


### PR DESCRIPTION
little improvement to add support to the arm-none-eabi- (like the one used in debian) so that we don't have to specify the toolchain prefix every time we build