### PR TITLE
dts: add the board-id of Vivo Y51A (PD1510)

### DIFF
--- a/lk2nd/device/dts/msm8916/msm8916-vivo-pd1510.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-vivo-pd1510.dts
@@ -5,7 +5,8 @@
 
 / {
 	qcom,msm-id = <QCOM_ID_MSM8916 0>;
-	qcom,board-id = <QCOM_BOARD_ID_MTP 0x16>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0x16>,
+                  <0x08 0x12>;
 };
 
 &lk2nd {


### PR DESCRIPTION
dts: add the board-id of Vivo Y51A (PD1510)
There is only have the board-id of Vivo Y51L(PD1510) before this push.
I flash the image,but it can't load lk2nd.
So I check the .dtb file of Android kernel,and I found the board-id of Vivo Y51A(PD1510).
I compiled it and flash it to my Vivo Y51A(PD1510),it's loaded lk2nd successful.