### PR TITLE
lk2nd: dts: Drop redundant lk2nd device compatibles

### DIFF
--- a/lk2nd/device/dts/msm8610/msm8612-huawei-c8816.dts
+++ b/lk2nd/device/dts/msm8610/msm8612-huawei-c8816.dts
@@ -10,7 +10,7 @@
 
 &lk2nd {
 	model = "Huawei C8816";
-	compatible = "huawei,c8816", "lk2nd,device";
+	compatible = "huawei,c8816";
 
 	qcom,board-id = <8016 4>;
 	qcom,msm-id = <QCOM_ID_MSM8612 0x10001>;

--- a/lk2nd/device/dts/msm8916/msm8916-huawei-hwt1a21l.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-huawei-hwt1a21l.dts
@@ -10,7 +10,7 @@
 
 &lk2nd {
 	model = "Huawei Mediapad T1 A21L";
-	compatible = "huawei,hwt1a21l", "qcom,msm8916", "lk2nd,device";
+	compatible = "huawei,hwt1a21l";
 
 	//FIXME: lk2nd,dtb-files = "msm8916-huawei-hwt1a21l";
 };

--- a/lk2nd/device/dts/msm8960/bundle.dts
+++ b/lk2nd/device/dts/msm8960/bundle.dts
@@ -68,7 +68,7 @@
 	};
 	samsung-expressatt {
 		model = "Samsung Galaxy Express SGH-I437";
-		compatible = "samsung,expressatt", "qcom,msm8960";
+		compatible = "samsung,expressatt";
 		lk2nd,match-bootloader = "I437*";
 		lk2nd,dtb-files = "msm8960-samsung-expressatt";
 
@@ -114,7 +114,7 @@
 	};
 	samsung-expressltexx {
 		model = "Samsung Galaxy Express (GT-I8730)";
-		compatible = "samsung,expressltexx", "qcom,msm8960";
+		compatible = "samsung,expressltexx";
 		lk2nd,match-bootloader = "I8730*";
 		lk2nd,dtb-files = "msm8930-samsung-expressltexx";
 
@@ -137,7 +137,7 @@
 	};
 	samsung-espresso10att {
 		model = "Samsung Galaxy Tab 2 10.1 (SGH-I497)";
-		compatible = "samsung,espresso10att", "qcom,msm8960";
+		compatible = "samsung,espresso10att";
 		lk2nd,match-bootloader = "I497*";
 		lk2nd,dtb-files = "msm8960-samsung-espresso10att";
 
@@ -202,7 +202,7 @@
 		 * For the cmdline_lk2nd.txt, just fill it with "lk2nd".
 		 */
 		model = "Sony Xperia SP (huashan)";
-		compatible = "sony,huashan", "qcom,msm8960";
+		compatible = "sony,huashan";
 		lk2nd,dtb-files = "msm8960-sony-huashan";
 		lk2nd,match-bootloader = "s1";
 	};


### PR DESCRIPTION
The &lk2nd node is supposed to contain only the actual device compatible, not any fallback compatibles representing the SoC or lk2nd,device from the legacy branch.