### PR TITLE
dts: msm8909: Add support for Orbic Journey V

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -90,6 +90,7 @@
 - Nokia 6300 4G
 - Nokia 8000 4G
 - Nokia 8110 4G
+- Orbic Journey V (RC2200L)
 - ZTE N818S (sapphire)
 - Lenovo Tab e10 (TB-X104F)
 

--- a/lk2nd/device/dts/msm8909/msm8909-orbic-rc2200l.dts
+++ b/lk2nd/device/dts/msm8909/msm8909-orbic-rc2200l.dts
@@ -5,7 +5,7 @@
 
 / {
 	qcom,msm-id = <QCOM_ID_MSM8909 0>;
-	qcom,board-id = <0x08 0x11a>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0x11a>;
 	compatible = "qcom,msm8909-mtp", "qcom,msm8909", "qcom,mtp";
 };
 

--- a/lk2nd/device/dts/msm8909/msm8909-orbic-rc2200l.dts
+++ b/lk2nd/device/dts/msm8909/msm8909-orbic-rc2200l.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <skeleton32.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8909 0>;
+	qcom,board-id = <0x08 0x11a>;
+	compatible = "qcom,msm8909-mtp", "qcom,msm8909", "qcom,mtp";
+};
+
+&lk2nd {
+	orbic-rc2200l {
+		model = "Orbic RC2200L";
+		compatible = "orbic,rc2200l";
+
+		lk2nd,dtb-files = "msm8909-orbic-rc2200l";
+	};
+
+
+};

--- a/lk2nd/device/dts/msm8909/msm8909-orbic-rc2200l.dts
+++ b/lk2nd/device/dts/msm8909/msm8909-orbic-rc2200l.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton32.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8909 0>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0x11a>;
+	compatible = "qcom,msm8909-mtp", "qcom,msm8909", "qcom,mtp";
+};
+
+&lk2nd{
+	model = "Orbic RC2200L";
+	compatible = "orbic,rc2200l";
+
+	lk2nd,dtb-files = "msm8909-orbic-rc2200l";
+
+};

--- a/lk2nd/device/dts/msm8909/rules.mk
+++ b/lk2nd/device/dts/msm8909/rules.mk
@@ -10,8 +10,10 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8909-huawei-scale.dtb \
 	$(LOCAL_DIR)/msm8909-mtp.dtb \
 	$(LOCAL_DIR)/msm8909-zte-sapphire.dtb \
+	#$(LOCAL_DIR)/msm8909-orbic-rc2200l.dtb \
 
 ADTBS += \
 	$(LOCAL_DIR)/apq8009w-wtp.dtb \
 	$(LOCAL_DIR)/apq8009-qrd.dtb \
+	$(LOCAL_DIR)/msm8909-orbic-rc2200l.dtb \
 

--- a/lk2nd/device/dts/msm8909/rules.mk
+++ b/lk2nd/device/dts/msm8909/rules.mk
@@ -10,7 +10,6 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8909-huawei-scale.dtb \
 	$(LOCAL_DIR)/msm8909-mtp.dtb \
 	$(LOCAL_DIR)/msm8909-zte-sapphire.dtb \
-	#$(LOCAL_DIR)/msm8909-orbic-rc2200l.dtb \
 
 ADTBS += \
 	$(LOCAL_DIR)/apq8009w-wtp.dtb \

--- a/lk2nd/device/dts/msm8909/rules.mk
+++ b/lk2nd/device/dts/msm8909/rules.mk
@@ -14,4 +14,5 @@ QCDTBS += \
 ADTBS += \
 	$(LOCAL_DIR)/apq8009w-wtp.dtb \
 	$(LOCAL_DIR)/apq8009-qrd.dtb \
+	$(LOCAL_DIR)/msm8909-orbic-rc2200l.dtb \
 


### PR DESCRIPTION
Added dts, note it has to be appended in order to boot properly, otherwise the android bootloader complains and drops to fastboot. (see boot logs below)

### without dtb appended:

```
Android Bootloader - UART_DM Initialized!!!
[30] Qseecom Init Done in Appsbl version is 0x1001000
[40] secure app region addr=0x87900000 size=0x300000[40] TZ App region notif returned with status:0 addr:87900000 size:3145728
[50] TZ App log region register returned with status:0 addr:8f720000 size:4096
[50] Qseecom TZ Init Done in Appsbl
[70] Loading cmnlib done
[80] [0000000187eab704]<8>keymaster64: KEYMASTER Init 
[90] Not able to search the panel:
[90] init_panel_data ST7789_HONGYUAN_QVGA_SPI_CMD_PANEL
[380] ERROR: Splash image header invalid
[380] mdss_spi_panel_init
[1130] Not able to search the panel:
[1130] init_panel_data ST7789_HONGYUAN_QVGA_SPI_CMD_PANEL
[1410] ERROR: Splash image header invalid
[1420] mdss_spi_panel_init
[1920] Device is unlocked! Skipping verification...
[1930] [0000000187eab704]<8>keymaster64: cmd_id=SET_ROT begin
[1930] [0000000187eab704]<8>keymaster64: Error: qsee_cfg_getpropval in get_enable_set_bandwidth failed for enable_set_bandwidth, ret_size = 0
[1950] [0000000187eab704]<8>keymaster64: rot.data_length: 32
[1950] [0000000187eab704]<8>keymaster64: cmd_id=SET_ROT done with ret: 0 time taken: 0
[1960] [0000000187eab704]<8>keymaster64: cmd_id=GET_VERSION begin
[1970] Authentication Key not yet programmed
[1970] [0000000187eab704]<8>keymaster64: qsee_stor_device_init error ret: -14
[1980] [0000000187eab704]<8>keymaster64: secboot device : 0
[1980] [0000000187eab704]<8>keymaster64: cmd_id=GET_VERSION done with ret: 0 time taken: 12
[1990] [0000000187eab704]<8>keymaster64: cmd_id=SET_BOOT_STATE begin
[2000] [0000000187eab704]<8>keymaster64: is_unlocked: 1
[2000] [0000000187eab704]<8>keymaster64: color: 1
[2010] [0000000187eab704]<8>keymaster64: system_version: 0
[2010] [0000000187eab704]<8>keymaster64: system_security_level 200000
[2020] [0000000187eab704]<8>keymaster64: cmd_id=SET_BOOT_STATE done with ret: 0 time taken: 0
[2030] Sending Root of Trust to trustzone: end
[2030] DTB offset is incorrect, kernel image does not have appended DTB
[2040] ERROR: Appended Device Tree Blob not found
[2040] ERROR: Could not do normal boot. Reverting to fastboot mode.
[2170] udc_start()
``` 

### with dtb appended: 

```
Android Bootloader - UART_DM Initialized!!!
[30] Qseecom Init Done in Appsbl version is 0x1001000
[40] secure app region addr=0x87900000 size=0x300000[40] TZ App region notif returned with status:0 addr:87900000 size:3145728
[50] TZ App log region register returned with status:0 addr:8f720000 size:4096
[50] Qseecom TZ Init Done in Appsbl
[70] Loading cmnlib done
[80] [0000000187eab704]<8>keymaster64: KEYMASTER Init 
[90] Not able to search the panel:
[90] init_panel_data ST7789_HONGYUAN_QVGA_SPI_CMD_PANEL
[380] ERROR: Splash image header invalid
[380] mdss_spi_panel_init
[1130] Not able to search the panel:
[1130] init_panel_data ST7789_HONGYUAN_QVGA_SPI_CMD_PANEL
[1410] ERROR: Splash image header invalid
[1420] mdss_spi_panel_init
[1960] Device is unlocked! Skipping verification...
[1960] [0000000187eab704]<8>keymaster64: cmd_id=SET_ROT begin
[1970] [0000000187eab704]<8>keymaster64: Error: qsee_cfg_getpropval in get_enable_set_bandwidth failed for enable_set_bandwidth, ret_size = 0
[1980] [0000000187eab704]<8>keymaster64: rot.data_length: 32
[1980] [0000000187eab704]<8>keymaster64: cmd_id=SET_ROT done with ret: 0 time taken: 0
[1990] [0000000187eab704]<8>keymaster64: cmd_id=GET_VERSION begin
[2000] Authentication Key not yet programmed
[2000] [0000000187eab704]<8>keymaster64: qsee_stor_device_init error ret: -14
[2010] [0000000187eab704]<8>keymaster64: secboot device : 0
[2010] [0000000187eab704]<8>keymaster64: cmd_id=GET_VERSION done with ret: 0 time taken: 12
[2020] [0000000187eab704]<8>keymaster64: cmd_id=SET_BOOT_STATE begin
[2030] [0000000187eab704]<8>keymaster64: is_unlocked: 1
[2030] [0000000187eab704]<8>keymaster64: color: 1
[2040] [0000000187eab704]<8>keymaster64: system_version: 0
[2040] [0000000187eab704]<8>keymaster64: system_security_level 200000
[2050] [0000000187eab704]<8>keymaster64: cmd_id=SET_BOOT_STATE done with ret: 0 time taken: 0
[2060] Sending Root of Trust to trustzone: end
[2060] [0000000187eab704]<8>keymaster64: cmd_id=MILESTONE_CALL begin
[2070] [0000000187eab704]<8>keymaster64: cmd_id=MILESTONE_CALL done with ret: 0 time taken: 0
[2080] Success [2080] Qseecom De-Init Done in Appsbl
[2080] Channel alloc freed
Android Bootloader - UART_DM Initialized!!!
[0] welcome to lk

[10] platform_init()
[10] target_init()
[20] MMC card: QN1SMB (0.1, 02 2002), manufacturer: 15, OEM: 100, capacity: 7818182656 bytes
[30] SDHC Running in HS200 mode
[80] Done initialization of the card
[90] Waiting for the RPM to populate smd channel table
[90] lk2nd_init()
``` 