### PR TITLE
platform: msm_shared: qpic_nand: Skip writing trailing 0xFF pages for EFS

### DIFF
--- a/platform/msm_shared/qpic_nand.c
+++ b/platform/msm_shared/qpic_nand.c
@@ -2105,18 +2105,37 @@ flash_ecc_bch_enabled(void)
 	return (flash.ecc_width == NAND_WITH_4_BIT_ECC)? 0 : 1;
 }
 
+static uint32_t find_num_pages_to_write(const uint8_t *data, uint32_t num_pages, uint32_t wsize)
+{
+	data += num_pages * wsize; /* Go to end of block */
+
+	/* Scan backward page-by-page, checking if any byte is not 0xFF */
+	while (num_pages > 0) {
+		data -= wsize; /* Go back one page */
+		for (uint32_t i = 0; i < wsize; i++)
+			if (data[i] != 0xff)
+				return num_pages;
+		--num_pages;
+	}
+	return 0; /* Entire block is empty 0xFF, write 0 pages */
+}
+
 int
 flash_write(struct ptentry *ptn,
 			unsigned write_extra_bytes,
 			const void *data,
 			unsigned bytes)
 {
+	/* EFS2 expects empty 0xFF pages to remain erased */
+	bool skip_trailing_0xff = strcmp(ptn->name, "efs2") == 0;
 	uint32_t page = ptn->start * flash.num_pages_per_blk;
 	uint32_t lastpage = (ptn->start + ptn->length) * flash.num_pages_per_blk;
+	uint32_t num_pages_to_write = flash.num_pages_per_blk;
 	uint32_t *spare = (unsigned *)flash_spare_bytes;
 	const unsigned char *image = data;
 	uint32_t wsize;
 	uint32_t spare_byte_count = 0;
+	uint32_t pages_avail = 0;
 	int r;
 
 	spare_byte_count = ((flash.cw_size * flash.cws_per_page)- flash.page_size);
@@ -2130,6 +2149,8 @@ flash_write(struct ptentry *ptn,
 
 	while (bytes > 0)
 	{
+		uint32_t page_in_blk;
+
 		if (bytes < wsize)
 		{
 			dprintf(CRITICAL,
@@ -2145,7 +2166,8 @@ flash_write(struct ptentry *ptn,
 			return -1;
 		}
 
-		if ((page & flash.num_pages_per_blk_mask) == 0)
+		page_in_blk = page & flash.num_pages_per_blk_mask;
+		if (page_in_blk == 0)
 		{
 			if (qpic_nand_blk_erase(page))
 			{
@@ -2156,6 +2178,21 @@ flash_write(struct ptentry *ptn,
 				page += flash.num_pages_per_blk;
 				continue;
 			}
+
+			pages_avail = MIN(bytes / wsize, flash.num_pages_per_blk);
+			if (skip_trailing_0xff)
+				num_pages_to_write = find_num_pages_to_write(image, pages_avail, wsize);
+		}
+
+		if (page_in_blk >= num_pages_to_write)
+		{
+			uint32_t skip = pages_avail - page_in_blk;
+			dprintf(INFO, "flash_write_image: Block %u: wrote %u pages, skipping %u trailing 0xFF pages (%u-%u)\n",
+				page / flash.num_pages_per_blk, page_in_blk, skip, page, page + skip - 1);
+			page += skip;
+			image += skip * wsize;
+			bytes -= skip * wsize;
+			continue;
 		}
 
 		memcpy(rdwr_buf, image, flash.page_size);


### PR DESCRIPTION
At the moment, attempting to restore a backup of the EFS2 partitions for the modem corrupts it, e.g.

	$ fastboot fetch efs2 efs2.img
	$ fasbtoot flash efs2 efs2.img
	$ fastboot reboot
	qcom-q6v5-mss 4080000.remoteproc: fatal error received:
	    fs_logr.c:114:Ran out of good blocks in log-rgn XY

It looks like the mdoem relies on having erased ("good") blocks to write to. The current flash_write() routine blindly writes all pages, so if there was an erased page with all 0xFF in the input, it is still explicitly written rather than leaving the page erased. To write these pages, the modem would need to erase the whole block (consisting of multiple pages) and re-write all pages in the beginning.

We can't reliably distinguish between an explicitly written all-0xFF page and an erased page in the image, so let's just assume that all trailing 0xFF pages at the end of a block were erased and leave them that way when flashing. Apply this behavior only for the "efs2" partition, since most other partitions (e.g. "boot", "aboot", "sbl1" etc) contain actual file images were explicitly writing all-0xFF pages makes more sense.

This is similar to the "nandwrite --skip-all-ffs" option on Linux, except that we only consider trailing all-0xFF pages in a block. This is unlikely to make much difference in practice, but it seems to be closer to how the modem firmware is managing the EFS partition.