### PR TITLE
dts: msm8226: msm8926-v2-720p-mtp: fix dtb name for Sony Xperia M2

### DIFF
--- a/lk2nd/device/dts/msm8226/msm8926-v2-720p-mtp.dts
+++ b/lk2nd/device/dts/msm8226/msm8926-v2-720p-mtp.dts
@@ -47,7 +47,7 @@
 		compatible = "sony,eagle";
 		lk2nd,match-bootloader = "s1*";
 
-		// FIXME: lk2nd,dtb-files = "msm8926-sony-eagle";
+		lk2nd,dtb-files = "msm8926-sony-xperia-yukon-eagle";
 
 		gpio-keys {
 			compatible = "gpio-keys";


### PR DESCRIPTION
In mainline Linux it is a common practice for Sony devices to be named after their platform name along with their device codename. Change `lk2nd,dtb-names` property to reflect this so lk2nd can pick the right dtb for our device.

See also: https://lore.kernel.org/linux-arm-msm/178379938607.163099.16596449114579997016.b4-ty@kernel.org/