### PR TITLE
ext2: allocate cache-line aligned memory for group descriptor buffer

### DIFF
--- a/lib/fs/ext2/ext2.c
+++ b/lib/fs/ext2/ext2.c
@@ -23,7 +23,9 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <malloc.h>
 #include <debug.h>
+#include <arch/defines.h>
 #include <lib/fs.h>
 #include "ext2_priv.h"
 
@@ -156,10 +158,11 @@ status_t ext2_mount(bdev_t *dev, fscookie **cookie)
     }
 
     /* read in all the group descriptors */
-    ext2->gd = malloc(sizeof(struct ext2_group_desc) * ext2->s_group_count);
+    size_t gd_size = sizeof(struct ext2_group_desc) * ext2->s_group_count;
+    ext2->gd = memalign(CACHE_LINE, ROUNDUP(gd_size, CACHE_LINE));
     err = bio_read(ext2->dev, (void *)ext2->gd,
                    (EXT2_BLOCK_SIZE(ext2->sb) == 4096) ? 4096 : 2048,
-                   sizeof(struct ext2_group_desc) * ext2->s_group_count);
+                   gd_size);
     if (err < 0) {
         err = -4;
         return err;

--- a/lib/fs/ext2/ext2.c
+++ b/lib/fs/ext2/ext2.c
@@ -23,7 +23,9 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <malloc.h>
 #include <debug.h>
+#include <arch/defines.h>
 #include <lib/fs.h>
 #include "ext2_priv.h"
 
@@ -116,9 +118,17 @@ status_t ext2_mount(bdev_t *dev, fscookie **cookie)
     ext2_t *ext2 = malloc(sizeof(ext2_t));
     ext2->dev = dev;
 
-    err = bio_read(dev, &ext2->sb, 1024, sizeof(struct ext2_super_block));
-    if (err < 0)
+    struct ext2_super_block *sb = memalign(CACHE_LINE,
+                                           ROUNDUP(sizeof(struct ext2_super_block), CACHE_LINE));
+
+    err = bio_read(dev, sb, 1024, sizeof(struct ext2_super_block));
+    if (err < 0) {
+        free(sb);
         goto err;
+    }
+
+    memcpy(&ext2->sb, sb, sizeof(struct ext2_super_block));
+    free(sb);
 
     endian_swap_superblock(&ext2->sb);
 
@@ -156,10 +166,11 @@ status_t ext2_mount(bdev_t *dev, fscookie **cookie)
     }
 
     /* read in all the group descriptors */
-    ext2->gd = malloc(sizeof(struct ext2_group_desc) * ext2->s_group_count);
+    size_t gd_size = sizeof(struct ext2_group_desc) * ext2->s_group_count;
+    ext2->gd = memalign(CACHE_LINE, ROUNDUP(gd_size, CACHE_LINE));
     err = bio_read(ext2->dev, (void *)ext2->gd,
                    (EXT2_BLOCK_SIZE(ext2->sb) == 4096) ? 4096 : 2048,
-                   sizeof(struct ext2_group_desc) * ext2->s_group_count);
+                   gd_size);
     if (err < 0) {
         err = -4;
         return err;


### PR DESCRIPTION
LLM explanation:

> The read DMA path requires cache-line-aligned buffers, and that requirement is silently unenforced. sdhci_send_command even documents and asserts it:
> 
> 
> /* Assert if the data buffer is not aligned to cache line size for read operations. */
> if (cmd->trans_mode == SDHCI_READ_MODE)          // sdhci.c:771
>     ASSERT(IS_CACHE_LINE_ALIGNED(cmd->data.data_ptr));
> …except SDHCI_READ_MODE is BIT(4) = 16, while every real read sets cmd.trans_mode = SDHCI_MMC_READ = 1 (mmc_sdhci.c:701 et al). So trans_mode == SDHCI_READ_MODE is never true and the alignment assert is dead code — an unaligned read buffer sails straight past the guard the authors put there to reject it (the post-read invalidate two lines down correctly uses == SDHCI_MMC_READ, so it does run).
> 
> ext2 hands it a plain malloc buffer. malloc(sizeof(gd)*count) → heap_alloc(size, 0) returns a pointer-aligned (≤8B) address, so the group-descriptor buffer's first and last cache lines are shared with neighbouring heap data. The 1 KiB GDT read is a single ADMA transfer into that buffer. With a non-coherent DMA destination, doing line-granular clean/invalidate on a line that's shared with adjacent data is unsafe: the shared boundary line can interleave the neighbour's (dirty, or subsequently re-dirtied) bytes with the DMA'd bytes — the line gets written back over freshly-DMA'd data, or a stale fill masks it. It happened to land on the tail here = the last group descriptor (gd[N-1]) reading back as zeros, which broke any file in the final block group (extlinux.conf). Intermittent, because it depends on heap layout and what touches the neighbouring line during the transfer — a retry with a different allocation address boots fine.
