### PR TITLE
dts: msm8952: Add support for Asus Zenfone 4 Max (X00ID)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -94,6 +94,7 @@
 ### lk2nd-msm8952
 
 - Alcatel Idol 4 (6055*)
+- Asus Zenfone 4 Max (x00id) (MSM8937)
 - Asus Zenfone 4 Max Pro (x00i)
 - BQ X5 Plus (Longcheer L9360)
 - Cat S22 Flip (S22FLIP)

--- a/lk2nd/device/dts/msm8952/msm8937-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-mtp.dts
@@ -130,6 +130,10 @@
 			qcom,mdss_dsi_ili9881c_fhd_video_dj {
 				compatible = "asus,x00id-ili9881c";
 			};
+
+			qcom,mdss_dsi_ili9885_fhd_video_dj {
+				compatible = "asus,x00id-ili9885";
+			};
 		};
 	};
 };

--- a/lk2nd/device/dts/msm8952/msm8937-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-mtp.dts
@@ -116,4 +116,20 @@
 			};
 		};
 	};
+
+	x00id {
+		model = "Asus ZenFone 4 Max (X00ID)";
+		compatible = "asus,x00id";
+		lk2nd,match-panel;
+
+		lk2nd,dtb-files = "msm8937-asus-x00id";
+
+		panel {
+			compatible = "asus,x00id-panel", "lk2nd,panel";
+
+			qcom,mdss_dsi_ili9881c_fhd_video_dj {
+				compatible = "asus,x00id-ili9881c";
+			};
+		};
+	};
 };


### PR DESCRIPTION
DESCRIPTIONS:
Add initial lk2nd DTS support for Asus ZenFone 4 Max X00ID ; MSM8937 under MSM8952.

TESTING:
- Successfully booted&flashed lk2nd.img via fastboot boot&fastboot flash boot.
- Device model is correctly modified and displayed on screen: `Asus ZenFone 4 Max (X00ID)`.
- Screen panel drive (`qcom,mdss_dsi_ili9881c_fhd_video_dj`) and key navigation work as expected

SCREENSHOTS:
<img width="1280" height="1707" alt="24be91f95e1e9005643e8105dff6a98b" src="https://github.com/user-attachments/assets/c1462ee4-8586-4272-bc5f-0f3217b14b91" />
<img width="1276" height="1702" alt="d85c8f5a4e40227d79cd3a9df214a3f4" src="https://github.com/user-attachments/assets/f4f448f8-6d8f-413b-a8c7-0726b038e553" />

P1: before
P2: after