### PR TITLE
device: msm8960: add Samsung Galaxy S4 (SGH-M919)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -235,6 +235,7 @@
 - Asus Nexus 7 (flo)
 - Samsung Galaxy Ace 3 LTE (GT-S7275R) (display refresh doesn't work)
 - Samsung Galaxy Express (SGH-I437)
+- Samsung Galaxy S4 (SGH-M919)
 - Samsung Galaxy S4 Mini (GT-I9195)
 - Sony Xperia SP (huashan) (quirky - see comment in `lk2nd/device/dts/msm8960/bundle.dts`)
 

--- a/lk2nd/device/dts/msm8960/bundle.dts
+++ b/lk2nd/device/dts/msm8960/bundle.dts
@@ -112,6 +112,29 @@
 			};
 		};
 	};
+	samsung-jfltetmo {
+		model = "Samsung Galaxy S4 (SGH-M919)";
+		compatible = "samsung,jfltetmo", "samsung,jflte";
+		lk2nd,match-bootloader = "M919*";
+		lk2nd,dtb-files = "qcom-apq8064-samsung-jflte";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+
+			volume-up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&pmic 34 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			volume-down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&pmic 36 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			home {
+				lk2nd,code = <KEY_HOME>;
+				gpios = <&pmic 29 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
 	samsung-expressltexx {
 		model = "Samsung Galaxy Express (GT-I8730)";
 		compatible = "samsung,expressltexx";


### PR DESCRIPTION
The T-Mobile Galaxy S4 (SGH-M919, jfltetmo) is an apq8064 device in the jflte family but had no matching lk2nd node, so it fell through to the unknown device with no keymap. It reports bootloader string M919UVSFQA1; match on M919* and reuse the jflte dtb and PMIC key GPIOs.

Tested on hardware: device is now correctly identified and volume-key navigation works.