### PR TITLE
dts: msm8939: Add device tree for vivo V3Max A (PD1523)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -56,6 +56,7 @@
 - Samsung Galaxy Tab A 8.0 (2015) - SM-T350, SM-T355, SM-T355Y, SM-T357W
 - Samsung Galaxy Tab A 9.7 (2015) - SM-T550, SM-T555
 - Samsung Galaxy Tab E 9.6 WiFi (2015) - SM-T560NU
+- Vivo V3-Max /Vivo V3-Max A (2016) - pd1523
 - Vivo Y13L / Y613f / Y913 - PD1304CL, PD1304CF, PD1304CV (use lk1st quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-vivo-cdp-1.dts`)
 - Vivo Y23L / Y623 / Y923 - PD1419L, PD1419F, PD1419V (use lk1st quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-vivo-cdp-1.dts`)
 - Vivo Y21L

--- a/lk2nd/device/dts/msm8916/msm8939-vivo-pd1523.dts
+++ b/lk2nd/device/dts/msm8916/msm8939-vivo-pd1523.dts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <skeleton64.dtsi>
+#include <lk2nd.dtsi>
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8939 0>;
+	qcom,board-id = <QCOM_BOARD_ID_CDP 13>;
+};
+
+&lk2nd {
+	vivo-pd1523 {
+		model = "vivo V3 Max (PD1523)";
+		compatible = "vivo,pd1523";
+		lk2nd,match-panel;
+
+		lk2nd,dtb-files = "msm8939-vivo-pd1523";
+
+		gpio-keys {
+			compatible = "gpio-keys";
+
+			volume-up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&tlmm 107 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+
+		panel {
+			compatible = "vivo,pd1523-panel", "lk2nd,panel";
+
+			qcom,mdss_dsi_otm1901_1080p_video {
+				compatible = "vivo,pd1523-otm1901";
+			};
+			qcom,mdss_dsi_nt35596_1080p_video {
+				compatible = "vivo,pd1523-nt35596";
+			};
+			qcom,mdss_dsi_jdi_1080p_video {
+				compatible = "vivo,pd1523-jdi";
+			};
+			qcom,mdss_dsi_tryotm1901a_1080p_video {
+				compatible = "vivo,pd1523-tryotm1901a";
+			};
+		};
+	};
+};

--- a/lk2nd/device/dts/msm8916/rules.mk
+++ b/lk2nd/device/dts/msm8916/rules.mk
@@ -49,4 +49,5 @@ QCDTBS += \
 	$(LOCAL_DIR)/msm8939-qrd-wt82918.dtb \
 	$(LOCAL_DIR)/msm8939-qrd-wt82918hd.dtb \
 	$(LOCAL_DIR)/msm8939-samsung.dtb \
+        $(LOCAL_DIR)/msm8939-vivo-pd1523.dtb \
 	$(LOCAL_DIR)/msm8939-xiaomi-ido.dtb \


### PR DESCRIPTION
Add lk2nd device tree for vivo V3Max A (China variant).

Device info:
- SoC: Qualcomm MSM8939v2 (Snapdragon 616)
- RAM: 3 GB
- Storage: 32 GB
- Display: 1920x1080 (5.5")
- Codename: PD1523