### PR TITLE
platform: msm_shared: mmc: bound MCLK register write wait

### DIFF
--- a/platform/msm_shared/mmc.c
+++ b/platform/msm_shared/mmc.c
@@ -35,6 +35,7 @@
 #include <platform/clock.h>
 #include <platform/iomap.h>
 #include <platform/timer.h>
+#include <platform.h>
 #include <bits.h>
 #include <../../../app/aboot/bootimg.h>
 
@@ -55,6 +56,8 @@
 
 #define MMC_BOOT_DATA_READ     0
 #define MMC_BOOT_DATA_WRITE    1
+
+#define MMC_BOOT_MCLK_WR_TIMEOUT_MS  1
 
 static unsigned int mmc_boot_data_transfer(unsigned int *data_ptr,
 						unsigned int data_len,
@@ -174,7 +177,15 @@ void mmc_mclk_reg_wr_delay(void)
 	if (mmc_host.mmc_cont_version)
 	{
 		/* Wait for the MMC_BOOT_MCI register write to go through. */
-		while(readl(MMC_BOOT_MCI_STATUS2) & MMC_BOOT_MCI_MCLK_REG_WR_ACTIVE);
+		time_t deadline = current_time() + MMC_BOOT_MCLK_WR_TIMEOUT_MS;
+		while (readl(MMC_BOOT_MCI_STATUS2) & MMC_BOOT_MCI_MCLK_REG_WR_ACTIVE) {
+			if (current_time() > deadline) {
+				dprintf(CRITICAL,
+					"mmc_mclk_reg_wr_delay: MCLK write stuck (STATUS2:0x%x)\n",
+					readl(MMC_BOOT_MCI_STATUS2));
+				break;
+			}
+		}
 	}
 	else
 		udelay((1 + ((3 * USEC_PER_SEC) / (mmc_host.mclk_rate? mmc_host.mclk_rate : MMC_CLK_400KHZ))));


### PR DESCRIPTION
> [!NOTE]
> This is one of a series of PRs to support booting from microSD on the msm8960 platform.

`mmc_mclk_reg_wr_delay()` can hang indefinitely if the controller core clock is not running. This can happen when probing the microSD slot if its clocks were not enabled by the PBL.

Add a 1 ms timeout to the wait, matching the behavior of `msmsdcc_sync_reg_wr()` in the downstream msm_sdcc driver.

References:
- [Sony msm8960t downstream](https://github.com/LineageOS/android_kernel_sony_msm8960t/blob/93319b1e5aa343ec1c1aabcb028c5e88c7df7c01/drivers/mmc/host/msm_sdcc.c#L534-L556)
- [Samsung msm8660 downstream](https://github.com/LineageOS/android_kernel_samsung_msm8660-common/blob/ee785111146f563e47857939ff5f0fc09be3fbd0/drivers/mmc/host/msm_sdcc.c#L380-L402)

Tested on Sony Xperia SP (MSM8960T). Verified that a disabled core clock hits the timeout and prints the warning instead of hanging, while an enabled clock completes the write without hitting the timeout.