### PR TITLE
dts: msm8952: fix asus x00i

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -95,7 +95,6 @@
 
 - Alcatel Idol 4 (6055*)
 - Asus Zenfone 4 Max (x00id) (MSM8937)
-- Asus Zenfone 4 Max Pro (x00i)
 - BQ X5 Plus (Longcheer L9360)
 - Cat S22 Flip (S22FLIP)
 - Fossil Gen 6 (hoki) (requires flashing [minimal DTBO](#minimal-dtb-overlay))

--- a/lk2nd/device/dts/msm8952/msm8937-mtp.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-mtp.dts
@@ -134,6 +134,10 @@
 			qcom,mdss_dsi_ili9885_fhd_video_dj {
 				compatible = "asus,x00id-ili9885";
 			};
+
+			qcom,mdss_dsi_hx8394f_720p_video {
+				compatible = "asus,x00id-hx8394f-720p";
+			};
 		};
 	};
 };

--- a/lk2nd/device/dts/msm8952/msm8937-qrd.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-qrd.dts
@@ -23,19 +23,4 @@
 			};
 		};
 	};
-
-	x00i {
-		model = "Asus Zenfone 4 Max Pro (x00i)";
-		compatible = "asus,x00i";
-		lk2nd,match-panel;
-
-		lk2nd,dtb-files = "msm8937-asus-x00i";
-
-		panel {
-			compatible = "asus,x00i-panel", "lk2nd,panel";
-			qcom,mdss_dsi_hx8394f_720p_video {
-				compatible = "asus,x00i-hx8394f-720p";
-			};
-		};
-	};
 };


### PR DESCRIPTION
Did some cleaning for the duplicated asus x00i

before

<img width="1440" height="1920" alt="image" src="https://github.com/user-attachments/assets/001f4943-c9e3-4b4d-8e11-90ecbcdb68c2" />


after

<img width="1440" height="1920" alt="image" src="https://github.com/user-attachments/assets/4d879c5b-da9b-4854-a0e9-a7496514cab0" />
