### PR TITLE
dts: msm8916: add OPPO A37 (a37f)

### DIFF
--- a/Documentation/devices.md
+++ b/Documentation/devices.md
@@ -33,6 +33,7 @@
 - Motorola Moto E (2015) - surnia
 - Motorola Moto G (2015) - osprey
 - Motorola Moto G4 Play - harpia
+- OPPO A37 - a37f (quirky - see comment in `lk2nd/device/dts/msm8916/msm8916-mtp.dts`)
 - Panasonic ELUGA U2
 - Samsung Galaxy A3 (2015) - SM-A300F, SM-A300FU, SM-A300YZ
 - Samsung Galaxy A5 (Duos) (2015) - SM-A5000, SM-A500F, SM-A500FU, SM-A500H, SM-A500YZ

--- a/lk2nd/device/dts/msm8916/msm8916-mtp.dts
+++ b/lk2nd/device/dts/msm8916/msm8916-mtp.dts
@@ -65,6 +65,47 @@
 		};
 	};
 
+	/*
+	 * To build for oppo-a37, add LK2ND_ADTBS="msm8916-mtp.dtb" LK2ND_QCDTBS=
+	 * to your make cmdline. The A37 does not boot a lk2nd image that carries a
+	 * QCDT table -- the bootloader gets upset and goes into the phone's
+	 * fastboot. Only an appended DTB works.
+	 */
+	oppo-a37 {
+		model = "OPPO A37";
+		compatible = "oppo,a37";
+		lk2nd,match-panel;
+
+		lk2nd,dtb-files = "msm8916-oppo-a37";
+
+		panel {
+			compatible = "oppo,a37-panel", "lk2nd,panel";
+
+			qcom,mdss_dsi_oppo15399boe_ili9881c_720p_video {
+				compatible = "oppo,a37-boe-ili9881c";
+			};
+			qcom,mdss_dsi_oppo15399tm_nt35521s_720p_video {
+				compatible = "oppo,a37-tm-nt35521s";
+			};
+			qcom,mdss_dsi_oppo15399truly_nt35521s_720p_video {
+				compatible = "oppo,a37-truly-nt35521s";
+			};
+		};
+
+		gpio-keys {
+			compatible = "gpio-keys";
+
+			volume-up {
+				lk2nd,code = <KEY_VOLUMEUP>;
+				gpios = <&tlmm 107 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+			volume-down {
+				lk2nd,code = <KEY_VOLUMEDOWN>;
+				gpios = <&tlmm 108 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			};
+		};
+	};
+
 	asus-z010d {
 		model = "Asus Zenfone Max ZC550KL";
 		compatible = "asus,z010d";


### PR DESCRIPTION
Adds a device entry for the OPPO A37 (a37f).

### Why this goes in `msm8916-mtp.dts` rather than its own file

Unlike #699 (OPPO A33), the A37 has no board-id of its own to match on. It
reports the generic MTP board-id `<8 0>`, and its SMEM says `hw_platform = MTP`
with `platform_subtype_id = 0`. The OPPO project number (15399) is present in
the vendor DTB's `qcom,board-id` third cell, but never appears in SMEM, so
standard DTB matching cannot see it.

A stock `lk2nd-msm8916` image therefore already boots on this device
unmodified. This entry adds the things that need a device match: correct model
reporting, kernel DTB selection, and the volume down key. Panel matching is the
discriminator, the same as the other entries in this file.

### `gpio-keys` is required here

Without it `lk2nd_keys_pressed()` falls through to the msm8916 target defaults,
and `target/msm8916/init.c` implements those asymmetrically:

```c
#define TLMM_VOL_UP_BTN_GPIO    107
target_volume_up()   -> gpio_status(TLMM_VOL_UP_BTN_GPIO)
target_volume_down() -> pm8x41_resin_status()
```

The A37 has both volume keys on TLMM, up on 107 and down on 108. Volume up
therefore works by coincidence, because the default happens to read the same
pin the A37 uses, while volume down is never read at all. The symptom is a menu
that only responds to power and volume up.

Both keys are declared rather than only the broken one, so the entry does not
silently depend on that coincidence.

Device evidence: `/proc/interrupts` lists two separate `msm_tlmm_irq` entries
named `volume_up` and `volume_down`, both with non-zero counts, and
`/sys/kernel/debug/gpio` labels TLMM 107 `volume_up` and TLMM 108
`volume_down`. Neither key is on the PMIC.

### Panel names

Taken from the device's own `/proc/cmdline`. The reference unit reports the BOE
variant:

```
mdss_mdp.panel=1:dsi:0:qcom,mdss_dsi_oppo15399boe_ili9881c_720p_video:1:none
```

The other two names are the Tianma and Truly variants listed by the same
firmware; they are untested, as this unit does not have those panels.

### Testing

Verified on an A37f. `fastboot getvar all` with this entry:

```
(bootloader) product:lk2nd-msm8916
(bootloader) unlocked:yes
(bootloader) secure:no
(bootloader) lk2nd:version:23.1-next-3b7896fc-20260816-dirty
(bootloader) lk2nd:model:OPPO A37
(bootloader) lk2nd:compatible:oppo,a37
(bootloader) lk2nd:panel:qcom,mdss_dsi_oppo15399boe_ili9881c_720p_video
```

Build tested both ways on `3b7896fc`:

| Configuration | Result |
|---|---|
| `LK2ND_ADTBS="msm8916-mtp.dtb" LK2ND_QCDTBS= DEBUG=2 DEBUG_FBCON=1` | 305168 B, `dt_size = 0`, entry and both keys present in the appended DTB |
| default flags | 426000 B, QCDT with 118 entries, `msm8916-mtp.dtb` built |

Note for anyone flashing this device: the A37 only boots lk2nd with an
**appended** DTB. Its stock bootloader does not load an image built with the
QCDT table, so build with `LK2ND_ADTBS="msm8916-mtp.dtb" LK2ND_QCDTBS=`.

### Related finding, not part of this PR

While bringing this up I found that OPPO's `dtbTool` writes **7-word** QCDT
entries, inserting the project number between `soc_rev` and `offset`:

```
  msm-id | variant | subtype | soc_rev | 15399 | offset | size
  206    | 8       | 0       | 0       | 15399 | 2048   | 208896
```

`dev_tree.c` reads the standard 6 words, so for the first entry it sees a
matching msm-id/variant/subtype and then `offset = 15399, size = 2048`, and
loads garbage as the device tree. This affects every image built from an OPPO
downstream tree, including the stock boot image and TWRP, and it fails silently
by returning to lk2nd. Both the A37's downstream LineageOS `boot.img` and its
TWRP image carry an identical table.

I have only worked around it by rewriting the table outside lk2nd. If support
for this layout would be welcome in `dev_tree.c`, I am happy to open a separate
PR or an issue with the full analysis.
