### PR TITLE
RFC: platform: msm_shared: dev_tree: support OPPO seven-word QCDT entries

### DIFF
--- a/platform/msm_shared/dev_tree.c
+++ b/platform/msm_shared/dev_tree.c
@@ -1412,6 +1412,52 @@ void *dev_tree_appended(void *kernel, uint32_t kernel_size, uint32_t dtb_offset,
 	return NULL;
 }
 
+/*
+ * Return the size of a version 2 QCDT entry for this table.
+ *
+ * Standard entries are six words. Some OPPO devices ship a table that still
+ * declares version 2 but uses seven, with the OPPO project number inserted
+ * between soc_rev and offset. Reading such a table with the standard stride
+ * finds a matching platform_id/variant_id/board_hw_subtype and then takes the
+ * project number as the DTB offset, so a device tree is "found" but the data
+ * loaded from it is garbage. The failure is silent.
+ *
+ * Tell the two apart by checking the fields that must be well formed: a DTB
+ * offset is at least four byte aligned, and no entry has a zero size. Under
+ * the wrong stride both land on unrelated words and one of the two almost
+ * always fails.
+ */
+static uint32_t dev_tree_entry_size_v2(struct dt_table *table)
+{
+	const uint32_t *words = (const uint32_t *)
+		((const unsigned char *)table + DEV_TREE_HEADER_SIZE);
+	const uint32_t std_words = sizeof(struct dt_entry_v2) / sizeof(uint32_t);
+	const uint32_t oppo_words = sizeof(struct dt_entry_v2_oppo) / sizeof(uint32_t);
+	bool std_ok = true, oppo_ok = true;
+	uint32_t i;
+
+	if (!table->num_entries)
+		return sizeof(struct dt_entry_v2);
+
+	for (i = 0; i < table->num_entries && (std_ok || oppo_ok); i++) {
+		const uint32_t *std = words + i * std_words;
+		const uint32_t *oppo = words + i * oppo_words;
+
+		/* offset, size are the last two words of the entry */
+		if ((std[std_words - 2] & 3) || !std[std_words - 1])
+			std_ok = false;
+		if ((oppo[oppo_words - 2] & 3) || !oppo[oppo_words - 1])
+			oppo_ok = false;
+	}
+
+	if (!std_ok && oppo_ok) {
+		dprintf(INFO, "DTB table uses OPPO seven-word entries\n");
+		return sizeof(struct dt_entry_v2_oppo);
+	}
+
+	return sizeof(struct dt_entry_v2);
+}
+
 /* Returns 0 if the device tree is valid. */
 int dev_tree_validate(struct dt_table *table, unsigned int page_size, uint32_t *dt_hdr_size)
 {
@@ -1427,7 +1473,7 @@ int dev_tree_validate(struct dt_table *table, unsigned int page_size, uint32_t *
 	if (table->version == DEV_TREE_VERSION_V1) {
 		dt_entry_size = sizeof(struct dt_entry_v1);
 	} else if (table->version == DEV_TREE_VERSION_V2) {
-		dt_entry_size = sizeof(struct dt_entry_v2);
+		dt_entry_size = dev_tree_entry_size_v2(table);
 	} else if (table->version == DEV_TREE_VERSION_V3) {
 		dt_entry_size = DEV_TREE_DT_ENTRY_SIZE_V3;
 	} else {
@@ -1859,6 +1905,7 @@ int dev_tree_get_entry_info(struct dt_table *table, struct dt_entry *dt_entry_in
 	struct dt_entry_node *dt_entry_queue = NULL;
 	struct dt_entry_node *dt_node_tmp1 = NULL;
 	struct dt_entry_node *dt_node_tmp2 = NULL;
+	uint32_t entry_size_v2 = 0;
 	uint32_t found = 0;
 
 	if (!dt_entry_info) {
@@ -1868,6 +1915,7 @@ int dev_tree_get_entry_info(struct dt_table *table, struct dt_entry *dt_entry_in
 	}
 
 	table_ptr = (unsigned char *)table + DEV_TREE_HEADER_SIZE;
+	entry_size_v2 = dev_tree_entry_size_v2(table);
 	cur_dt_entry = &dt_entry_buf_1;
 	best_match_dt_entry = NULL;
 	dt_entry_queue = (struct dt_entry_node *)
@@ -1922,9 +1970,16 @@ int dev_tree_get_entry_info(struct dt_table *table, struct dt_entry *dt_entry_in
 			cur_dt_entry->pmic_rev[1] = board_pmic_target(1);
 			cur_dt_entry->pmic_rev[2] = board_pmic_target(2);
 			cur_dt_entry->pmic_rev[3] = board_pmic_target(3);
-			cur_dt_entry->offset = dt_entry_v2->offset;
-			cur_dt_entry->size = dt_entry_v2->size;
-			table_ptr += sizeof(struct dt_entry_v2);
+			if (entry_size_v2 == sizeof(struct dt_entry_v2_oppo)) {
+				struct dt_entry_v2_oppo *oppo =
+					(struct dt_entry_v2_oppo *)table_ptr;
+				cur_dt_entry->offset = oppo->offset;
+				cur_dt_entry->size = oppo->size;
+			} else {
+				cur_dt_entry->offset = dt_entry_v2->offset;
+				cur_dt_entry->size = dt_entry_v2->size;
+			}
+			table_ptr += entry_size_v2;
 			break;
 		case DEV_TREE_VERSION_V3:
 			memcpy(cur_dt_entry, (struct dt_entry *)table_ptr,

--- a/platform/msm_shared/include/dev_tree.h
+++ b/platform/msm_shared/include/dev_tree.h
@@ -159,6 +159,23 @@ struct dt_entry_v2
 	uint32_t size;
 };
 
+/*
+ * Some OPPO devices ship a QCDT table that declares version 2 but uses
+ * seven-word entries: their dtbTool inserts the OPPO project number, which
+ * is the third cell of the vendor qcom,board-id, between soc_rev and offset.
+ * Standard v2 has no field for it.
+ */
+struct dt_entry_v2_oppo
+{
+	uint32_t platform_id;
+	uint32_t variant_id;
+	uint32_t board_hw_subtype;
+	uint32_t soc_rev;
+	uint32_t oppo_project_id;
+	uint32_t offset;
+	uint32_t size;
+};
+
 struct dt_entry
 {
 	uint32_t platform_id;


### PR DESCRIPTION
**RFC.** The change works and is tested, but it detects the layout by
inspecting the table rather than being told about it. If you would rather have
this declared explicitly — a build flag, or a property on the lk2nd device node
— say so and I will rework it that way. I would rather ask than guess how you
want core parsing to behave.

Follow-up to the note in #761.

### The problem

Some OPPO devices ship a QCDT table that declares version 2 but uses
seven-word entries. Their `dtbTool` inserts the OPPO project number — the third
cell of the vendor `qcom,board-id` — between `soc_rev` and `offset`:

```
  msm-id | variant | subtype | soc_rev | project | offset | size
  206    | 8       | 0       | 0       | 15399   | 2048   | 208896
  248    | 8       | 0       | 0       | 15399   | 2048   | 208896
  249    | 8       | 0       | 0       | 15399   | 2048   | 208896
  250    | 8       | 0       | 0       | 15399   | 2048   | 208896
```

Standard v2 has no field for it. Read with the six-word stride, the first entry
looks like this to `dev_tree_get_entry_info()`:

```
  platform_id=206 variant_id=8 board_hw_subtype=0 soc_rev=0   <- matches the board
  offset=15399  size=2048                                     <- garbage
```

So a device tree *is* found — the match fields are all correct — and then the
DTB is loaded from offset 15399, which is not even four byte aligned. Nothing
reports an error. On lk2nd the device simply returns to fastboot, which reads
like an empty or corrupt partition rather than a parsing problem.

This affects every image built from an affected OPPO downstream tree. On an
OPPO A37 both the stock-derived LineageOS `boot.img` and the TWRP image carry
an identical table, so neither can be chainloaded.

### The approach

Detect the layout instead of assuming it, using the two fields that must be
well formed in a valid table: a DTB offset is at least four byte aligned, and
no entry has a zero size. Under the wrong stride both land on unrelated words
and one of the two almost always fails.

The seven-word layout is only used when the standard stride fails for **some**
entry *and* the seven-word stride holds for **all** of them, so a well formed
standard table is never reinterpreted.

### Testing

Six real tables, four of them standard as a negative test:

| Table | Entries | Detected | entry[0] offset |
|---|---|---|---|
| OPPO A37 downstream LineageOS `boot.img` | 4 | OPPO | 2048 → `d00dfeed` |
| OPPO A37 TWRP 3.7.1_12 | 4 | OPPO | 2048 → `d00dfeed` |
| `lk2nd-msm8916` (this tree) | 118 | standard | 4096 → `d00dfeed` |
| `lk2nd-msm8974` (release 23.1) | 52 | standard | 2048 → `d00dfeed` |
| `lk2nd-msm8226` (release 23.1) | 13 | standard | 2048 → `d00dfeed` |
| `lk2nd-msm8953` (release 23.1) | 9 | standard | 2048 → `d00dfeed` |

In every case the offset taken from the chosen layout points at a valid
`d00dfeed`. Before the change the two OPPO images resolved to offset 15399.

`make lk2nd-msm8916` builds clean, no new warnings.

I have not been able to test the OPPO path on hardware end to end yet — the
device it was found on currently runs postmarketOS from the `boot` partition.
What is verified is the parsing: the same function, run unmodified against the
real tables above, picks the right stride and lands on a valid DTB every time.

### Alternatives I considered

- **A build flag**, like the `LK2ND_QCDTBS` quirk used elsewhere. Clean, but it
  cannot help here: the problem is reading an image produced by the *vendor*
  bootloader chain, not one we build.
- **Keying off the device entry.** The table is parsed before device matching
  happens, so that information is not available yet.
- **Trusting `version`.** The affected tables declare version 2, so there is
  nothing in the header to key off.

If you prefer a different shape entirely, I am happy to redo it.
